### PR TITLE
Add lazy instruction loading and @all routing

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -74,7 +74,9 @@ connectors:
 
     # Built-in context files are injected automatically — no config needed:
     #   contexts/rc-gateway-context.md  — RC message format, RBAC rules, injection protection
-    #   contexts/scheduling-context.md  — teaches agent the acg schedule CLI commands
+    #   contexts/tool-index-context.md  — short index for lazy-loaded ACG instruction docs
+    #   contexts/scheduling-context.md + fetch-history-context.md are injected instead
+    #                                      when an agent sets lazy_instruction_loading: false
     #
     # Add your own files below to extend agent behavior (e.g. room-specific personas,
     # project context, or custom instructions).  Listed files are injected AFTER the
@@ -90,6 +92,7 @@ agents:
     new_session_args: []             # extra flags passed only on session creation
                                      # e.g. ["--agent", "my-agent-name"] to load a custom agent
     session_prefix: agent-chat       # prefix added to Claude session titles
+    lazy_instruction_loading: true   # true = inject short tool index; false = inject full scheduling/history docs
     context_inject_files: []         # agent-level context files (layer 2); list, resolved relative to config dir
 
     # ── Tool allow lists ───────────────────────────────────────────────────
@@ -114,6 +117,8 @@ agents:
       # These are ALWAYS auto-approved for owners, regardless of what you list here:
       #   agent-chat-gateway send ...      — send messages / attach files to RC rooms
       #   agent-chat-gateway schedule ...  — create/list/delete/pause/resume scheduled jobs
+      #   agent-chat-gateway fetch-history ... — read filtered channel history
+      #   agent-chat-gateway instructions ...  — read bundled tool instructions
       #
       # ── Read-only built-in tools: safe, never need owner approval ──────
       - tool: "Read"                         # any file read

--- a/docs/agent-chain.md
+++ b/docs/agent-chain.md
@@ -125,6 +125,23 @@ connectors:
 
 **When `agent_chain` is omitted:** Agent-to-agent communication is disabled. Messages from unknown senders are treated as regular user messages. No loop protection is active.
 
+### Addressing and `@all`
+
+In Rocket.Chat rooms, ACG adds a trusted `to:` field to each agent prompt so agents can
+tell whether a message is meant for them, another agent, or the room at large:
+
+- `to: me` — this bot was explicitly mentioned, or the message arrived as a DM.
+- `to: @other-agent` — another configured agent was mentioned; this bot should usually stay silent.
+- `to: me+@other-agent` — this bot and another configured agent were both mentioned.
+- `to: @all` — the sender used Rocket.Chat's room-wide `@all` mention; broader agent fan-out is intentional.
+- `to: me+@all+@other-agent` — room-wide fan-out plus specific priority responders.
+- `to: *` — no explicit agent mention; agents should be conservative and respond only with useful new information.
+
+When `@all` appears together with specific agent mentions, ACG preserves the specific
+mentions as **priority responders** rather than letting `@all` erase them. Agents that
+do not have useful, non-duplicative input should respond with only
+`<end-of-agent-chain>` so the chain terminates cleanly.
+
 ---
 
 ## Prompt Injection & Turn Awareness
@@ -307,6 +324,14 @@ This lets agents hand off work gracefully and restart with a fresh budget after 
 ### 6. Observe Conversations in the Room
 
 Don't hide agent conversations in threads. Let humans see what's happening. Open threads reduce surprise and allow for timely intervention.
+
+### 7. Use `@all` Sparingly
+
+Use Rocket.Chat `@all` only when you intentionally want every configured agent in the
+room to consider responding. Prefer specific agent mentions such as `@research-bot` for
+directed handoffs. If you combine `@all` with a specific agent mention, that specific
+agent remains a priority responder while other agents should only add non-duplicative
+value.
 
 ---
 

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -19,6 +19,7 @@ This document clearly communicates what agent-chat-gateway supports today, what 
 - ✅ **Message triggering**
   - Direct message (DM) activation — all DMs to bot are forwarded to agent
   - Channel/group activation — requires `@mention` of bot username
+  - Room-wide `@all` activation — treated as explicit permission for broader multi-agent fan-out
 
 - ✅ **Attachments**
   - Inbound attachment download (files, images, documents)
@@ -147,6 +148,8 @@ This document clearly communicates what agent-chat-gateway supports today, what 
 
 #### Behavior
 - ✅ Injected on session start (one-time, not per-message)
+- ✅ Built-in Rocket.Chat gateway context injected automatically
+- ✅ Lazy instruction loading for bundled scheduling/history docs via `agent-chat-gateway instructions ...`
 - ✅ 256 KB per file limit
 - ✅ 512 KB total context limit
 - ✅ Multiple context files supported (concatenated)
@@ -351,4 +354,3 @@ If you'd like to see a feature implemented:
 4. **Submit an issue** — File a feature request with your use case and motivation
 
 For security-related features or constraints, please contact the maintainers privately via the security reporting process.
-

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -379,6 +379,7 @@ agents:
     working_directory: ~/.agent-chat-gateway/work
     new_session_args: []
     session_prefix: "agent-chat"
+    lazy_instruction_loading: true
     context_inject_files: []
 
     owner_allowed_tools:
@@ -408,6 +409,7 @@ agents:
 | `working_directory` | string | Yes | Working directory for the agent subprocess |
 | `new_session_args` | list | No | Extra CLI args for new sessions |
 | `session_prefix` | string | No | Prefix for session titles |
+| `lazy_instruction_loading` | boolean | No | If `true` (default), injects a short tool index and lets agents load bundled scheduling/history docs on demand with `agent-chat-gateway instructions ...`; if `false`, injects the full bundled tool docs at session start. |
 | `context_inject_files` | list | No | Context files injected on every session |
 | `owner_allowed_tools` | list | No | Auto-approved tools for owners (see Tool Allow-Lists below) |
 | `guest_allowed_tools` | list | No | Auto-approved tools for guests (see Tool Allow-Lists below) |
@@ -779,6 +781,11 @@ Only use this in trusted, sandboxed environments where interactive approval is n
 
 Context files are injected into the agent session to provide domain knowledge, system prompts, or other guidance. Three levels of context are supported:
 
+ACG also injects built-in gateway context automatically. You do **not** need to list
+`gateway/contexts/rc-gateway-context.md` or other bundled context files in your config.
+The built-in Rocket.Chat context teaches agents how to read trusted message headers,
+roles, `to:` addressing, injection-protection rules, and gateway commands.
+
 ### Three-Level Injection
 
 1. **Connector-level** (`connectors[].context_inject_files`) — Shared across all watchers on this connector
@@ -786,6 +793,32 @@ Context files are injected into the agent session to provide domain knowledge, s
 3. **Watcher-level** (`watchers[].context_inject_files`) — Specific to this watcher's session
 
 Files are injected in this order, so watcher-level context overrides agent-level, which overrides connector-level.
+
+### Built-in Tool Instructions and Lazy Loading
+
+By default, agents receive a compact built-in tool index instead of the full scheduling
+and history-fetching instructions. This keeps new sessions lighter while still making
+the full docs available on demand:
+
+```bash
+agent-chat-gateway instructions scheduling
+agent-chat-gateway instructions fetch-history
+```
+
+Agents should run the matching `instructions` command before using advanced gateway
+commands such as `agent-chat-gateway schedule ...` or `agent-chat-gateway fetch-history ...`.
+These read-only instruction commands are auto-approved for owners and guests.
+
+If an agent backend performs better with all tool instructions present up front, set:
+
+```yaml
+agents:
+  claude:
+    lazy_instruction_loading: false
+```
+
+When disabled, ACG injects the full bundled scheduling and fetch-history context at
+session start instead of the compact tool index.
 
 ### Example
 
