### PR TITLE
docs: bring remaining docs up to date with the Mattermost connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Mattermost connector** — a second full chat platform connector (REST v4 +
+  WebSocket), alongside Rocket.Chat, with dual auth (Bot Token or
+  username/password), RBAC role/mention filtering, threaded replies,
+  attachments, reconnect history replay, and shared multi-agent agent-chain
+  loop protection (#59). Onboarding CLI wizard support and an E2E docker test
+  harness are deferred to a follow-up.
 - **`day:` field in the Rocket.Chat message header** — the gateway now
   precomputes the weekday (e.g. `day: Sun`) alongside `ts:` so agents don't
   have to infer it from a bare date, which was unreliable and could cause

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,8 @@ gateway/
 │
 ├── connectors/
 │   ├── __init__.py     # connector_factory() — register new connectors here
-│   └── rocketchat/     # reference connector implementation
+│   ├── rocketchat/     # reference connector implementation (DDP WebSocket + REST)
+│   └── mattermost/     # second reference implementation (REST v4 + WebSocket, no per-channel subscribe)
 │
 └── agents/
     ├── claude/         # ClaudeBackend
@@ -134,7 +135,11 @@ class MyPlatformConnector(Connector):
 ```
 
 See `gateway/core/connector.py` for the full interface and docstrings, and
-`gateway/connectors/rocketchat/` as a reference implementation.
+`gateway/connectors/rocketchat/` or `gateway/connectors/mattermost/` as reference
+implementations — the two differ structurally (RC uses DDP WebSocket subscriptions
+per room; Mattermost's WebSocket streams every channel the bot belongs to with no
+per-channel subscribe), which is useful to compare when deciding how your own
+platform's transport model should map onto the `Connector` ABC.
 
 ### 3. Register in the factory
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,11 +67,19 @@ Run ACG as a container — no Python, Node.js, or Claude Code required on the ho
 
 2. **Fill in `.env`** — Claude Code OAuth token (see the file for instructions on how to obtain it)
 
-3. **Fill in `config/.env`** — Rocket.Chat credentials:
+3. **Fill in `config/.env`** — chat platform credentials. Rocket.Chat:
    ```
    RC_URL=https://your-rocketchat.example.com
    RC_USERNAME=bot
    RC_PASSWORD=yourpassword
+   ```
+   Mattermost (no `.env` convention is generated for you — the Docker example ships
+   with Rocket.Chat only; add your own vars here and reference them from
+   `config/config.yaml`'s `server:` block, e.g. `MM_URL`, `MM_TEAM`, `MM_BOT_TOKEN`):
+   ```
+   MM_URL=https://your-mattermost.example.com
+   MM_TEAM=yourteam
+   MM_BOT_TOKEN=yourbotaccesstoken
    ```
 
 4. **Edit `config/config.yaml`** — set your owners, watcher rooms, and agent config.
@@ -91,7 +99,7 @@ Run ACG as a container — no Python, Node.js, or Claude Code required on the ho
 
 | Host path | Container path | Purpose |
 |-----------|---------------|---------|
-| `./config/` | `~/.agent-chat-gateway/config/` | `config.yaml` + `.env` (RC credentials) |
+| `./config/` | `~/.agent-chat-gateway/config/` | `config.yaml` + `.env` (chat platform credentials) |
 | `./agents/` | `~/.agent-chat-gateway/work/` | Agent working directories |
 | `./contexts/` | `~/.agent-chat-gateway/contexts/` | Context files injected into agent sessions |
 
@@ -146,10 +154,18 @@ The `onboard` wizard creates three files in `~/.agent-chat-gateway/`:
 
 **Never put passwords directly in `config.yaml`.** Use the `$RC_PASSWORD` env var reference — it is expanded automatically from `.env` at startup.
 
+**Mattermost:** the `onboard` wizard only walks through Rocket.Chat setup today — it does not
+yet generate a Mattermost `connectors:` block. To add a Mattermost connector, run the wizard
+for your first (Rocket.Chat) connector as usual, then hand-edit `config.yaml` to add a second
+connector with `type: mattermost` — see the [Connectors](user-guide.md#connectors) section of
+the user guide for the full field reference and a worked example (including the
+`server.team`/`server.token` fields Mattermost needs that Rocket.Chat doesn't).
+
 ### Watcher room formats
 
-- `@username` — direct message room with that user
+- `@username` — direct message room with that user (both platforms)
 - `roomname` — a Rocket.Chat channel or private group
+- `channelname` — a Mattermost channel within the connector's configured `server.team`
 
 ---
 
@@ -198,7 +214,8 @@ tail -50 ~/.agent-chat-gateway/gateway.log
 Common causes:
 - Invalid config YAML — run `python3 -c "import yaml; yaml.safe_load(open('$HOME/.agent-chat-gateway/config.yaml'))"` to validate
 - Wrong Rocket.Chat credentials — verify RC_URL, RC_USERNAME, RC_PASSWORD in `~/.agent-chat-gateway/.env`
-- Bot account not added to the watched room in Rocket.Chat
+- Wrong Mattermost credentials — verify `server.url`/`server.team`/`server.token` (or `username`/`password`) in `config.yaml`
+- Bot account not added to the watched room in Rocket.Chat, or not a member of the configured `server.team` in Mattermost
 
 ### Permission denied errors
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cd my-acg
 
 # 2. Fill in your credentials and settings
 #    .env          — Claude Code OAuth token (see file for instructions)
-#    config/.env   — Rocket.Chat URL, username, password
+#    config/.env   — chat platform credentials (Rocket.Chat URL/username/password, or Mattermost URL/team/token)
 #    config/config.yaml — owners, rooms, agents
 
 # 3. Start

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,6 +116,12 @@ graph TD
 | **connectors/rocketchat/normalize.py** | RC DDP doc → IncomingMessage (dedup, attachment download) | `normalize_rc_message()` |
 | **connectors/rocketchat/outbound.py** | RC outbound helpers (send_text, typing, online) | `send_message()`, `notify_typing()` |
 | **connectors/rocketchat/policy.py** | RC message filtering policy (bot, edits, threads) | `should_process_message()` |
+| **connectors/mattermost/connector.py** | MattermostConnector: all Mattermost-specific logic | `MattermostConnector` |
+| **connectors/mattermost/websocket.py** | Mattermost Realtime WebSocket client (no per-channel subscribe — one stream covers every channel the bot is in) | `MattermostWebSocketClient` |
+| **connectors/mattermost/rest.py** | Mattermost REST v4 client (dual auth, post, upload, history) | `MattermostREST` |
+| **connectors/mattermost/normalize.py** | Mattermost post → IncomingMessage (mention/dedup filtering, attachment download) | `filter_mm_message()`, `normalize_mm_message()` |
+| **connectors/mattermost/outbound.py** | Mattermost outbound helpers (chunked send, media upload) | `send_text()`, `send_media()` |
+| **connectors/mattermost/policy.py** | Re-export of the shared `apply_thread_policy()` (see `core/thread_policy.py`) | `apply_thread_policy` |
 | **connectors/script/connector.py** | ScriptConnector: in-memory connector for tests/scripting | `ScriptConnector` |
 
 ---
@@ -744,13 +750,23 @@ class DiscordConnector(Connector):
         return f"[Discord #{msg.room.name} | from: {msg.sender.username} | role: {msg.role.value}]"
 ```
 
-Register in `service.py`:
+Register in `gateway/connectors/__init__.py`'s `connector_factory()` (imported and called from `service.py`, but the factory itself lives here). It currently has four branches (`rocketchat`, `script`, `voice`, `mattermost`) — add a fifth:
 
 ```python
-def connector_factory(cfg: ConnectorConfig) -> Connector:
-    if cfg.type == "discord":
-        return DiscordConnector(config=cfg.discord)
-    ...
+def connector_factory(cc: ConnectorConfig) -> Connector:
+    if cc.type == "rocketchat":
+        ...
+    if cc.type == "script":
+        ...
+    if cc.type == "voice":
+        ...
+    if cc.type == "mattermost":
+        ...
+    if cc.type == "discord":
+        from .discord import DiscordConnector
+        from .discord.config import DiscordConfig
+        return DiscordConnector(DiscordConfig.from_connector_config(cc))
+    raise ValueError(f"Unknown connector type: {cc.type!r}")
 ```
 
 Add to `config.yaml`:

--- a/docs/install-agent.md
+++ b/docs/install-agent.md
@@ -13,9 +13,9 @@ Before starting, ensure you have:
 - **Claude CLI** or **OpenCode CLI** installed and authenticated
   - Claude CLI: https://claude.ai/download
   - OpenCode CLI: https://opencode.ai
-- **Rocket.Chat server** with a dedicated bot account
-  - You'll need bot username and password
-  - You'll need Rocket.Chat admin or room owner access to add the bot to rooms
+- **A chat server with a dedicated bot account** — either works, pick one:
+  - **Rocket.Chat**: bot username + password, and admin or room-owner access to add the bot to rooms
+  - **Mattermost**: a Bot Account access token (or a regular account's username + password), and the bot account must be a member of the team your channels live in
 - **Basic familiarity** with YAML and the command line
 
 ---
@@ -51,7 +51,12 @@ You should see the available commands: `start`, `stop`, `status`, `list`, `pause
 
 ---
 
-## Step 2: Create a Bot Account in Rocket.Chat
+## Step 2: Create a Bot Account
+
+**Ask the user which chat platform they're connecting** (Rocket.Chat or Mattermost) before
+proceeding — the rest of this step and Step 3 branch on that choice.
+
+### Option A: Rocket.Chat
 
 1. Log in to your Rocket.Chat server as an administrator
 2. Click the avatar menu → **Administration** → **Users**
@@ -66,6 +71,15 @@ You should see the available commands: `start`, `stop`, `status`, `list`, `pause
 7. Click **Save User**
 8. Add the bot to at least one room or DM (you can do this later)
 
+### Option B: Mattermost
+
+1. Create the bot account — either works:
+   - **Bot Account** (recommended): System Console → Integrations → Bot Accounts → **Add Bot Account**, or via CLI: `mmctl --local bot create --username agent-bot --display-name "Agent Bot"`. This issues an access token directly — **keep it handy; you'll need it**, it's shown only once.
+   - **Regular account + username/password**: create (or reuse) a normal Mattermost user account instead, if you'd rather authenticate with credentials than a token.
+2. **Add the bot to the team** your channels live in — this is required and easy to miss (Mattermost channels are team-scoped, unlike Rocket.Chat rooms): `mmctl --local team add <team-name> <bot-username>`, or via System Console.
+3. Add the bot to at least one channel (you can do this later)
+4. **Keep handy:** the bot's access token (or username/password), and the **team name** (the URL slug, not the display name) — you'll need both in Step 3.
+
 ---
 
 ## Step 3: Create the Configuration
@@ -77,7 +91,9 @@ mkdir -p ~/.agent-chat-gateway
 
 ### Create `.env` file
 
-Store sensitive credentials:
+Store sensitive credentials — use whichever block matches the platform chosen in Step 2.
+
+**Rocket.Chat:**
 ```bash
 cat > ~/.agent-chat-gateway/.env << 'EOF'
 RC_URL=https://your-rocket-chat-server.com
@@ -86,11 +102,23 @@ RC_PASSWORD=your-bot-password
 EOF
 chmod 600 ~/.agent-chat-gateway/.env
 ```
-
 Replace the values with your Rocket.Chat server URL and bot credentials.
+
+**Mattermost** (bot-token auth — the recommended path from Step 2's Option B; if using
+username/password instead, store `MM_USERNAME`/`MM_PASSWORD` in place of `MM_BOT_TOKEN`):
+```bash
+cat > ~/.agent-chat-gateway/.env << 'EOF'
+MM_URL=https://your-mattermost-server.com
+MM_TEAM=your-team-name
+MM_BOT_TOKEN=your-bot-access-token
+EOF
+chmod 600 ~/.agent-chat-gateway/.env
+```
+Replace the values with your Mattermost server URL, team name (the URL slug), and bot token.
 
 ### Create `config.yaml` file
 
+**Rocket.Chat:**
 ```bash
 cat > ~/.agent-chat-gateway/config.yaml << 'EOF'
 connectors:
@@ -109,8 +137,8 @@ connectors:
       download_timeout: 30
     reply_in_thread: false
     permission_reply_in_thread: true    # post approval requests inside a thread
-    context_inject_files:
-      - contexts/rc-gateway-context.md  # injected once per session: RC format, RBAC rules
+    # No context_inject_files needed here — the RC-specific gateway context
+    # (message format, RBAC rules, how to send files) is injected automatically.
 
 agents:
   my-agent:
@@ -167,18 +195,100 @@ watchers:
 EOF
 ```
 
+**Mattermost** (same `agents:`/`watchers:` shape — only the `connectors:` block and the
+watcher's `connector:`/`room:` values differ from the Rocket.Chat example above):
+```bash
+cat > ~/.agent-chat-gateway/config.yaml << 'EOF'
+connectors:
+  - name: mm-home
+    type: mattermost
+    server:
+      url: $MM_URL
+      team: $MM_TEAM
+      token: $MM_BOT_TOKEN
+      # username: $MM_USERNAME       # use this + password instead of token, not both
+      # password: $MM_PASSWORD
+    allowed_users:
+      owners:
+        - your-username
+      guests: []
+    attachments:
+      max_file_size_mb: 10
+      download_timeout: 30
+    reply_in_thread: false
+    permission_reply_in_thread: true    # post approval requests inside a thread
+    # No context_inject_files needed here — the Mattermost-specific gateway context
+    # (message format, RBAC rules, how to send files) is injected automatically.
+
+agents:
+  my-agent:
+    type: claude
+    command: claude
+    working_directory: ~/.agent-chat-gateway/work
+    new_session_args: []                # extra CLI flags passed when creating a new session
+    session_prefix: "agent-chat"
+    context_inject_files: []            # agent-level extra context (usually empty)
+
+    # ── Tool allow-lists ───────────────────────────────────────────────────
+    # Tools matched here are auto-approved for that role — no chat notification.
+    # Anything NOT matched triggers the human-in-the-loop approval flow.
+    # Each entry: tool (regex on tool name) + optional params (regex on primary param).
+    owner_allowed_tools:
+      - tool: "Read"
+      - tool: "Glob"
+      - tool: "Grep"
+      - tool: "WebSearch"
+      - tool: "WebFetch"
+        params: "https?://(www\\.)?github\\.com/.*"
+      - tool: "WebFetch"
+        params: "https?://[^/]*\\.wikipedia\\.org/.*"
+      - tool: "Bash"
+        params: "git (log|diff|status|show)( .*)?"   # read-only git
+      - tool: "Bash"
+        params: "ls( .*)?"
+      - tool: "Bash"
+        params: "agent-chat-gateway\\s+send\\s+.*"   # agent-initiated file send to chat
+
+    guest_allowed_tools:
+      - tool: "Read"
+      - tool: "Glob"
+      - tool: "Grep"
+      - tool: "WebFetch"
+        params: "https?://[^/]*\\.wikipedia\\.org/.*"
+      - tool: "Bash"
+        params: "agent-chat-gateway\\s+send\\s+.*"
+
+    timeout: 360
+    permissions:
+      enabled: true
+      timeout: 300
+
+watchers:
+  - name: dm-me
+    connector: mm-home
+    room: "@your-username"
+    agent: my-agent
+    session_id: null
+    context_inject_files: []            # watcher-level extra context (usually empty)
+    online_notification: "✅ _Agent online_"
+    offline_notification: "❌ _Agent offline_"
+EOF
+```
+
 **Replace:**
-- `your-username` — your Rocket.Chat username (the one who will own the bot)
-- `your-rocket-chat-server.com` — your Rocket.Chat server URL
+- `your-username` — your username on the chosen chat platform (the one who will own the bot)
+- `your-rocket-chat-server.com` / `your-mattermost-server.com` — your server URL
+- `your-team-name` (Mattermost only) — the team's URL slug (not its display name) that your channels live in
 - `~/.agent-chat-gateway/work` — **the project folder where Claude Code or OpenCode will run tasks and create files**. Default to the current project directory (`pwd`); ask the user to confirm or change it before proceeding.
 - If using OpenCode instead of Claude, change `type: claude` and `command: claude` to `type: opencode` and `command: opencode`
 
-> **About `context_inject_files`:** The file `contexts/rc-gateway-context.md` is copied to
-> `~/.agent-chat-gateway/contexts/` by the installer. It tells the agent about the RC message
-> format, RBAC rules, and how to send files. Paths are resolved relative to `~/.agent-chat-gateway/`.
+> **About context injection:** The built-in gateway context (message format, RBAC rules,
+> how to send files — `rc-gateway-context.md` or `mm-gateway-context.md`, matched
+> automatically to the connector's `type`) is injected on every session with no config
+> needed. `context_inject_files` is only for your own additional context, if any.
 
 > **About `owner_allowed_tools`:** Any tool call not matched by these rules triggers a
-> human-in-the-loop approval notification in RC. Adjust the list to match your security needs —
+> human-in-the-loop approval notification in chat. Adjust the list to match your security needs —
 > the example above allows common read-only tools and safe bash commands. See
 > `config.example.yaml` for more patterns and documentation.
 
@@ -232,7 +342,7 @@ dm-me: (rc-home) @your-username [my-agent] session=agent-chat-xxxx [active]
 
 ## Step 6: Send a Test Message
 
-1. Open Rocket.Chat and go to your direct message with the bot (or the configured room)
+1. Open your chat platform and go to your direct message with the bot (or the configured room/channel)
 2. Send a message (e.g., "Hello, what can you do?")
 3. The agent should respond in a few seconds
 4. If you don't see a response, check the logs: `tail -f ~/.agent-chat-gateway/gateway.log`
@@ -241,14 +351,16 @@ dm-me: (rc-home) @your-username [my-agent] session=agent-chat-xxxx [active]
 
 ## Step 7: Add More Watchers (Optional)
 
-To monitor additional rooms:
+To monitor additional rooms/channels:
 
-1. Add the bot to the room in Rocket.Chat
-2. Edit `~/.agent-chat-gateway/config.yaml` and add a new watcher entry:
+1. Add the bot to the room (Rocket.Chat) or channel (Mattermost — must also already be a
+   team member, see Step 2)
+2. Edit `~/.agent-chat-gateway/config.yaml` and add a new watcher entry, pointing `connector:`
+   at whichever connector name you created in Step 3 (`rc-home` or `mm-home`):
    ```yaml
    - name: dev-room
-     connector: rc-home
-     room: "#dev"
+     connector: rc-home   # or mm-home
+     room: "dev"           # bare channel name, no leading "#", on either platform
      agent: my-agent
      session_id: null
    ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -4,7 +4,7 @@
 
 Inspired by [OpenClaw](https://github.com/openclaw/openclaw)'s vision of making AI agents accessible from any messaging app, `agent-chat-gateway` bridges your existing AI agent tools — Claude CLI, OpenCode, or any custom backend — to your team's chat platform. When someone messages the bot in a watched room, the message is forwarded to the configured agent and the response is posted back.
 
-Think of it as a persistent bridge: set up once, configure which rooms to watch, and your AI assistant becomes available across your entire Rocket.Chat workspace — with full support for role-based access control, human-in-the-loop permission approvals, and file attachments.
+Think of it as a persistent bridge: set up once, configure which rooms to watch, and your AI assistant becomes available across your entire chat workspace (Rocket.Chat or Mattermost — mix both if you use more than one) — with full support for role-based access control, human-in-the-loop permission approvals, and file attachments.
 
 > **How it compares to Claude Code Channels:** Claude Code's native [Channels](https://code.claude.com/docs/en/channels) feature (v2.1.80+) lets a single Claude Code session receive messages from Telegram, Discord, or iMessage — a great fit for personal use. `agent-chat-gateway` was developed independently before Channels shipped and targets a different layer: team deployments with multiple agent backends (not just Claude Code), Owner/Guest roles with per-tool allow-lists, and a shared workspace where multiple people can interact with the same or different agents across multiple rooms simultaneously.
 
@@ -12,7 +12,7 @@ Think of it as a persistent bridge: set up once, configure which rooms to watch,
 
 | Term | Meaning |
 |--|--|
-| **Connector** | Adapter for a chat platform (e.g., Rocket.Chat). Handles incoming messages and posts replies back. |
+| **Connector** | Adapter for a chat platform (Rocket.Chat, Mattermost). Handles incoming messages and posts replies back. |
 | **Agent backend** | The AI tool being dispatched to (e.g., Claude CLI subprocess, OpenCode subprocess). |
 | **Watcher** | A binding between one chat room and one agent backend. One watcher per room. |
 
@@ -23,11 +23,13 @@ Think of it as a persistent bridge: set up once, configure which rooms to watch,
 Before installing, ensure you have:
 
 - **Python 3.12 or later** — verify with `python3 --version`
-- **Rocket.Chat server access** — your workspace URL and bot account credentials
+- **A chat server** — Rocket.Chat or Mattermost, with your workspace/team URL
 - **Claude CLI or OpenCode installed** — at least one agent backend available
   - Claude CLI: https://claude.ai/download
   - OpenCode: https://github.com/anthropics/opencode
-- **A Rocket.Chat bot account** — with permissions to post messages and read room history
+- **A bot account on your chat server** — with permissions to post messages and read room history
+  - Rocket.Chat: a bot user account (username + password)
+  - Mattermost: a Bot Account access token, or a regular account's username + password — see [Connectors](#connectors) below
 - **At least one owner username** — someone who can approve/deny tool calls in chat
 
 ---
@@ -236,7 +238,7 @@ watchers:
 - Set `permissions.enabled: false` for personal use where approval friction isn't needed
 - Set yourself as the sole owner; omit `guests` entirely
 
-> **Similar to Claude Code Channels:** Claude Code's [Channels](https://code.claude.com/docs/en/channels) feature (v2.1.80+) also connects external platforms (Telegram, Discord, iMessage) to a local Claude Code session via `claude --channels`. The key differences: Channels is Claude Code-specific and single-user focused, while `agent-chat-gateway` supports any agent backend (Claude CLI, OpenCode, custom), multi-user RBAC, and is designed for team-shared Rocket.Chat workspaces. If you only use Claude Code and only need personal access, Channels may be simpler to set up; if you need team access or a different agent backend, `agent-chat-gateway` is the better fit.
+> **Similar to Claude Code Channels:** Claude Code's [Channels](https://code.claude.com/docs/en/channels) feature (v2.1.80+) also connects external platforms (Telegram, Discord, iMessage) to a local Claude Code session via `claude --channels`. The key differences: Channels is Claude Code-specific and single-user focused, while `agent-chat-gateway` supports any agent backend (Claude CLI, OpenCode, custom), multi-user RBAC, and is designed for team-shared chat workspaces (Rocket.Chat or Mattermost). If you only use Claude Code and only need personal access, Channels may be simpler to set up; if you need team access or a different agent backend, `agent-chat-gateway` is the better fit.
 
 ---
 
@@ -324,12 +326,14 @@ agent-chat-gateway start
 
 ### Connectors
 
-Each connector represents a connection to one chat platform (currently only Rocket.Chat is supported).
+Each connector represents a connection to one chat platform. Rocket.Chat and Mattermost
+are both fully supported today; a daemon can run one, the other, or both at once (see
+[Multi-Connector Setup](#multi-connector-setup)).
 
 ```yaml
 connectors:
   - name: rc-main                    # Unique identifier
-    type: rocketchat                 # Only type currently supported
+    type: rocketchat
     server:
       url: "https://chat.example.com"
       username: "bot-username"
@@ -347,17 +351,43 @@ connectors:
     reply_in_thread: false            # Start new thread for replies
     permission_reply_in_thread: true  # Post permission requests in thread
     context_inject_files: []          # Files sent to agent on session start
+
+  - name: mm-main                     # A second connector — Mattermost, in this case
+    type: mattermost
+    server:
+      url: "https://chat.example.com"
+      team: myteam                    # Mattermost channels are team-scoped; one connector = one team
+      token: "${MM_BOT_TOKEN}"        # Bot Account / Personal Access Token — OR username+password below, not both
+      # username: "bot-username"
+      # password: "${MM_PASSWORD}"
+    allowed_users:
+      owners:
+        - alice
+      guests:
+        - charlie
+    attachments:
+      max_file_size_mb: 50
+      download_timeout: 30
+      cache_dir_global: ~/.agent-chat-gateway/attachments
+    reply_in_thread: false
+    permission_reply_in_thread: true
+    context_inject_files: []
 ```
+
+> Mattermost has no onboarding CLI wizard support yet — this block must be hand-written
+> (unlike Rocket.Chat, which `agent-chat-gateway onboard` can generate for you).
 
 **Connector Fields:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | Yes | Unique connector identifier (used in CLI commands and watcher references) |
-| `type` | string | Yes | Platform type; currently only `rocketchat` |
-| `server.url` | string | Yes | Rocket.Chat server URL (e.g., `https://chat.example.com`) |
-| `server.username` | string | Yes | Bot account username |
-| `server.password` | string | Yes | Bot account password (use `${VAR}` for env expansion) |
+| `type` | string | Yes | Platform type: `rocketchat` or `mattermost` |
+| `server.url` | string | Yes | Chat server URL (e.g., `https://chat.example.com`) |
+| `server.username` | string | Yes (RC); one of username/password or token (Mattermost) | Bot account username |
+| `server.password` | string | Yes (RC); one of username/password or token (Mattermost) | Bot account password (use `${VAR}` for env expansion) |
+| `server.team` | string | Yes (Mattermost only) | Team name the bot's channels belong to — Mattermost channels are team-scoped, unlike Rocket.Chat |
+| `server.token` | string | One of token or username/password (Mattermost only) | Bot Account / Personal Access Token — used directly, no login call, no expiry handling needed |
 | `allowed_users.owners` | list | No | Usernames with full tool access |
 | `allowed_users.guests` | list | No | Usernames with restricted tool access |
 | `attachments.max_file_size_mb` | integer | No | Maximum file size; 0 = unlimited |
@@ -420,7 +450,7 @@ agents:
 
 ### Watchers
 
-Each watcher binds a Rocket.Chat room to an AI agent backend.
+Each watcher binds one chat room/channel (on whichever connector it names) to an AI agent backend.
 
 ```yaml
 watchers:
@@ -440,7 +470,7 @@ watchers:
 |-------|------|----------|-------------|
 | `name` | string | Yes | Unique watcher identifier (used in CLI commands) |
 | `connector` | string | Yes | Must match a connector name above |
-| `room` | string | Yes | Rocket.Chat room name or `@username` for DMs |
+| `room` | string | Yes | Room/channel name (as known to the `connector` named above) or `@username` for DMs |
 | `agent` | string | No | Agent backend to use; falls back to `default_agent` if omitted |
 | `session_id` | string | No | Optional sticky session ID (e.g., `ses_abc123`); `null` = auto-create |
 | `context_inject_files` | list | No | Watcher-specific context files |
@@ -604,10 +634,18 @@ agent-chat-gateway upgrade
 
 ### How It Works
 
-Every message sent to the agent is prefixed with a trusted header:
+Every message sent to the agent is prefixed with a trusted header. The exact format is
+connector-specific (see `CLAUDE.md`'s connector prefix-format table for the authoritative
+list) — Rocket.Chat's looks like:
 
 ```
 [Rocket.Chat #<room> | from: <username> | role: owner|guest]  <message text>
+```
+
+and Mattermost's like:
+
+```
+[Mattermost #<channel> | from: <username> | role: owner|guest]  <message text>
 ```
 
 The agent uses this header to determine:
@@ -619,7 +657,8 @@ The agent uses this header to determine:
 
 ## User-Aware Responses
 
-Every message the gateway forwards to the agent is prefixed with a trusted header:
+Every message the gateway forwards to the agent is prefixed with a trusted header
+(format varies slightly by connector — see above):
 
 ```
 [Rocket.Chat #general | from: alice | role: owner]  Hey, can you review this PR?
@@ -645,10 +684,10 @@ Create a file like `contexts/rc-room-profiles.md` (you can copy the template fro
 [`contexts/rc-room-profiles.example.md`](../contexts/rc-room-profiles.example.md)):
 
 ```markdown
-## Rocket.Chat Room Profiles
+## Chat Room Profiles
 
 **IMPORTANT — scope:** The profiles below apply **only** when interacting via the
-Rocket.Chat gateway (i.e., when the `[Rocket.Chat #<room> | from: <username> | role: ...]`
+gateway (i.e., when a trusted `[Rocket.Chat #<room> | ...]` or `[Mattermost #<channel> | ...]`
 message prefix is present). Do NOT apply these profiles during CLI/terminal sessions.
 
 Cross-reference the `from: <username>` field in the message prefix with the profiles
@@ -730,14 +769,16 @@ When `permissions.enabled: true` and a user attempts a tool call not in their al
 
 ### Responding to Permission Requests
 
-In the Rocket.Chat chat room, type directly (no slash prefix):
+In the chat room, type directly (no slash prefix):
 
 ```
 approve a3k9    ← Allow the tool call to proceed
 deny a3k9       ← Block the tool call
 ```
 
-**Important:** These are NOT slash commands. If you type `/approve`, Rocket.Chat's client will intercept it before reaching the gateway.
+**Important:** These are NOT slash commands. If you type `/approve`, the chat client itself
+(Rocket.Chat or Mattermost — both reserve the `/` prefix for their own built-in commands)
+will intercept it before it ever reaches the gateway.
 
 ### Error Messages
 
@@ -782,9 +823,10 @@ Only use this in trusted, sandboxed environments where interactive approval is n
 Context files are injected into the agent session to provide domain knowledge, system prompts, or other guidance. Three levels of context are supported:
 
 ACG also injects built-in gateway context automatically. You do **not** need to list
-`gateway/contexts/rc-gateway-context.md` or other bundled context files in your config.
-The built-in Rocket.Chat context teaches agents how to read trusted message headers,
-roles, `to:` addressing, injection-protection rules, and gateway commands.
+`gateway/contexts/rc-gateway-context.md`, `gateway/contexts/mm-gateway-context.md`, or
+other bundled context files in your config — the right one is chosen automatically based
+on the connector's `type`. The built-in context teaches agents how to read trusted
+message headers, roles, `to:` addressing, injection-protection rules, and gateway commands.
 
 ### Three-Level Injection
 
@@ -885,7 +927,7 @@ watchers:
       - contexts/rc-room-profiles.md     # Room member profiles — specific to this room
 ```
 
-The built-in Rocket.Chat context sets up baseline gateway behavior automatically:
+The built-in gateway context (matched to the watcher's connector type) sets up baseline gateway behavior automatically:
 response length, message format parsing, `to:` addressing, injection protection, and
 guest access rules. Use your own context files only for custom behavior such as room
 member profiles, project knowledge, or team-specific tone.
@@ -901,7 +943,7 @@ If context files exceed the limit, the gateway will log a warning and skip the l
 
 ## Attachment Handling
 
-When users upload files to Rocket.Chat, the gateway automatically downloads them and injects them into the agent prompt.
+When users upload files (on Rocket.Chat or Mattermost), the gateway automatically downloads them and injects them into the agent prompt.
 
 ### Configuration
 
@@ -918,7 +960,7 @@ connectors:
 
 1. **User uploads file** to a watched room
 2. **Gateway detects** attachment in incoming message
-3. **Download file** from Rocket.Chat (respects size limits and timeout)
+3. **Download file** from the chat platform (respects size limits and timeout)
 4. **Cache locally** (prevents repeated downloads)
 5. **Inject path** into agent prompt: `Attachment: /path/to/file`
 
@@ -1013,7 +1055,7 @@ cat ~/.agent-chat-gateway/state.rc-main.json | jq .
 **Solution:**
 1. Check status: `agent-chat-gateway status`
 2. Check logs: `tail -f ~/.agent-chat-gateway/gateway.log`
-3. Verify the bot is in the watched room in Rocket.Chat
+3. Verify the bot account is a member of the watched room/channel (Mattermost also requires the bot to be a member of the `server.team` itself — `mmctl team add <team> <username>`)
 4. Try the CLI: `agent-chat-gateway send <room> "test"` (should post immediately)
 5. Verify agent backend: `claude -p` or `opencode run` (should start a session)
 
@@ -1039,14 +1081,15 @@ cat ~/.agent-chat-gateway/state.rc-main.json | jq .
 
 ### Connection failures
 
-**Symptom:** `ERROR: RC websocket disconnected` in logs, frequent reconnects.
+**Symptom:** `ERROR: RC websocket disconnected` (Rocket.Chat) or a WebSocket reconnect loop
+(Mattermost) in logs, frequent reconnects.
 
 **Solution:**
-1. Verify Rocket.Chat server is reachable: `curl https://chat.example.com/api/version`
-2. Verify bot credentials: `username` and `password` in config
-3. Check bot account has required permissions in Rocket.Chat admin panel
+1. Verify the chat server is reachable: `curl https://chat.example.com/api/version` (Rocket.Chat) or `curl https://chat.example.com/api/v4/system/ping` (Mattermost)
+2. Verify bot credentials: `username`/`password`, or Mattermost's `token`, in config
+3. Check bot account has required permissions (Rocket.Chat admin panel) or team membership (Mattermost — see "Agent not responding" above)
 4. Check network connectivity: `ping chat.example.com`
-5. Review Rocket.Chat server logs for auth failures
+5. Review the chat server's logs for auth failures
 
 ### Files not downloading
 
@@ -1107,6 +1150,10 @@ watchers:
 
 ### Multi-Connector Setup
 
+Connectors are independent — run several instances of the same platform, or mix
+platforms entirely, in one daemon. `connector` names in `watchers` are what tie a
+room/channel to a specific connector instance.
+
 For teams using multiple Rocket.Chat servers or workspaces:
 
 ```yaml
@@ -1139,6 +1186,41 @@ watchers:
   - name: partner-collab
     connector: rc-partner
     room: general
+    agent: claude
+```
+
+Or mix Rocket.Chat and Mattermost in the same daemon — e.g. a team migrating between
+platforms, or with different groups on each:
+
+```yaml
+connectors:
+  - name: rc-main
+    type: rocketchat
+    server:
+      url: https://chat.company.com
+      username: bot
+      password: "${RC_PASSWORD}"
+    allowed_users:
+      owners: [alice]
+
+  - name: mm-main
+    type: mattermost
+    server:
+      url: https://mattermost.company.com
+      team: engineering
+      token: "${MM_BOT_TOKEN}"
+    allowed_users:
+      owners: [bob]
+
+watchers:
+  - name: rc-general
+    connector: rc-main
+    room: general
+    agent: claude
+
+  - name: mm-general
+    connector: mm-main
+    room: town-square
     agent: claude
 ```
 
@@ -1202,7 +1284,7 @@ tail -f ~/.agent-chat-gateway/gateway.log
 
 ## Summary
 
-`agent-chat-gateway` provides a flexible, secure bridge from Rocket.Chat to AI agents. Start with a minimal config, use role-based access control to grant appropriate permissions, and leverage the permission approval system to ensure human oversight of sensitive operations.
+`agent-chat-gateway` provides a flexible, secure bridge from your chat platform (Rocket.Chat or Mattermost) to AI agents. Start with a minimal config, use role-based access control to grant appropriate permissions, and leverage the permission approval system to ensure human oversight of sensitive operations.
 
 For production deployments, carefully review your tool allow-lists, set appropriate timeouts, and monitor your logs for errors and token usage.
 


### PR DESCRIPTION
## Summary
Follow-up to #59 (Mattermost connector). That PR updated CLAUDE.md, docs/supported-features.md, and README.md's feature list, but left every other doc framed as if Rocket.Chat were the only supported platform. Audited all remaining docs (via a fresh agent pass, classifying every Rocket.Chat mention as either a fine illustrative example or a now-stale exclusivity claim) and fixed the real gaps:

- **docs/architecture.md** — the "Adding a New Connector" factory example pointed at the wrong file (`service.py` instead of `gateway/connectors/__init__.py`) and showed a fictional 1-branch factory instead of the real 4-branch one; added `connectors/mattermost/*` rows to the component-reference table.
- **CONTRIBUTING.md** — project structure tree and reference-implementation pointer only mentioned `rocketchat/`.
- **docs/user-guide.md** — removed several "currently only rocketchat is supported" false claims, added a full Mattermost connector config example (dual auth, `team` field), a mixed RC+Mattermost multi-connector example, and genericized RC-only wording in the trusted-header, attachment, approve/deny, and troubleshooting sections.
- **INSTALL.md / docs/install-agent.md** — added a Mattermost bot-account setup path and `config.yaml` example alongside the existing Rocket.Chat one (config.yaml must be hand-written for Mattermost — no onboarding wizard support yet, noted explicitly). Also fixed a pre-existing (RC-affecting too) stale claim that `context_inject_files` needs to manually list the built-in gateway context file — that's been automatic for a while, unrelated to Mattermost but caught in the same pass.
- **README.md** — genericized a leftover Docker setup comment.
- **CHANGELOG.md** — added an `[Unreleased]` entry for the Mattermost connector (missing from #59).

Docs-only change — no code touched. All markdown code-fence counts verified even (no broken formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)