@@ -835,15 +868,13 @@ cp contexts/rc-room-profiles.example.md contexts/rc-room-profiles.md
 # Edit rc-room-profiles.md with your team's actual profiles
 ```
 
-Then reference it in your config. `rc-gateway-context.md` belongs at the **connector level**
-(shared across all rooms); room profiles are **watcher-level** (room-specific):
+Then reference it in your config. Built-in gateway behavior context is injected
+automatically; room profiles are **watcher-level** because they are room-specific:
 
 ```yaml
 connectors:
   - name: rc-main
     ...
-    context_inject_files:
-      - contexts/rc-gateway-context.md   # Gateway behavior rules — shared across all rooms
 
 watchers:
   - name: general
@@ -854,10 +885,10 @@ watchers:
       - contexts/rc-room-profiles.md     # Room member profiles — specific to this room
 ```
 
-`contexts/rc-gateway-context.md` (included in the repo) sets up baseline gateway behavior:
-response length, message format parsing, injection protection, and guest access rules.
-Placing it at the connector level means you only need to list it once, and every room
-on that connector automatically benefits from it.
+The built-in Rocket.Chat context sets up baseline gateway behavior automatically:
+response length, message format parsing, `to:` addressing, injection protection, and
+guest access rules. Use your own context files only for custom behavior such as room
+member profiles, project knowledge, or team-specific tone.
 
 ### Limits
 

--- a/gateway/cli.py
+++ b/gateway/cli.py
@@ -120,6 +120,17 @@ def main():
     fh_p.add_argument("--verbatim", type=int, default=15, metavar="N",
                       help="Last N messages kept verbatim; older messages condensed (default: 15)")
 
+    # instructions
+    instructions_p = sub.add_parser(
+        "instructions",
+        help="Print bundled ACG instruction docs by name",
+    )
+    instructions_p.add_argument(
+        "name",
+        choices=_instruction_names(),
+        help="Instruction document to print",
+    )
+
     # schedule (sub-subcommands)
     schedule_p = sub.add_parser("schedule", help="Manage scheduled agent tasks")
     schedule_sub = schedule_p.add_subparsers(dest="schedule_cmd", help="Schedule subcommands")
@@ -311,8 +322,28 @@ def main():
     elif args.command == "fetch-history":
         _run_fetch_history(args)
 
+    elif args.command == "instructions":
+        _run_instructions(args)
+
     elif args.command == "schedule":
         _run_schedule(args)
+
+
+def _run_instructions(args) -> None:
+    """Print a bundled instruction document without requiring the daemon."""
+    from .instructions import read_instruction
+
+    try:
+        print(read_instruction(args.name), end="")
+    except (OSError, ValueError) as exc:
+        print(f"Error: could not read instruction {args.name!r}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _instruction_names() -> list[str]:
+    from .instructions import instruction_names
+
+    return instruction_names()
 
 
 def _run_fetch_history(args) -> None:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -207,6 +207,12 @@ class GatewayConfig:
                     f"or is not a directory: '{working_directory}'"
                 )
 
+            lazy_instruction_loading = agent_raw.get("lazy_instruction_loading", True)
+            if not isinstance(lazy_instruction_loading, bool):
+                raise ValueError(
+                    f"Agent '{agent_name}': lazy_instruction_loading must be a boolean"
+                )
+
             agents[agent_name] = AgentConfig(
                 name=agent_name,
                 type=agent_raw.get("type", "claude"),
@@ -214,6 +220,7 @@ class GatewayConfig:
                 new_session_args=agent_raw.get("new_session_args", []),
                 working_directory=working_directory,
                 session_prefix=agent_raw.get("session_prefix", "agent-chat"),
+                lazy_instruction_loading=lazy_instruction_loading,
                 context_inject_files=ctx_files,
                 owner_allowed_tools=_parse_tool_rules(
                     agent_raw.get("owner_allowed_tools", []), agent_name

--- a/gateway/connectors/rocketchat/connector.py
+++ b/gateway/connectors/rocketchat/connector.py
@@ -31,6 +31,7 @@ from ...core.connector import (
 from ...core.tz_utils import local_iana_timezone as _server_local_timezone
 from .agent_chain import TurnStore
 from .config import RocketChatConfig
+from .mentions import is_room_wide_mention
 from .normalize import FilterResult, filter_rc_message, normalize_rc_message
 from .outbound import send_media as _send_media
 from .outbound import send_text as _send_text
@@ -400,6 +401,8 @@ class RocketChatConnector(Connector):
         - ``to: me``          — only this bot is @mentioned
         - ``to: @wavebro``    — one or more other agents mentioned, not this bot
         - ``to: me+@wavebro`` — this bot and other agents mentioned
+        - ``to: @all``        — room-wide explicit mention such as ``@all``
+        - ``to: me+@all+@wavebro`` — room-wide mention plus priority agents
         - ``to: *``           — no explicit agent mention in a channel (broadcast)
 
         DMs are treated as ``to: me`` because the user is speaking to the bot
@@ -418,18 +421,21 @@ class RocketChatConnector(Connector):
         mentioned = set(msg.mentions)
 
         own_mentioned = own in mentioned
+        all_mentioned = any(is_room_wide_mention(u) for u in mentioned)
         other_agents = [
             self._PREFIX_UNSAFE_RE.sub("_", u)
             for u in msg.mentions
-            if u != own and u in agent_names
+            if u != own and not is_room_wide_mention(u) and u in agent_names
         ]
 
-        if not own_mentioned and not other_agents:
+        if not own_mentioned and not all_mentioned and not other_agents:
             return "to: *"
 
         parts = []
         if own_mentioned:
             parts.append("me")
+        if all_mentioned:
+            parts.append("@all")
         parts.extend(f"@{u}" for u in other_agents)
         return "to: " + "+".join(parts)
 

--- a/gateway/connectors/rocketchat/mentions.py
+++ b/gateway/connectors/rocketchat/mentions.py
@@ -1,0 +1,10 @@
+"""Rocket.Chat mention helpers shared by normalize and prompt routing."""
+
+from __future__ import annotations
+
+ROOM_WIDE_MENTIONS = frozenset({"all"})
+
+
+def is_room_wide_mention(username: str) -> bool:
+    """Return True when a Rocket.Chat mention targets the whole room."""
+    return username in ROOM_WIDE_MENTIONS

--- a/gateway/connectors/rocketchat/normalize.py
+++ b/gateway/connectors/rocketchat/normalize.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING
 
 from ...core.adapter_utils import ts_to_float as _ts_to_float
 from ...core.connector import Attachment, IncomingMessage, Room, User, UserRole
+from .mentions import is_room_wide_mention
 
 if TYPE_CHECKING:
     from .agent_chain import TurnStore
@@ -106,7 +107,10 @@ def filter_rc_message(
     if config.require_mention and not is_agent and room_type != "dm":
         mentions = doc.get("mentions", [])
         bot_mentioned = any(m.get("username") == config.username for m in mentions)
-        if not bot_mentioned:
+        room_wide_mentioned = any(
+            is_room_wide_mention(m.get("username", "")) for m in mentions
+        )
+        if not bot_mentioned and not room_wide_mentioned:
             msg_text = doc.get("msg", "")
             attach_descs = " ".join(
                 a.get("description", "") for a in doc.get("attachments", [])
@@ -226,19 +230,6 @@ async def normalize_rc_message(
         for m in doc.get("mentions", [])
         if m.get("username")
     ]
-
-    raw_msg = doc.get("msg", "")
-    if isinstance(raw_msg, str) and "@all" in raw_msg:
-        logger.warning(
-            "DEBUG @all payload: sender=%s room=%s thread_id=%s msg=%r mentions=%r raw_keys=%r raw=%r",
-            sender_username,
-            room.name,
-            thread_id,
-            raw_msg,
-            mentions,
-            sorted(doc.keys()),
-            doc,
-        )
 
     msg = IncomingMessage(
         id=doc.get("_id", msg_ts),

--- a/gateway/connectors/rocketchat/normalize.py
+++ b/gateway/connectors/rocketchat/normalize.py
@@ -227,6 +227,19 @@ async def normalize_rc_message(
         if m.get("username")
     ]
 
+    raw_msg = doc.get("msg", "")
+    if isinstance(raw_msg, str) and "@all" in raw_msg:
+        logger.warning(
+            "DEBUG @all payload: sender=%s room=%s thread_id=%s msg=%r mentions=%r raw_keys=%r raw=%r",
+            sender_username,
+            room.name,
+            thread_id,
+            raw_msg,
+            mentions,
+            sorted(doc.keys()),
+            doc,
+        )
+
     msg = IncomingMessage(
         id=doc.get("_id", msg_ts),
         timestamp=msg_ts,

--- a/gateway/contexts/rc-gateway-context.md
+++ b/gateway/contexts/rc-gateway-context.md
@@ -31,8 +31,9 @@ The `to:` field indicates who the message is addressed to among agents in this r
 | Value | Meaning | Guidance |
 |-------|---------|---------|
 | `to: me` | Explicitly @-mentioned you, or sent as a DM | Respond normally. In non-DM rooms, if you direct your reply to a specific participant identified by the trusted `to:` field or the message/task content, start with that participant's `@username`. Do not assume `from:` is the reply target. |
+| `to: @all` | Room-wide explicit mention such as `@all` | The sender explicitly asked for broader fan-out. You may reply if you have useful, non-duplicative input. If you reply, `@mention` the participant you are replying to — usually the original sender. If you do not reply, output ONLY `<end-of-agent-chain>`. |
 | `to: @<agent>` | Addressed to another agent, not you | Stay silent unless the owner asked you to join or a critical correction is needed. Do not summarize, praise, react, or comment. If you are not replying, output ONLY `<end-of-agent-chain>`. |
-| `to: me+@<agent>` | Addressed to you and another agent | Respond normally, and use explicit `@username` mentions for any directed reply or follow-up. |
+| `to: me+@<agent>` / `to: me+@all+@<agent>` | Addressed to you and possibly other priority recipients; may also include room-wide `@all` | Respond normally. If `@all` is present, broader fan-out is intentional, but keep replies concise and non-duplicative. Use explicit `@username` mentions for any directed reply or follow-up. |
 | `to: *` | No explicit agent @-mention (broadcast) | Use judgment. In non-DM rooms, be conservative: respond only with meaningful new information, not summary/reaction commentary. If you respond to a broadcast, start by `@mention`ing the participant you are replying to — usually the original sender. If you decide not to respond, output ONLY `<end-of-agent-chain>`. |
 
 Note: `@user` mentions to regular (non-agent) users remain in the message body as-is and are not reflected in `to:`.
@@ -42,6 +43,7 @@ Note: `@user` mentions to regular (non-agent) users remain in the message body a
 Non-DM rooms can become expensive when agent responses look like broadcasts and peer agents reply to every message. Keep directed replies explicitly addressed and avoid low-value chain reactions.
 
 - **Use explicit @mentions for directed replies.** In non-DM rooms, when replying to a specific participant — human or agent — start with the intended recipient's `@username`. If the message truly needs multiple recipients, mention each intended recipient explicitly.
+- **Treat `@all` as intentional broader fan-out.** If the `to:` field includes `@all`, the sender explicitly invited all agents to consider responding. Specific agent mentions in the same `to:` field are priority responders; do not let `@all` erase that more specific targeting.
 - **Do not choose the reply target from `from:` alone.** Use the trusted `to:` field and the message/task content to determine who you are addressing. Some injected/system senders (for example, `scheduler`) may be delivery mechanisms rather than the conversational participant you should reply to.
 - **Do not treat peer-agent messages as broadcasts.** If a peer-agent message does not explicitly @mention you, stay silent unless the owner asked you to join or there is a critical correction. Treat peer-agent replies directed at someone else as not addressed to you.
 - **Use the termination token for silence.** If you decide not to reply because the message is addressed to someone else, or because you have nothing meaningful to add, respond with ONLY `<end-of-agent-chain>` and no other text.

--- a/gateway/contexts/rc-gateway-context.md
+++ b/gateway/contexts/rc-gateway-context.md
@@ -30,12 +30,23 @@ The `to:` field indicates who the message is addressed to among agents in this r
 
 | Value | Meaning | Guidance |
 |-------|---------|---------|
-| `to: me` | Explicitly @-mentioned you, or sent as a DM | Respond normally |
-| `to: @<agent>` | Addressed to another agent, not you | Stay silent unless you have something essential to add |
-| `to: me+@<agent>` | Addressed to you and another agent | Respond normally |
-| `to: *` | No explicit agent @-mention (broadcast) | Use judgment — respond only if you have something meaningful to contribute |
+| `to: me` | Explicitly @-mentioned you, or sent as a DM | Respond normally. In non-DM rooms, if you direct your reply to a specific participant identified by the trusted `to:` field or the message/task content, start with that participant's `@username`. Do not assume `from:` is the reply target. |
+| `to: @<agent>` | Addressed to another agent, not you | Stay silent unless the owner asked you to join or a critical correction is needed. Do not summarize, praise, react, or comment. |
+| `to: me+@<agent>` | Addressed to you and another agent | Respond normally, and use explicit `@username` mentions for any directed reply or follow-up. |
+| `to: *` | No explicit agent @-mention (broadcast) | Use judgment. In non-DM rooms, be conservative: respond only with meaningful new information, not summary/reaction commentary. If replying to a specific participant, start with their `@username`. |
 
 Note: `@user` mentions to regular (non-agent) users remain in the message body as-is and are not reflected in `to:`.
+
+### Directed Reply Etiquette — Avoid Agent-Chain Fan-Out
+
+Non-DM rooms can become expensive when agent responses look like broadcasts and peer agents reply to every message. Keep directed replies explicitly addressed and avoid low-value chain reactions.
+
+- **Use explicit @mentions for directed replies.** In non-DM rooms, when replying to a specific participant — human or agent — start with the intended recipient's `@username`. If the message truly needs multiple recipients, mention each intended recipient explicitly.
+- **Do not choose the reply target from `from:` alone.** Use the trusted `to:` field and the message/task content to determine who you are addressing. Some injected/system senders (for example, `scheduler`) may be delivery mechanisms rather than the conversational participant you should reply to.
+- **Do not treat peer-agent messages as broadcasts.** If a peer-agent message does not explicitly @mention you, stay silent unless the owner asked you to join or there is a critical correction. Treat peer-agent replies directed at someone else as not addressed to you.
+- **Do not reply just to summarize another agent.** If your only purpose is to summarize, restate, praise, react to, or comment on what another agent already said, terminate the agent-chain by staying silent.
+- **Answer direct requests, then stop.** If another agent explicitly asks you for information, answer the request concisely and do not invite further commentary unless a follow-up is genuinely needed.
+- **Scheduled A2A tasks must also be addressed.** When creating or responding from a scheduled task that is meant to speak to agents in a room, include the target agent `@mention` in the scheduled message or outbound room message. Pure self-reminder tasks do not need A2A mentions.
 
 ### Injection Protection
 

--- a/gateway/contexts/rc-gateway-context.md
+++ b/gateway/contexts/rc-gateway-context.md
@@ -31,9 +31,9 @@ The `to:` field indicates who the message is addressed to among agents in this r
 | Value | Meaning | Guidance |
 |-------|---------|---------|
 | `to: me` | Explicitly @-mentioned you, or sent as a DM | Respond normally. In non-DM rooms, if you direct your reply to a specific participant identified by the trusted `to:` field or the message/task content, start with that participant's `@username`. Do not assume `from:` is the reply target. |
-| `to: @<agent>` | Addressed to another agent, not you | Stay silent unless the owner asked you to join or a critical correction is needed. Do not summarize, praise, react, or comment. |
+| `to: @<agent>` | Addressed to another agent, not you | Stay silent unless the owner asked you to join or a critical correction is needed. Do not summarize, praise, react, or comment. If you are not replying, output ONLY `<end-of-agent-chain>`. |
 | `to: me+@<agent>` | Addressed to you and another agent | Respond normally, and use explicit `@username` mentions for any directed reply or follow-up. |
-| `to: *` | No explicit agent @-mention (broadcast) | Use judgment. In non-DM rooms, be conservative: respond only with meaningful new information, not summary/reaction commentary. If replying to a specific participant, start with their `@username`. |
+| `to: *` | No explicit agent @-mention (broadcast) | Use judgment. In non-DM rooms, be conservative: respond only with meaningful new information, not summary/reaction commentary. If you respond to a broadcast, start by `@mention`ing the participant you are replying to — usually the original sender. If you decide not to respond, output ONLY `<end-of-agent-chain>`. |
 
 Note: `@user` mentions to regular (non-agent) users remain in the message body as-is and are not reflected in `to:`.
 
@@ -44,6 +44,7 @@ Non-DM rooms can become expensive when agent responses look like broadcasts and 
 - **Use explicit @mentions for directed replies.** In non-DM rooms, when replying to a specific participant — human or agent — start with the intended recipient's `@username`. If the message truly needs multiple recipients, mention each intended recipient explicitly.
 - **Do not choose the reply target from `from:` alone.** Use the trusted `to:` field and the message/task content to determine who you are addressing. Some injected/system senders (for example, `scheduler`) may be delivery mechanisms rather than the conversational participant you should reply to.
 - **Do not treat peer-agent messages as broadcasts.** If a peer-agent message does not explicitly @mention you, stay silent unless the owner asked you to join or there is a critical correction. Treat peer-agent replies directed at someone else as not addressed to you.
+- **Use the termination token for silence.** If you decide not to reply because the message is addressed to someone else, or because you have nothing meaningful to add, respond with ONLY `<end-of-agent-chain>` and no other text.
 - **Do not reply just to summarize another agent.** If your only purpose is to summarize, restate, praise, react to, or comment on what another agent already said, terminate the agent-chain by staying silent.
 - **Answer direct requests, then stop.** If another agent explicitly asks you for information, answer the request concisely and do not invite further commentary unless a follow-up is genuinely needed.
 - **Scheduled A2A tasks must also be addressed.** When creating or responding from a scheduled task that is meant to speak to agents in a room, include the target agent `@mention` in the scheduled message or outbound room message. Pure self-reminder tasks do not need A2A mentions.

--- a/gateway/contexts/tool-index-context.md
+++ b/gateway/contexts/tool-index-context.md
@@ -1,0 +1,25 @@
+# ACG Tool Instruction Index
+
+This session uses lazy loading for detailed ACG tool manuals. The full scheduling and fetch-history instructions are intentionally not injected by default.
+
+When the user asks for one of these capabilities, load the matching instruction first and follow it exactly:
+
+---
+instruction: scheduling
+detail: agent-chat-gateway instructions scheduling
+when: User asks to create, list, pause, resume, or delete scheduled tasks, reminders, recurring jobs, or automations.
+rule: Before running `agent-chat-gateway schedule ...`, run `agent-chat-gateway instructions scheduling` and follow the returned instructions exactly.
+---
+
+---
+instruction: fetch-history
+detail: agent-chat-gateway instructions fetch-history
+when: You need to look up earlier room messages, refresh recent history, page through channel history, or fetch raw evidence from the conversation.
+rule: Before running `agent-chat-gateway fetch-history ...`, run `agent-chat-gateway instructions fetch-history` and follow the returned instructions exactly.
+---
+
+Available command:
+
+```bash
+agent-chat-gateway instructions <scheduling|fetch-history>
+```

--- a/gateway/control.py
+++ b/gateway/control.py
@@ -220,6 +220,10 @@ class ControlServer:
         if cmd == "fetch-history":
             return await self._handle_fetch_history(request)
 
+        # instructions: static bundled docs for lazy instruction loading
+        if cmd == "instructions":
+            return self._handle_instructions(request)
+
         # schedule-*: managed by JobStore (no connector routing needed)
         if cmd and cmd.startswith("schedule-"):
             return self._handle_schedule(cmd, request)
@@ -239,6 +243,18 @@ class ControlServer:
             return entry  # error response
 
         return await entry.session_manager.dispatch_command(request)
+
+    def _handle_instructions(self, request: dict) -> dict:
+        """Return a bundled instruction document by name."""
+        from .instructions import read_instruction
+
+        name = request.get("name")
+        if not isinstance(name, str) or not name:
+            return {"ok": False, "error": "Missing 'name' field in instructions command"}
+        try:
+            return {"ok": True, "name": name, "text": read_instruction(name)}
+        except (OSError, ValueError) as exc:
+            return {"ok": False, "error": str(exc)}
 
     def _resolve_entry(
         self, connector_name: str | None

--- a/gateway/core/config.py
+++ b/gateway/core/config.py
@@ -24,9 +24,9 @@ _BUILTIN_CONTEXTS_DIR = Path(__file__).parent.parent / "contexts"
 # without triggering a 🔐 human-approval prompt — they are the gateway's own management
 # interface, not arbitrary shell commands.
 #
-# Owner rules: send, schedule, fetch-history, date
+# Owner rules: send, schedule, fetch-history, instructions, date
 #   (owners get all commands — write, mutation, and read-only)
-# Guest rules:  fetch-history only (read-only; send/schedule are owner-only)
+# Guest rules:  fetch-history and instructions only (read-only; send/schedule are owner-only)
 _BUILTIN_OWNER_TOOL_RULES: "list[ToolRule]" = []  # populated after ToolRule is defined
 _BUILTIN_GUEST_TOOL_RULES: "list[ToolRule]" = []  # populated after ToolRule is defined
 
@@ -102,6 +102,7 @@ _BUILTIN_OWNER_TOOL_RULES = [
     ToolRule(tool="Bash", params="agent-chat-gateway\\s+send\\s+.*"),
     ToolRule(tool="Bash", params="agent-chat-gateway\\s+schedule\\s+.*"),
     ToolRule(tool="Bash", params="agent-chat-gateway\\s+fetch-history\\s+.*"),
+    ToolRule(tool="Bash", params="agent-chat-gateway\\s+instructions\\s+(scheduling|fetch-history)\\s*"),
     # date is a read-only command used by agents to compute timestamps.
     # It is safe to auto-approve for owners so that compound bash commands
     # containing $(date ...) sub-expressions do not trigger approval prompts.
@@ -112,6 +113,7 @@ _BUILTIN_GUEST_TOOL_RULES = [
     # fetch-history is read-only — guests can safely query channel history
     # for context without being able to send messages or create schedules.
     ToolRule(tool="Bash", params="agent-chat-gateway\\s+fetch-history\\s+.*"),
+    ToolRule(tool="Bash", params="agent-chat-gateway\\s+instructions\\s+(scheduling|fetch-history)\\s*"),
 ]
 
 
@@ -123,6 +125,7 @@ class AgentConfig:
     new_session_args: list[str] = field(default_factory=list)
     working_directory: str = ""  # cwd for sidecar process (opencode agents); "" = inherit gateway cwd
     session_prefix: str = "agent-chat"  # prefix for session names/titles
+    lazy_instruction_loading: bool = True  # inject short tool index; load full docs on demand
     context_inject_files: list[str] = field(default_factory=list)  # paths injected once per session
     owner_allowed_tools: list[ToolRule] = field(default_factory=list)  # auto-approved for owners
     guest_allowed_tools: list[ToolRule] = field(default_factory=list)  # auto-approved for guests
@@ -132,20 +135,22 @@ class AgentConfig:
     def effective_owner_allowed_tools(self) -> "list[ToolRule]":
         """Return owner_allowed_tools with built-in gateway rules prepended.
 
-        The built-in rules (``agent-chat-gateway send``, ``schedule``, and
-        ``fetch-history``) are always included so that agents can call gateway
-        management commands without triggering a 🔐 human-approval prompt —
-        no user config required.  User-defined rules follow the built-in ones
-        so that custom patterns can further extend the allow list.
+        The built-in rules (``agent-chat-gateway send``, ``schedule``,
+        ``fetch-history``, and ``instructions``) are always included so that
+        agents can call gateway management commands without triggering a 🔐
+        human-approval prompt — no user config required.  User-defined rules
+        follow the built-in ones so that custom patterns can further extend
+        the allow list.
         """
         return list(_BUILTIN_OWNER_TOOL_RULES) + list(self.owner_allowed_tools)
 
     def effective_guest_allowed_tools(self) -> "list[ToolRule]":
         """Return guest_allowed_tools with built-in read-only gateway rules prepended.
 
-        The built-in guest rule allows ``agent-chat-gateway fetch-history`` —
-        a read-only operation safe for guest-role agents.  Write operations
-        (``send``, ``schedule``) remain owner-only.
+        The built-in guest rules allow ``agent-chat-gateway fetch-history``
+        and ``agent-chat-gateway instructions`` — read-only operations safe
+        for guest-role agents.  Write operations (``send``, ``schedule``)
+        remain owner-only.
         """
         return list(_BUILTIN_GUEST_TOOL_RULES) + list(self.guest_allowed_tools)
 
@@ -263,7 +268,8 @@ class CoreConfig:
         Concatenates four layers in order:
           0. Built-in system files (auto-injected; no user config needed):
                - rc-gateway-context.md  — injected for every Rocket.Chat connector
-               - scheduling-context.md  — injected for every configured connector
+               - tool-index-context.md  — injected when the agent uses lazy instruction loading
+               - scheduling/fetch-history docs — injected when lazy loading is disabled
           1. Connector-level files (from ConnectorConfig.context_inject_files)
           2. Agent-level files    (from AgentConfig.context_inject_files)
           3. Watcher-level files  (passed in directly as watcher_ctx)
@@ -276,18 +282,21 @@ class CoreConfig:
         """
         result: list[str] = []
         connector_cfg = self.connector_configs.get(connector_name)
+        agent_cfg = self.agent_config(agent_name)
 
         # Layer 0: built-in system context files (shipped inside the package)
         if connector_cfg is not None:
             if connector_cfg.type == "rocketchat":
                 result.append(str(_BUILTIN_CONTEXTS_DIR / "rc-gateway-context.md"))
-            result.append(str(_BUILTIN_CONTEXTS_DIR / "scheduling-context.md"))
-            result.append(str(_BUILTIN_CONTEXTS_DIR / "fetch-history-context.md"))
+            if agent_cfg.lazy_instruction_loading:
+                result.append(str(_BUILTIN_CONTEXTS_DIR / "tool-index-context.md"))
+            else:
+                result.append(str(_BUILTIN_CONTEXTS_DIR / "scheduling-context.md"))
+                result.append(str(_BUILTIN_CONTEXTS_DIR / "fetch-history-context.md"))
             # Layer 1: connector-level user files
             result.extend(connector_cfg.context_inject_files)
 
         # Layer 2: agent-level user files
-        agent_cfg = self.agent_config(agent_name)
         result.extend(agent_cfg.context_inject_files)
 
         # Layer 3: watcher-level user files

--- a/gateway/core/context_injector.py
+++ b/gateway/core/context_injector.py
@@ -197,8 +197,9 @@ class ContextInjector:
                     f"## Multi-Agent Addressing\n"
                     f"Each message header includes a `to:` field. Use it to decide your response:\n"
                     f"- `to: me` — message explicitly addressed to you → respond normally\n"
+                    f"- `to: @all` — room-wide explicit mention → broader fan-out is intentional; reply only with useful, non-duplicative input, otherwise output ONLY `<end-of-agent-chain>`\n"
                     f"- `to: @<agent>` — addressed to another agent → stay silent unless you have something essential to add\n"
-                    f"- `to: me+@<agent>` — addressed to you and others → respond normally\n"
+                    f"- `to: me+@<agent>` / `to: me+@all+@<agent>` — addressed to you and other priority responders; if `@all` is present, broader fan-out is intentional but keep replies concise and non-duplicative\n"
                     f"- `to: *` — no explicit agent mention → use judgment; respond only if you have something meaningful to contribute\n"
                 )
             # Inject order (innermost = inserted last at position 0):

--- a/gateway/instructions.py
+++ b/gateway/instructions.py
@@ -1,0 +1,30 @@
+"""Bundled instruction document lookup for lazy-loaded ACG docs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+BUILTIN_CONTEXTS_DIR = Path(__file__).parent / "contexts"
+INSTRUCTION_DOCS = {
+    "scheduling": "scheduling-context.md",
+    "fetch-history": "fetch-history-context.md",
+}
+
+
+def instruction_names() -> list[str]:
+    """Return the supported instruction names in stable CLI display order."""
+    return sorted(INSTRUCTION_DOCS)
+
+
+def read_instruction(name: str) -> str:
+    """Return a bundled instruction document by name.
+
+    Raises:
+        ValueError: if the instruction name is unknown.
+        OSError: if the bundled file cannot be read.
+    """
+    filename = INSTRUCTION_DOCS.get(name)
+    if filename is None:
+        supported = ", ".join(instruction_names())
+        raise ValueError(f"Unknown instruction {name!r}; expected one of: {supported}")
+    return (BUILTIN_CONTEXTS_DIR / filename).read_text(encoding="utf-8")

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -159,6 +159,26 @@ class TestCLIArgParsing(unittest.TestCase):
         self.assertEqual(cm.exception.code, 1)
 
 
+class TestCLIInstructions(_CLITestBase):
+    """instructions: print bundled docs without contacting the daemon."""
+
+    def test_instructions_scheduling_prints_scheduling_doc(self):
+        stdout, stderr, code = self._run(["instructions", "scheduling"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("# ACG Scheduling Commands", stdout)
+        self.assertIn("agent-chat-gateway schedule create", stdout)
+
+    def test_instructions_fetch_history_prints_fetch_history_doc(self):
+        stdout, stderr, code = self._run(["instructions", "fetch-history"])
+
+        self.assertEqual(code, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("# fetch-history", stdout)
+        self.assertIn("agent-chat-gateway fetch-history", stdout)
+
+
 # ---------------------------------------------------------------------------
 # Tests: status command
 # ---------------------------------------------------------------------------

--- a/tests/integration/test_context_injector.py
+++ b/tests/integration/test_context_injector.py
@@ -841,7 +841,15 @@ class TestContextInjectorDynamicHeader(unittest.IsolatedAsyncioTestCase):
             return None
 
         with patch("gateway.core.context_injector.asyncio.to_thread", side_effect=fake_to_thread):
-            await injector.inject(ws, "ses_header_test", agent, "default", "rc-home", wc)
+            await injector.inject(
+                ws,
+                "ses_header_test",
+                agent,
+                "default",
+                "rc-home",
+                wc,
+                agent_username="bot",
+            )
 
         self.assertIsNotNone(sent_prompt, "agent.send must have been called")
         # Dynamic header must appear before the static file content
@@ -853,6 +861,10 @@ class TestContextInjectorDynamicHeader(unittest.IsolatedAsyncioTestCase):
         # Watcher name and connector must appear in the header
         self.assertIn("my-watcher", sent_prompt)
         self.assertIn("rc-home", sent_prompt)
+        self.assertIn("to: @all", sent_prompt)
+        self.assertIn("broader fan-out is intentional", sent_prompt)
+        self.assertIn("priority responders", sent_prompt)
+        self.assertIn("ONLY `<end-of-agent-chain>`", sent_prompt)
 
     async def test_dynamic_header_not_sent_when_all_files_oversized(self):
         """When all context files are oversized, agent.send must NOT be called."""

--- a/tests/unit/test_agent_chain.py
+++ b/tests/unit/test_agent_chain.py
@@ -24,6 +24,7 @@ from unittest.mock import patch
 
 from gateway.connectors.rocketchat.agent_chain import AGENT_CHAIN_TERMINATION_TOKEN, TurnStore
 from gateway.connectors.rocketchat.config import AgentChainConfig, RocketChatConfig
+from gateway.connectors.rocketchat.mentions import is_room_wide_mention
 from gateway.connectors.rocketchat.normalize import filter_rc_message
 from gateway.core.agent_chain import AGENT_CHAIN_TERMINATION_TOKEN as CORE_TOKEN
 from gateway.core.agent_chain import build_agent_chain_context
@@ -302,6 +303,36 @@ class TestFilterRcMessageAgentChain(unittest.TestCase):
 
         self.assertTrue(result.accepted)
         self.assertFalse(result.is_agent_chain)
+
+    def test_require_mention_true_accepts_room_wide_all_mention(self):
+        config = _make_config(owners=["human1"], require_mention=True)
+        room_wide_username = "all"
+        self.assertTrue(is_room_wide_mention(room_wide_username))
+        doc = _make_doc(
+            sender="human1",
+            rid="room1",
+            msg="@all everyone please check in",
+            mentions=[{"username": room_wide_username}],
+        )
+
+        result = filter_rc_message(doc, config, "channel", None)
+
+        self.assertTrue(result.accepted)
+        self.assertFalse(result.is_agent_chain)
+
+    def test_room_wide_all_mention_does_not_bypass_sender_filter(self):
+        config = _make_config(owners=["human1"], require_mention=True, filter_sender=True)
+        doc = _make_doc(
+            sender="stranger",
+            rid="room1",
+            msg="@all everyone please check in",
+            mentions=[{"username": "all"}],
+        )
+
+        result = filter_rc_message(doc, config, "channel", None)
+
+        self.assertFalse(result.accepted)
+        self.assertEqual(result.reason, "sender not in allow-list")
 
     def test_filter_sender_false_allows_unknown_senders(self):
         config = _make_config(owners=["human1"], filter_sender=False)

--- a/tests/unit/test_builtin_contexts.py
+++ b/tests/unit/test_builtin_contexts.py
@@ -7,6 +7,9 @@ def test_rc_context_contains_directed_reply_etiquette():
     context_path = Path(__file__).parents[2] / "gateway" / "contexts" / "rc-gateway-context.md"
     text = context_path.read_text(encoding="utf-8")
 
+    assert "`to: @all`" in text
+    assert "intentional broader fan-out" in text
+    assert "priority responders" in text
     assert "Directed Reply Etiquette" in text
     assert "Use explicit @mentions for directed replies" in text
     assert "human or agent" in text

--- a/tests/unit/test_builtin_contexts.py
+++ b/tests/unit/test_builtin_contexts.py
@@ -1,0 +1,17 @@
+"""Regression tests for bundled system context docs."""
+
+from pathlib import Path
+
+
+def test_rc_context_contains_directed_reply_etiquette():
+    context_path = Path(__file__).parents[2] / "gateway" / "contexts" / "rc-gateway-context.md"
+    text = context_path.read_text(encoding="utf-8")
+
+    assert "Directed Reply Etiquette" in text
+    assert "Use explicit @mentions for directed replies" in text
+    assert "human or agent" in text
+    assert "directed at someone else as not addressed to you" in text
+    assert "Do not choose the reply target from `from:` alone" in text
+    assert "scheduler" in text
+    assert "Do not reply just to summarize another agent" in text
+    assert "Scheduled A2A tasks must also be addressed" in text

--- a/tests/unit/test_builtin_contexts.py
+++ b/tests/unit/test_builtin_contexts.py
@@ -13,5 +13,7 @@ def test_rc_context_contains_directed_reply_etiquette():
     assert "directed at someone else as not addressed to you" in text
     assert "Do not choose the reply target from `from:` alone" in text
     assert "scheduler" in text
+    assert "usually the original sender" in text
+    assert "ONLY `<end-of-agent-chain>`" in text
     assert "Do not reply just to summarize another agent" in text
     assert "Scheduled A2A tasks must also be addressed" in text

--- a/tests/unit/test_config_loading.py
+++ b/tests/unit/test_config_loading.py
@@ -68,6 +68,22 @@ class TestWorkingDirectoryValidation(unittest.TestCase):
         path = self._write_config("default:\n  type: claude\n  working_directory: /tmp")
         config = GatewayConfig.from_file(path)
         self.assertEqual(config.agents["default"].working_directory, "/tmp")
+        self.assertTrue(config.agents["default"].lazy_instruction_loading)
+
+    def test_lazy_instruction_loading_false_accepted(self):
+        path = self._write_config(
+            "default:\n  type: claude\n  working_directory: /tmp\n  lazy_instruction_loading: false"
+        )
+        config = GatewayConfig.from_file(path)
+        self.assertFalse(config.agents["default"].lazy_instruction_loading)
+
+    def test_lazy_instruction_loading_must_be_boolean(self):
+        path = self._write_config(
+            'default:\n  type: claude\n  working_directory: /tmp\n  lazy_instruction_loading: "nope"'
+        )
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("lazy_instruction_loading", str(ctx.exception))
 
     def test_relative_directory_resolved_to_config_dir(self):
         """A relative working_directory is resolved relative to the config file's directory."""
@@ -430,7 +446,8 @@ class TestBuiltinContextAutoInjection(unittest.TestCase):
     """Built-in system context files are auto-prepended in context_inject_files_for().
 
     rc-gateway-context.md  → injected for every Rocket.Chat connector
-    scheduling-context.md  → injected for every configured connector
+    tool-index-context.md  → injected for lazy-loading agents (default)
+    scheduling/fetch-history docs → injected when an agent disables lazy loading
     """
 
     def _make_core_config(self, connector_type: str, user_ctx: list[str] | None = None):
@@ -448,37 +465,90 @@ class TestBuiltinContextAutoInjection(unittest.TestCase):
             default_agent="default",
         )
 
-    def test_rc_connector_gets_both_builtin_files(self):
-        """RC connector → rc-gateway-context.md + scheduling-context.md prepended."""
+    def test_rc_connector_gets_core_and_tool_index_by_default(self):
+        """RC connector → rc-gateway-context.md + tool-index-context.md prepended."""
         config = self._make_core_config("rocketchat")
         files = config.context_inject_files_for("rc", "default", [])
         basenames = [Path(f).name for f in files]
         self.assertIn("rc-gateway-context.md", basenames)
-        self.assertIn("scheduling-context.md", basenames)
+        self.assertIn("tool-index-context.md", basenames)
+        self.assertNotIn("scheduling-context.md", basenames)
+        self.assertNotIn("fetch-history-context.md", basenames)
 
-    def test_rc_gateway_context_comes_before_scheduling(self):
-        """rc-gateway-context.md must appear before scheduling-context.md."""
+    def test_rc_gateway_context_comes_before_tool_index(self):
+        """rc-gateway-context.md must appear before tool-index-context.md."""
         config = self._make_core_config("rocketchat")
         files = config.context_inject_files_for("rc", "default", [])
         basenames = [Path(f).name for f in files]
         rc_idx = basenames.index("rc-gateway-context.md")
-        sched_idx = basenames.index("scheduling-context.md")
-        self.assertLess(rc_idx, sched_idx)
+        index_idx = basenames.index("tool-index-context.md")
+        self.assertLess(rc_idx, index_idx)
 
-    def test_non_rc_connector_gets_scheduling_only(self):
-        """Non-RC connector → only scheduling-context.md injected (no rc-gateway-context.md)."""
+    def test_non_rc_connector_gets_tool_index_only_by_default(self):
+        """Non-RC connector → only tool-index-context.md injected (no rc-gateway-context.md)."""
         config = self._make_core_config("script")
         files = config.context_inject_files_for("rc", "default", [])
         basenames = [Path(f).name for f in files]
         self.assertNotIn("rc-gateway-context.md", basenames)
+        self.assertIn("tool-index-context.md", basenames)
+        self.assertNotIn("scheduling-context.md", basenames)
+        self.assertNotIn("fetch-history-context.md", basenames)
+
+    def test_agent_can_disable_lazy_instruction_loading(self):
+        """Per-agent lazy_instruction_loading=False restores full docs."""
+        from gateway.core.config import AgentConfig
+
+        config = self._make_core_config("rocketchat")
+        config.agents["default"] = AgentConfig(
+            name="default",
+            timeout=10,
+            lazy_instruction_loading=False,
+        )
+        files = config.context_inject_files_for("rc", "default", [])
+        basenames = [Path(f).name for f in files]
+        self.assertIn("rc-gateway-context.md", basenames)
         self.assertIn("scheduling-context.md", basenames)
+        self.assertIn("fetch-history-context.md", basenames)
+        self.assertNotIn("tool-index-context.md", basenames)
+
+    def test_yaml_lazy_instruction_loading_false_reaches_context_injection(self):
+        """YAML lazy_instruction_loading=False flows through to built-in full docs."""
+        from gateway.core.config import CoreConfig
+
+        cfg_text = textwrap.dedent("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+                lazy_instruction_loading: false
+            watchers:
+              - name: w1
+                room: general
+        """)
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(cfg_text)
+            path = f.name
+
+        gateway_config = GatewayConfig.from_file(path)
+        core_config = CoreConfig.from_gateway_config(gateway_config)
+
+        files = core_config.context_inject_files_for("rc", "default", [])
+        basenames = [Path(f).name for f in files]
+        self.assertIn("rc-gateway-context.md", basenames)
+        self.assertIn("scheduling-context.md", basenames)
+        self.assertIn("fetch-history-context.md", basenames)
+        self.assertNotIn("tool-index-context.md", basenames)
 
     def test_builtin_files_precede_user_connector_files(self):
         """Built-in layer 0 files must come before user-configured connector files."""
         config = self._make_core_config("rocketchat", user_ctx=["/user/custom.md"])
         files = config.context_inject_files_for("rc", "default", [])
         basenames = [Path(f).name for f in files]
-        sched_idx = basenames.index("scheduling-context.md")
+        sched_idx = basenames.index("tool-index-context.md")
         custom_idx = basenames.index("custom.md")
         self.assertLess(sched_idx, custom_idx)
 
@@ -486,7 +556,7 @@ class TestBuiltinContextAutoInjection(unittest.TestCase):
         """Built-in file paths must be absolute (so ContextInjector can read them)."""
         config = self._make_core_config("rocketchat")
         files = config.context_inject_files_for("rc", "default", [])
-        builtin = [f for f in files if Path(f).name in ("rc-gateway-context.md", "scheduling-context.md")]
+        builtin = [f for f in files if Path(f).name in ("rc-gateway-context.md", "tool-index-context.md")]
         for f in builtin:
             self.assertTrue(Path(f).is_absolute(), f"{f} must be absolute")
 
@@ -494,7 +564,7 @@ class TestBuiltinContextAutoInjection(unittest.TestCase):
         """Built-in context files must be present in the installed package."""
         config = self._make_core_config("rocketchat")
         files = config.context_inject_files_for("rc", "default", [])
-        builtin = [f for f in files if Path(f).name in ("rc-gateway-context.md", "scheduling-context.md")]
+        builtin = [f for f in files if Path(f).name in ("rc-gateway-context.md", "tool-index-context.md")]
         for f in builtin:
             self.assertTrue(Path(f).exists(), f"Built-in context file missing: {f}")
 
@@ -506,13 +576,14 @@ class TestBuiltinContextAutoInjection(unittest.TestCase):
         basenames = [Path(f).name for f in files]
         self.assertNotIn("rc-gateway-context.md", basenames)
         self.assertNotIn("scheduling-context.md", basenames)
+        self.assertNotIn("tool-index-context.md", basenames)
 
     def test_watcher_user_files_appended_after_builtin(self):
         """Watcher-level user files are appended last, after all built-in and agent files."""
         config = self._make_core_config("rocketchat")
         files = config.context_inject_files_for("rc", "default", ["/watcher/extra.md"])
         basenames = [Path(f).name for f in files]
-        sched_idx = basenames.index("scheduling-context.md")
+        sched_idx = basenames.index("tool-index-context.md")
         extra_idx = basenames.index("extra.md")
         self.assertLess(sched_idx, extra_idx)
 
@@ -554,6 +625,16 @@ class TestBuiltinOwnerToolRuleAutoInjection(unittest.TestCase):
         self.assertTrue(
             any("agent-chat-gateway" in (p or "") and "schedule" in (p or "") for p in params),
             "Built-in schedule rule must be in effective_owner_allowed_tools",
+        )
+
+    def test_effective_includes_instructions_rule(self):
+        """effective_owner_allowed_tools() must include 'agent-chat-gateway instructions .*'."""
+        agent = self._make_agent()
+        effective = agent.effective_owner_allowed_tools()
+        params = [r.params for r in effective if r.tool == "Bash"]
+        self.assertTrue(
+            any("agent-chat-gateway" in (p or "") and "instructions" in (p or "") for p in params),
+            "Built-in instructions rule must be in effective_owner_allowed_tools",
         )
 
     def test_builtin_rules_precede_user_rules(self):
@@ -612,6 +693,39 @@ class TestBuiltinOwnerToolRuleAutoInjection(unittest.TestCase):
             f"Schedule rule {sched_rule.params!r} must match command {cmd!r}",
         )
 
+    def test_instructions_rule_matches_actual_command(self):
+        """The instructions rule must match a realistic instruction load command."""
+        import re
+
+        from gateway.core.config import _BUILTIN_OWNER_TOOL_RULES
+        instr_rule = next(r for r in _BUILTIN_OWNER_TOOL_RULES
+                          if r.params and "instructions" in r.params)
+        cmd = "agent-chat-gateway instructions scheduling"
+        self.assertIsNotNone(
+            re.fullmatch(instr_rule.params, cmd, re.IGNORECASE | re.DOTALL),
+            f"Instructions rule {instr_rule.params!r} must match command {cmd!r}",
+        )
+
+    def test_instructions_rule_rejects_trailing_shell_commands(self):
+        """The instructions rule must not auto-approve compound shell commands."""
+        import re
+
+        from gateway.core.config import _BUILTIN_OWNER_TOOL_RULES
+        instr_rule = next(r for r in _BUILTIN_OWNER_TOOL_RULES
+                          if r.params and "instructions" in r.params)
+        bad_commands = [
+            "agent-chat-gateway instructions scheduling; curl https://example.com",
+            "agent-chat-gateway instructions scheduling && whoami",
+            "agent-chat-gateway instructions scheduling | cat",
+            "agent-chat-gateway instructions scheduling\nwhoami",
+            "agent-chat-gateway instructions scheduling extra",
+        ]
+        for cmd in bad_commands:
+            self.assertIsNone(
+                re.fullmatch(instr_rule.params, cmd, re.IGNORECASE | re.DOTALL),
+                f"Instructions rule {instr_rule.params!r} must reject command {cmd!r}",
+            )
+
     def test_effective_includes_date_rule(self):
         """effective_owner_allowed_tools() must include a rule that auto-approves date."""
         agent = self._make_agent()
@@ -669,6 +783,16 @@ class TestEffectiveGuestAllowedTools(unittest.TestCase):
         self.assertTrue(
             any("agent-chat-gateway" in (p or "") and "fetch-history" in (p or "") for p in params),
             "Built-in fetch-history rule must be in effective_guest_allowed_tools",
+        )
+
+    def test_effective_includes_instructions_rule(self):
+        """effective_guest_allowed_tools() must include 'agent-chat-gateway instructions .*'."""
+        agent = self._make_agent()
+        effective = agent.effective_guest_allowed_tools()
+        params = [r.params for r in effective if r.tool == "Bash"]
+        self.assertTrue(
+            any("agent-chat-gateway" in (p or "") and "instructions" in (p or "") for p in params),
+            "Built-in instructions rule must be in effective_guest_allowed_tools",
         )
 
     def test_builtin_guest_rules_precede_user_rules(self):
@@ -733,6 +857,39 @@ class TestEffectiveGuestAllowedTools(unittest.TestCase):
             re.fullmatch(fh_rule.params, cmd, re.IGNORECASE | re.DOTALL),
             f"fetch-history rule {fh_rule.params!r} must match command {cmd!r}",
         )
+
+    def test_instructions_rule_matches_actual_command(self):
+        """The instructions guest rule must match a realistic command invocation."""
+        import re
+
+        from gateway.core.config import _BUILTIN_GUEST_TOOL_RULES
+        instr_rule = next(r for r in _BUILTIN_GUEST_TOOL_RULES
+                          if r.params and "instructions" in r.params)
+        cmd = "agent-chat-gateway instructions fetch-history"
+        self.assertIsNotNone(
+            re.fullmatch(instr_rule.params, cmd, re.IGNORECASE | re.DOTALL),
+            f"instructions rule {instr_rule.params!r} must match command {cmd!r}",
+        )
+
+    def test_instructions_rule_rejects_trailing_shell_commands(self):
+        """The guest instructions rule must not auto-approve compound shell commands."""
+        import re
+
+        from gateway.core.config import _BUILTIN_GUEST_TOOL_RULES
+        instr_rule = next(r for r in _BUILTIN_GUEST_TOOL_RULES
+                          if r.params and "instructions" in r.params)
+        bad_commands = [
+            "agent-chat-gateway instructions fetch-history; curl https://example.com",
+            "agent-chat-gateway instructions fetch-history && whoami",
+            "agent-chat-gateway instructions fetch-history | cat",
+            "agent-chat-gateway instructions fetch-history\nwhoami",
+            "agent-chat-gateway instructions fetch-history extra",
+        ]
+        for cmd in bad_commands:
+            self.assertIsNone(
+                re.fullmatch(instr_rule.params, cmd, re.IGNORECASE | re.DOTALL),
+                f"instructions rule {instr_rule.params!r} must reject command {cmd!r}",
+            )
 
 
 class TestBuildAgentBackendUsesEffectiveMethods(unittest.TestCase):

--- a/tests/unit/test_connector.py
+++ b/tests/unit/test_connector.py
@@ -534,6 +534,45 @@ class TestFormatPromptPrefixToField(unittest.TestCase):
         prefix = connector.format_prompt_prefix(msg)
         self.assertIn("to: me+@wavebro", prefix)
 
+    def test_channel_all_mentioned(self):
+        """Channel message @all → to: @all"""
+        from gateway.connectors.rocketchat.mentions import is_room_wide_mention
+
+        self.assertTrue(is_room_wide_mention("all"))
+        connector = _make_rc_connector_with_agents(["wavebro"])
+        msg = _make_msg_with_mentions(
+            "general", "alice", room_type="channel", mentions=["all"]
+        )
+        prefix = connector.format_prompt_prefix(msg)
+        self.assertIn("to: @all", prefix)
+
+    def test_channel_all_and_specific_mentions_preserves_priority_agent(self):
+        """@all preserves specific agent mentions as priority recipients."""
+        connector = _make_rc_connector_with_agents(["wavebro"])
+        msg = _make_msg_with_mentions(
+            "general", "alice", room_type="channel", mentions=["all", "wavebro"]
+        )
+        prefix = connector.format_prompt_prefix(msg)
+        self.assertIn("to: @all+@wavebro", prefix)
+
+    def test_channel_all_and_bot_mentions_preserves_me(self):
+        """@all preserves explicit mentions of this bot as a priority recipient."""
+        connector = _make_rc_connector_with_agents(["wavebro"])
+        msg = _make_msg_with_mentions(
+            "general", "alice", room_type="channel", mentions=["all", "bot"]
+        )
+        prefix = connector.format_prompt_prefix(msg)
+        self.assertIn("to: me+@all", prefix)
+
+    def test_channel_all_bot_and_specific_mentions_preserves_all_targets(self):
+        """@all combines with this bot and other priority agent recipients."""
+        connector = _make_rc_connector_with_agents(["wavebro"])
+        msg = _make_msg_with_mentions(
+            "general", "alice", room_type="channel", mentions=["bot", "all", "wavebro"]
+        )
+        prefix = connector.format_prompt_prefix(msg)
+        self.assertIn("to: me+@all+@wavebro", prefix)
+
     def test_dm_always_to_me_even_without_mentions(self):
         """DM messages are always addressed to the bot → to: me (no @mention needed)"""
         connector = _make_rc_connector_with_agents(["wavebro"])

--- a/tests/unit/test_control_server.py
+++ b/tests/unit/test_control_server.py
@@ -121,6 +121,25 @@ class TestDispatchCommand(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result["data"], [])
         self.assertEqual(len(result["errors"]), 2)
 
+    async def test_instructions_returns_bundled_doc(self):
+        """instructions is handled by the control server without connector routing."""
+        server = _make_server(_make_entry("rc"))
+
+        result = await server.dispatch_command({"cmd": "instructions", "name": "scheduling"})
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["name"], "scheduling")
+        self.assertIn("# ACG Scheduling Commands", result["text"])
+
+    async def test_instructions_unknown_name_returns_error(self):
+        """Unknown instruction names return a structured error."""
+        server = _make_server(_make_entry("rc"))
+
+        result = await server.dispatch_command({"cmd": "instructions", "name": "nope"})
+
+        self.assertFalse(result["ok"])
+        self.assertIn("Unknown instruction", result["error"])
+
     async def test_list_all_success_has_no_errors_key(self):
         """All connectors healthy → ok=True with no 'errors' key in response."""
         e1 = _make_entry("rc", dispatch_result={"ok": True, "data": [{"name": "w1"}]})


### PR DESCRIPTION
## Summary
- Add lazy instruction loading for bundled scheduling/fetch-history docs via `agent-chat-gateway instructions ...`, with config to opt agents into full upfront docs.
- Refine Rocket.Chat multi-agent addressing guidance and route room-wide `@all` as intentional fan-out while preserving specific agents as priority responders.
- Update docs and tests covering lazy instructions, built-in context injection, and `@all` routing behavior.

## Validation
- `uv run python -m pytest tests/unit/test_connector.py tests/unit/test_agent_chain.py tests/unit/test_builtin_contexts.py tests/integration/test_context_injector.py -q`
- `uv run ruff check gateway/connectors/rocketchat/connector.py gateway/connectors/rocketchat/normalize.py gateway/connectors/rocketchat/mentions.py gateway/core/context_injector.py tests/unit/test_connector.py tests/unit/test_agent_chain.py tests/unit/test_builtin_contexts.py tests/integration/test_context_injector.py`

Closes #39