### PR TITLE
feat: compact config.yaml format with defaults/presets/rooms + config validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Compact config.yaml format (v0.2)**: top-level `connector_defaults:` /
+  `agent_defaults:` / `watcher_defaults:` blocks deep-merge into every entry
+  of the matching kind; named `tool_presets:` can be referenced by name from
+  any agent's `owner_allowed_tools`/`guest_allowed_tools`; and watcher
+  `rooms: [a, b, ...]` binds one connector+agent pair to many rooms at once
+  (auto-deriving each expanded watcher's name as `<connector>-<room>`). None
+  of this is required — existing config.yaml files keep working unchanged.
+  See `docs/migration-0.2.md`.
+- **`agent-chat-gateway config validate [--config PATH] [--lint]`** — checks
+  config.yaml without starting the daemon: full structural validation, plus
+  per-connector-type checks (e.g. empty Rocket.Chat/Mattermost credentials)
+  that were previously only caught lazily at daemon start, plus a warning
+  when a connector's persisted `state.<connector>.json` references a watcher
+  name no longer in the config (session about to be dropped). `--lint` flags
+  config values that just restate a built-in default or duplicate an
+  inherited `*_defaults` value.
+- **JSON Schema for config.yaml** (`gateway/schema/config.schema.json`) —
+  `config.example.yaml` references it via a `# yaml-language-server: $schema=`
+  comment for editor autocomplete and inline typo-checking.
 - **Mattermost connector** — a second full chat platform connector (REST v4 +
   WebSocket), alongside Rocket.Chat, with dual auth (Bot Token or
   username/password), RBAC role/mention filtering, threaded replies,
@@ -20,6 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   precomputes the weekday (e.g. `day: Sun`) alongside `ts:` so agents don't
   have to infer it from a bare date, which was unreliable and could cause
   scheduled weekday tasks to be silently skipped (#53).
+
+### Changed
+- **BREAKING: `online_notification`/`offline_notification` default to quiet
+  (`null`) instead of `"✅ _Agent online_"` / `"❌ _Agent offline_"`.** No
+  config error results — watchers that never set these fields explicitly
+  simply stop announcing online/offline after upgrading. Restore the old
+  behavior globally with `watcher_defaults: {online_notification: "✅ _Agent
+  online_", offline_notification: "❌ _Agent offline_"}`. See
+  `docs/migration-0.2.md`.
 
 ### Fixed
 - **Scheduled-task messages now carry a usable `ts:`/`day:` timestamp.**

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -212,7 +212,9 @@ tail -50 ~/.agent-chat-gateway/gateway.log
 ```
 
 Common causes:
-- Invalid config YAML — run `python3 -c "import yaml; yaml.safe_load(open('$HOME/.agent-chat-gateway/config.yaml'))"` to validate
+- Invalid config YAML — run `agent-chat-gateway config validate` to check syntax, cross-references,
+  and per-connector credentials without starting the daemon (add `--lint` to also flag redundant
+  defaults)
 - Wrong Rocket.Chat credentials — verify RC_URL, RC_USERNAME, RC_PASSWORD in `~/.agent-chat-gateway/.env`
 - Wrong Mattermost credentials — verify `server.url`/`server.team`/`server.token` (or `username`/`password`) in `config.yaml`
 - Bot account not added to the watched room in Rocket.Chat, or not a member of the configured `server.team` in Mattermost

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/HammerMei/agent-chat-gateway/main/gateway/schema/config.schema.json
 # agent-chat-gateway — example configuration
 # Copy this file to config.yaml and adjust to your setup.
 #
@@ -5,6 +6,28 @@
 # Use environment variables instead: set them in a .env file next to config.yaml
 # (copy .env.example → .env and fill in your values).
 # Any $VAR or ${VAR} reference in this file is automatically expanded at startup.
+#
+# ── Format notes (v0.2+) ──────────────────────────────────────────────────────
+# This example uses the compact config format: top-level `connector_defaults:` /
+# `agent_defaults:` / `watcher_defaults:` blocks that deep-merge into every entry
+# (the entry always wins on conflict), named `tool_presets:` you can reference by
+# name from any agent's tool allow-lists, and `rooms:` to bind one connector+agent
+# pair to many rooms without repeating the whole entry. None of this is required —
+# a single connector/agent/watcher setup barely needs it — but it keeps larger,
+# multi-bot deployments from becoming hundreds of near-duplicate lines. See
+# docs/migration-0.2.md if you're upgrading an older config.yaml.
+
+# ── Named tool-rule presets (optional) ────────────────────────────────────────
+# Reference a preset by name anywhere a tool-rule list is expected
+# (owner_allowed_tools / guest_allowed_tools). String items = preset names,
+# dict items = inline rules — the two forms can be freely mixed in one list.
+# A preset itself must be a flat list of inline rules (no preset-of-presets).
+tool_presets:
+  readonly-builtins:
+    - tool: "Read"
+    - tool: "Glob"
+    - tool: "Grep"
+    - tool: "WebSearch"
 
 connectors:
   # ── Voice Gateway (Siri / iOS Shortcuts) ─────────────────────────────────
@@ -121,14 +144,17 @@ agents:
     context_inject_files: []         # agent-level context files (layer 2); list, resolved relative to config dir
 
     # ── Tool allow lists ───────────────────────────────────────────────────
-    # Each entry is an object with:
-    #   tool:   (required) regex matched against the tool name
-    #   params: (optional) regex matched against the tool's primary parameter:
-    #             Bash        → tool_input["command"]   (Claude) / patterns[0] (OpenCode)
-    #             WebFetch    → tool_input["url"]        (Claude) / patterns[0] (OpenCode)
-    #             Read/Edit/
-    #             Write       → tool_input["file_path"]  (Claude) / patterns[0] (OpenCode)
-    #             unknown/MCP → full tool_input serialized as JSON (Claude) / patterns[0] (OpenCode)
+    # Each entry is either:
+    #   - a string naming a `tool_presets:` entry defined above (expanded in place), or
+    #   - an inline object with:
+    #       tool:   (required) regex matched against the tool name
+    #       params: (optional) regex matched against the tool's primary parameter:
+    #                 Bash        → tool_input["command"]   (Claude) / patterns[0] (OpenCode)
+    #                 WebFetch    → tool_input["url"]        (Claude) / patterns[0] (OpenCode)
+    #                 Read/Edit/
+    #                 Write       → tool_input["file_path"]  (Claude) / patterns[0] (OpenCode)
+    #                 unknown/MCP → full tool_input serialized as JSON (Claude) / patterns[0] (OpenCode)
+    # The two forms may be freely mixed; list order is preserved.
     #
     # owner_allowed_tools: auto-approved for owners — no RC notification sent.
     #   Anything NOT matched here triggers the human-in-the-loop approval flow.
@@ -144,12 +170,9 @@ agents:
       #   agent-chat-gateway schedule ...  — create/list/delete/pause/resume scheduled jobs
       #   agent-chat-gateway fetch-history ... — read filtered channel history
       #   agent-chat-gateway instructions ...  — read bundled tool instructions
-      #
-      # ── Read-only built-in tools: safe, never need owner approval ──────
-      - tool: "Read"                         # any file read
-      - tool: "Glob"                         # file pattern search
-      - tool: "Grep"                         # content search
-      - tool: "WebSearch"                    # web search
+
+      # ── Read-only built-in tools: preset defined above, safe, never need approval ──
+      - readonly-builtins
 
       # ── WebFetch: restrict by domain ───────────────────────────────────
       # params regex is matched against the full URL (tool_input["url"]).
@@ -176,10 +199,9 @@ agents:
         params: ".*\"action\":\\s*\"(get|list|read)\".*"  # read-only actions only
 
     guest_allowed_tools:
-      # Guests get a smaller subset — typically read-only tools only
-      - tool: "Read"
-      - tool: "Glob"
-      - tool: "Grep"
+      # Guests get a smaller subset — typically read-only tools only.
+      # Presets and inline rules mix freely, same as owner_allowed_tools above.
+      - readonly-builtins
       - tool: "WebFetch"
         params: "https?://[^/]*\\.wikipedia\\.org/.*"  # guests: Wikipedia only
       - tool: "mcp__rocketchat__get_.*"
@@ -244,7 +266,19 @@ watchers:
   #   agent-chat-gateway resume <watcher-name> — re-enable a paused watcher
   #   agent-chat-gateway reset  <watcher-name> — clear runtime state, start a fresh session
   #
-  # session_id:
+  # room / rooms:
+  #   room: "general"            — exactly one room; same as rooms: [general].
+  #   rooms: [general, "@alice"] — bind this connector+agent pair to several rooms at once.
+  #                                 Expands into one watcher per room at load time.
+  #
+  # name (optional):
+  #   Only allowed when the entry has exactly one room. If omitted, the watcher name is
+  #   auto-derived as "<connector>-<room>" (DM rooms like "@alice" become "<connector>-dm-alice").
+  #   Watcher names are persistent identifiers (state.json sessions, CLI pause/resume/reset,
+  #   attachment/system-prompt file paths) — set an explicit name on any watcher whose session
+  #   you want to survive editing the room list. See docs/migration-0.2.md.
+  #
+  # session_id: same one-room-only restriction as name.
   #   null (or omitted) — gateway auto-creates a session on first start and persists the ID.
   #                        'reset' clears the stored ID so a new session is created next time.
   #   "ses_abc123"      — gateway always connects to this specific session (sticky).
@@ -255,37 +289,66 @@ watchers:
   #
   # online_notification / offline_notification: customize the status message posted when
   #   this watcher starts or stops. Supports any text, emoji, or RC markdown.
-  #   Set to null (~) to suppress the message entirely for this watcher.
-  #   Defaults: "✅ _Agent online_" / "❌ _Agent offline_"
+  #   Default: null (no message). Set explicitly (or via watcher_defaults, below) to enable.
 
   # ── Voice watcher (pairs with the siri-voice connector above) ───────────
-  # - name: siri-watcher
-  #   connector: siri-voice
+  # - connector: siri-voice
   #   room: voice-room               # must be "voice-room" (fixed by VoiceConnector)
   #   agent: my-agent
-  #   session_id: ~
   #   context_inject_files:
   #     - gateway/contexts/voice-context.md  # enforces plain-text, no markdown/emoji for Siri
-  #   online_notification: ~         # suppress — no RC room to notify
-  #   offline_notification: ~
 
-  - name: general-room               # unique watcher name (used in CLI commands)
-    connector: rc-home               # must match a connector name above
-    room: general                    # room name, or @username for a DM
-    agent: my-agent                  # must match an agent name above
-    session_id: ~                    # null = auto-create
-    context_inject_files: []         # watcher-level extra context (usually empty)
-    online_notification: "✅ _Agent online_"    # set to ~ to suppress
-    offline_notification: "❌ _Agent offline_"  # set to ~ to suppress
+  - connector: rc-home              # must match a connector name above
+    agent: my-agent                 # must match an agent name above
+    rooms:
+      - general                     # -> watcher name: rc-home-general
+      # - "@your-admin-username"    # -> watcher name: rc-home-dm-your-admin-username
 
-  # - name: opencode-room
-  #   connector: rc-home
+  # - connector: rc-home
   #   room: opencode
   #   agent: opencode-agent
-  #   session_id: ~
-  #   context_inject_files: []
-  #   online_notification: "✅ _Agent online_"
-  #   offline_notification: "❌ _Agent offline_"
+
+# ── Defaults blocks (optional — most useful with 2+ connectors/agents) ───────
+# `connector_defaults:` / `agent_defaults:` / `watcher_defaults:` deep-merge into
+# every entry of the matching kind (the entry's own fields always win on conflict;
+# lists are replaced wholesale, not appended). This is what keeps a multi-bot
+# deployment (one connector + one agent per bot persona, fanned out across many
+# rooms) from turning into hundreds of near-duplicate lines. Example shape for a
+# fleet of bots sharing the same tool policy and agent-chain settings:
+#
+# agent_defaults:
+#   type: claude
+#   command: claude
+#   working_directory: ~/.agent-chat-gateway/work
+#   owner_allowed_tools: [readonly-builtins]
+#   permissions: {enabled: true, timeout: 300}
+#
+# connector_defaults:
+#   type: rocketchat
+#   agent_chain:
+#     agent_usernames: [laomei-bot, xiaomei-bot]
+#
+# agents:
+#   bot-a-agent: {}                       # inherits everything from agent_defaults
+#   bot-b-agent:
+#     timeout: 500                        # overrides just this one field
+#
+# connectors:
+#   - name: rc-bot-a
+#     server: {url: "$RC_URL", username: "$RC_USERNAME_A", password: "$RC_PASSWORD_A"}
+#   - name: rc-bot-b
+#     server: {url: "$RC_URL", username: "$RC_USERNAME_B", password: "$RC_PASSWORD_B"}
+#
+# watchers:
+#   - {connector: rc-bot-a, agent: bot-a-agent, rooms: [nest, hammer, "@glin"]}
+#   - {connector: rc-bot-b, agent: bot-b-agent, rooms: [nest, wave, "@glin"]}
+#
+# `watcher_defaults:` cannot set name/room/rooms/session_id (those identify a
+# specific watcher), but can set shared fields like `agent:` or notifications:
+#
+# watcher_defaults:
+#   online_notification: "✅ _Agent online_"   # restore the pre-0.2 default globally
+#   offline_notification: "❌ _Agent offline_"
 
 # ── Scheduler (optional) ──────────────────────────────────────────────────────
 # Controls the built-in cron scheduler.  All fields have sensible defaults

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -537,17 +537,31 @@ opencode run -s <session-id> --format json [-f <file> ...]
 
 ```
 config.yaml (user-editable)
-    ├─ connectors: [RocketChatConfig, ...]
-    ├─ agents: [AgentConfig, ...]
-    ├─ timeout: 360
-    ├─ default_agent: "assistance"
-    └─ plugins: [PluginConfig, ...]
-         → GatewayConfig (validated dataclass)
-            → AgentConfig, ConnectorConfig, PermissionConfig
-                → CoreConfig (passed to SessionManager)
+    ├─ tool_presets: {name: [ToolRule, ...]}              # named, reusable tool-rule lists
+    ├─ connector_defaults / agent_defaults / watcher_defaults  # deep-merged into entries below
+    ├─ connectors: [ConnectorConfig, ...]                 # room="a" | rooms=[a,b,...] on watchers
+    ├─ agents: {name: AgentConfig, ...}
+    ├─ default_agent: "my-agent"
+    ├─ watchers: [WatcherConfig, ...]
+    ├─ max_queue_depth: 100
+    └─ scheduler: {completed_job_ttl_days: 7}
+         → GatewayConfig.from_file()
+            1. expand $VAR / ${VAR} env references
+            2. deep-merge *_defaults into each connector/agent/watcher entry
+            3. resolve tool_presets references in owner/guest_allowed_tools
+            4. expand watcher rooms: into one WatcherConfig per room
+               (auto-name: "<connector>-<room>" unless name: is explicit)
+            5. validate cross-references (unknown connector/agent, dup names, ...)
+            → GatewayConfig (validated dataclass)
+               → AgentConfig, ConnectorConfig, WatcherConfig, PermissionConfig
+                  → CoreConfig (passed to SessionManager)
 ```
 
-All fields support env-var expansion via `$VARIABLE` syntax.
+All fields support env-var expansion via `$VARIABLE` syntax. See
+`docs/migration-0.2.md` for the compact-format rationale and
+`gateway/schema/config.schema.json` for the field-level JSON Schema. Run
+`agent-chat-gateway config validate --lint` to check a config.yaml without
+starting the daemon.
 
 ### Startup Sequence
 

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -1,0 +1,99 @@
+# Config editing tool — direction (decision record)
+
+Status: **decided, not yet implemented.** This document records the decision
+so the direction survives between sessions; no TUI code exists yet. The v0.2
+format simplification (`connector_defaults`/`agent_defaults`/`watcher_defaults`,
+`tool_presets`, watcher `rooms:`) plus `acg config validate` and the JSON
+Schema (see `docs/migration-0.2.md`) are prerequisites and have landed.
+
+## Problem
+
+`config.yaml` is hand-edited YAML. Even after the v0.2 format shrinks it
+considerably, typos are still possible, and the onboarding wizard
+(`gateway/onboard.py`) and any future interactive editor would otherwise be
+two separate things to maintain with duplicated logic.
+
+## Decision: a `textual`-based full-screen TUI, absorbing onboarding
+
+**Rejected: a local web UI.** An HTTP endpoint that edits permission
+allow-lists is a real attack surface (CSRF from any local browser tab, other
+local users) — directly against the OpenClaw-style principle this project
+already follows of not trusting user-controlled/network-reachable surfaces
+with config that grants tool access. It also needs port-forwarding to be
+usable when ACG runs on a remote server reached over SSH, which is the
+common deployment shape for this project.
+
+**Rejected as the primary interface: plain CLI subcommands**
+(`acg config add-connector`, etc.). These don't give an overview of what's
+already configured, and a growing flag surface per subcommand doesn't
+converge into "one tool." `acg config validate` stays as a plain command
+regardless — it's a scriptable check, not an editor.
+
+**Chosen: `textual`** (same authors as `rich`, which is already a
+dependency; textual builds on top of it). It runs over plain SSH — the
+primary way this project is operated — with zero network surface, and its
+widget/form model gives a natural mapping from the JSON Schema to editable
+fields.
+
+## Consolidation: one interactive surface, not two
+
+- `acg config` launches the app.
+  - Missing/empty `config.yaml` → setup flow (the current wizard, expressed
+    as screens: backend detection, connector credentials, first watcher).
+  - Existing `config.yaml` → editor: an overview screen listing
+    connectors/agents/watchers with live validation status, drilling into
+    per-entity forms.
+- `acg onboard` becomes an alias into the setup flow, then is deprecated once
+  the TUI ships.
+- `gateway/onboard.py`'s non-UI logic (`detect_agent_backends`, `.env`
+  writing with 0600 perms, `install_meta.json`, opencode plugin install) is
+  reused as-is by the setup flow; only the `rich` `Prompt`/`Confirm` wizard
+  UI is eventually deleted.
+
+## Single source of truth for validation
+
+- **Field-level** (types, enums, defaults, descriptions): the JSON Schema
+  (`gateway/schema/config.schema.json`). The TUI generates form widgets and
+  help text from it; `acg config validate` and the schema-sync tests
+  (`tests/unit/test_config_schema.py`) check documents against it.
+- **Cross-field / semantic** (watcher→connector/agent references, duplicate
+  names, `timeout > permissions.timeout`, working_directory existence): this
+  logic currently lives inline in `GatewayConfig.from_file`
+  (`gateway/config.py`) and in `gateway/config_validate.py`
+  (`validate_config()`), which already wraps `from_file` plus the extra
+  per-connector-type and state-orphan checks. `validate_config()` is written
+  as a plain, reusable function (not CLI-only) specifically so the TUI's
+  save-time check can call the same code path as `acg config validate` — no
+  third implementation of "is this config valid."
+- **Note for whoever implements the TUI:** `GatewayConfig.from_file` has a
+  side effect (`load_dotenv`) and a hard filesystem check
+  (`working_directory` must exist) baked into the same pass as pure
+  structural validation. Before wiring up live-as-you-type validation in the
+  editor, consider whether that check needs to become a separate, explicitly
+  invoked mode (e.g. "check syntax" vs "check ready to run") — that wasn't a
+  concern for a single validate-then-report CLI command, but matters for a
+  UI that re-validates on every keystroke.
+
+## Naming note
+
+`gateway/tools/tui.py` already exists — it's an unrelated interactive REPL
+for chatting with agent backends directly (`gateway-tui` console script),
+not a config editor. A naming collision only; the config tool should live in
+its own module (e.g. `gateway/configtool/`), not `gateway/tools/`.
+
+## Incremental delivery
+
+1. **M1 (MVP):** read-only overview screen (connectors/agents/watchers +
+   inline validation errors from `validate_config()`), plus an
+   "open in `$EDITOR`, re-validate on return" action. Small, immediately
+   useful, establishes the skeleton.
+2. **M2:** watcher editing (highest-churn entity — add/remove/edit room
+   bindings via `rooms:`), schema-driven forms, atomic save with a
+   timestamped backup (reuse `onboard.py`'s existing backup convention).
+   Decide at this point whether to adopt `ruamel.yaml` for comment-preserving
+   round-trip writes, or accept comment loss (PyYAML) with a pre-save backup.
+3. **M3:** agent editing (tool allow-lists using `tool_presets`) and
+   connector editing (credentials → `.env`, reusing `_write_env`).
+4. **M4:** setup flow (empty-config path) reusing the same forms;
+   `acg onboard` aliases it; delete the wizard's `Prompt`/`Confirm` UI so
+   exactly one interactive surface remains.

--- a/docs/install-agent.md
+++ b/docs/install-agent.md
@@ -188,10 +188,6 @@ watchers:
     connector: rc-home
     room: "@your-username"
     agent: my-agent
-    session_id: null
-    context_inject_files: []            # watcher-level extra context (usually empty)
-    online_notification: "✅ _Agent online_"
-    offline_notification: "❌ _Agent offline_"
 EOF
 ```
 
@@ -268,12 +264,14 @@ watchers:
     connector: mm-home
     room: "@your-username"
     agent: my-agent
-    session_id: null
-    context_inject_files: []            # watcher-level extra context (usually empty)
-    online_notification: "✅ _Agent online_"
-    offline_notification: "❌ _Agent offline_"
 EOF
 ```
+
+> By default a watcher doesn't announce online/offline in chat. Watching more than one
+> room with the same connector+agent? Use `rooms: [a, b, ...]` instead of `room:` and
+> one entry expands into a watcher per room automatically — see Step 7 below and
+> `config.example.yaml` for the full annotated format (including `tool_presets` and
+> `*_defaults` blocks for larger multi-bot setups).
 
 **Replace:**
 - `your-username` — your username on the chosen chat platform (the one who will own the bot)
@@ -355,16 +353,20 @@ To monitor additional rooms/channels:
 
 1. Add the bot to the room (Rocket.Chat) or channel (Mattermost — must also already be a
    team member, see Step 2)
-2. Edit `~/.agent-chat-gateway/config.yaml` and add a new watcher entry, pointing `connector:`
-   at whichever connector name you created in Step 3 (`rc-home` or `mm-home`):
+2. Edit `~/.agent-chat-gateway/config.yaml` and add the room to your watcher. If you're
+   watching several rooms with the same connector+agent, use `rooms:` instead of adding a
+   whole new entry per room — it expands into one watcher per room automatically, naming
+   each one `<connector>-<room>`:
    ```yaml
-   - name: dev-room
-     connector: rc-home   # or mm-home
-     room: "dev"           # bare channel name, no leading "#", on either platform
+   - connector: rc-home   # or mm-home
      agent: my-agent
-     session_id: null
+     rooms: ["general", "dev"]   # bare channel name, no leading "#", on either platform
    ```
-3. Restart the daemon: `agent-chat-gateway restart`
+   A one-off room still works as a single entry with `room:` instead of `rooms:` — see
+   `config.example.yaml` for the full annotated format, including `name:` for pinning a
+   specific watcher's identity (needed if you rely on its session surviving a config edit).
+3. Validate before restarting: `agent-chat-gateway config validate --config ~/.agent-chat-gateway/config.yaml`
+4. Restart the daemon: `agent-chat-gateway restart`
 
 ---
 

--- a/docs/migration-0.2.md
+++ b/docs/migration-0.2.md
@@ -1,0 +1,151 @@
+# Migrating to the v0.2 config format
+
+v0.2 adds a compact config format on top of what already worked: top-level
+`connector_defaults:` / `agent_defaults:` / `watcher_defaults:` blocks that
+deep-merge into every entry, named `tool_presets:` you can reference from any
+agent's tool allow-lists, and `rooms:` to bind one connector+agent pair to
+many rooms without repeating the whole watcher entry.
+
+**None of this is required.** Every field from the old format still parses.
+You can adopt the new format incrementally, field by field, or not at all.
+
+## 1. The one behavior change — read this first
+
+Watchers no longer post an "Agent online" / "Agent offline" message by
+default. The default for `online_notification` / `offline_notification` is
+now `null` (quiet) instead of `"✅ _Agent online_"` / `"❌ _Agent offline_"`.
+
+**This does not raise a config error** — an existing config.yaml that never
+set these fields explicitly will silently go quiet after upgrading. If you
+want the old behavior back, set it once for every watcher via
+`watcher_defaults:`:
+
+```yaml
+watcher_defaults:
+  online_notification: "✅ _Agent online_"
+  offline_notification: "❌ _Agent offline_"
+```
+
+Run `agent-chat-gateway config validate` after upgrading — it does not detect
+this particular change (it's a valid, quieter default, not an error), but it's
+good practice to re-validate after any version bump.
+
+## 2. Everything else is additive
+
+`room:` (singular) still works exactly as before — it's now formally an alias
+for `rooms: [<room>]`. Explicit watcher `name:`, full `attachments:` /
+`agent_chain:` / `permissions:` blocks, inline tool rules — all unchanged. You
+do not need to touch a working config.yaml at all to stay on v0.2.
+
+## 3. Before adopting `rooms:` — watcher names are persistent identifiers
+
+A watcher's `name` (explicit or auto-generated) is a filesystem- and
+state-persistence key:
+
+- `~/.agent-chat-gateway/state.<connector>.json` — keyed by watcher name;
+  session ID, sticky/paused flags
+- `<working_directory>/.acg-attachments/<name>/` — attachment cache
+- `<RUNTIME_DIR>/system-prompts/<name>.md` — injected system prompt
+- `agent-chat-gateway pause|resume|reset <name>` — CLI muscle memory
+
+If you rewrite a `name: my-watcher` / `room: general` entry as
+`rooms: [general]` (dropping the explicit name), the watcher's name changes
+from `my-watcher` to the auto-generated `<connector>-general`. That is a
+**different identity** as far as the gateway is concerned — the running
+session under the old name is orphaned:
+
+- Options:
+  1. **Keep the explicit `name:`** on any watcher whose session you care
+     about, and only use bare `rooms:` for new or disposable bindings. This
+     is the simplest and safest choice — do this for anything already in
+     production.
+  2. **Migrate state.json by hand**, if you want to keep both the session
+     and the new auto-generated name: stop the daemon
+     (`agent-chat-gateway stop`), rename the top-level watcher-name key in
+     `~/.agent-chat-gateway/state.<connector>.json` from the old name to the
+     new one, then start again. Attachment and system-prompt files under the
+     old name are left on disk (harmless orphans — safe to delete once
+     you've confirmed the new name is working).
+
+Run `agent-chat-gateway config validate` after any watcher-naming change — it
+warns when a connector's `state.<connector>.json` contains a watcher name
+that no longer exists in the (expanded) config, which is exactly this
+situation.
+
+## 4. Before/after recipes
+
+**Connector `agent_chain:` copied into every bot's connector:**
+
+```yaml
+# Before — repeated verbatim per connector
+connectors:
+  - name: mm-bot-a
+    type: mattermost
+    agent_chain: {agent_usernames: [bot-a, bot-b], max_turns: 5, ttl_seconds: 60}
+    server: {url: "$MM_URL", team: home, username: "$MM_USER_A", password: "$MM_PASS_A"}
+  - name: mm-bot-b
+    type: mattermost
+    agent_chain: {agent_usernames: [bot-a, bot-b], max_turns: 5, ttl_seconds: 60}
+    server: {url: "$MM_URL", team: home, username: "$MM_USER_B", password: "$MM_PASS_B"}
+
+# After — one shared block, per-connector fields only where they differ
+connector_defaults:
+  type: mattermost
+  agent_chain: {agent_usernames: [bot-a, bot-b], max_turns: 5, ttl_seconds: 60}
+
+connectors:
+  - name: mm-bot-a
+    server: {url: "$MM_URL", team: home, username: "$MM_USER_A", password: "$MM_PASS_A"}
+  - name: mm-bot-b
+    server: {url: "$MM_URL", team: home, username: "$MM_USER_B", password: "$MM_PASS_B"}
+```
+
+**Tool allow-lists copied into every agent:**
+
+```yaml
+# Before
+agents:
+  bot-a-agent: {owner_allowed_tools: [{tool: Read}, {tool: Glob}, {tool: Grep}]}
+  bot-b-agent: {owner_allowed_tools: [{tool: Read}, {tool: Glob}, {tool: Grep}]}
+
+# After
+tool_presets:
+  readonly: [{tool: Read}, {tool: Glob}, {tool: Grep}]
+agents:
+  bot-a-agent: {owner_allowed_tools: [readonly]}
+  bot-b-agent: {owner_allowed_tools: [readonly]}   # presets and inline rules mix freely
+```
+
+**Watcher cartesian product (one connector+agent, many rooms):**
+
+```yaml
+# Before — one full entry per room, name/session_id/notifications repeated
+watchers:
+  - {name: bot-a-nest, connector: mm-bot-a, room: nest, agent: bot-a-agent,
+     session_id: null, context_inject_files: [], online_notification: null, offline_notification: null}
+  - {name: bot-a-hammer, connector: mm-bot-a, room: hammer, agent: bot-a-agent,
+     session_id: null, context_inject_files: [], online_notification: null, offline_notification: null}
+
+# After
+watchers:
+  - {connector: mm-bot-a, agent: bot-a-agent, rooms: [nest, hammer]}
+    # -> mm-bot-a-nest, mm-bot-a-hammer
+```
+
+## 5. New tooling
+
+- `agent-chat-gateway config validate [--config PATH] [--lint]` — validates
+  config.yaml without starting the daemon; also instantiates each
+  connector's own config (catching empty `server:` credentials that
+  `from_file` alone doesn't check) and warns about state.json orphans. Add
+  `--lint` to flag values that just restate a built-in default or duplicate
+  a `*_defaults` entry.
+- `gateway/schema/config.schema.json` — a JSON Schema for editor
+  autocomplete and typo-checking. `config.example.yaml` references it via a
+  `# yaml-language-server: $schema=...` comment; most YAML-aware editors
+  (VS Code + the YAML extension, Neovim + yaml-language-server, etc.) pick
+  it up automatically.
+
+See `config.example.yaml` for a fully annotated reference using the new
+format, including a commented multi-connector example showing
+`connector_defaults` / `agent_defaults` / `watcher_defaults` together.

--- a/docs/permission-reference.md
+++ b/docs/permission-reference.md
@@ -69,6 +69,43 @@ agents:
       timeout: 300                 # seconds before auto-deny
 ```
 
+### Named Presets
+
+Any list item in `owner_allowed_tools` / `guest_allowed_tools` can be either
+an inline rule object (as above) or a **string naming a top-level
+`tool_presets` entry** — useful once the same rule set is repeated across
+multiple agents:
+
+```yaml
+tool_presets:
+  readonly:
+    - tool: "Read"
+    - tool: "Grep"
+    - tool: "Glob"
+
+agents:
+  my-agent:
+    owner_allowed_tools:
+      - readonly                     # preset reference — expands to the 3 rules above
+      - tool: "Bash"                 # inline rules and preset references mix freely
+        params: "git (log|diff).*"
+  other-agent:
+    owner_allowed_tools:
+      - readonly                     # same preset, no duplication
+```
+
+Presets are resolved before matching begins — at runtime there is no
+difference between a rule that came from a preset and one written inline.
+Rules:
+- List order is preserved regardless of which items are presets vs. inline.
+- A preset's own rule list must be flat inline rules only — a preset cannot
+  reference another preset by name.
+- All presets are regex-validated at config load time, even ones no agent
+  currently references, so a broken preset fails fast instead of only
+  surfacing when finally used.
+- An unknown preset name in an allow-list is a config load error naming the
+  agent, the field, and the list of presets that do exist.
+
 ### Matching Rules
 
 Each rule is an object with two regex fields:
@@ -467,12 +504,18 @@ Content-Type: application/json
 ### Complete YAML Schema
 
 ```yaml
+tool_presets:
+  a-preset-name:
+    - tool: "regex_pattern"
+      params: "optional_regex_pattern"
+
 agents:
   my-agent:
     # ... agent config ...
 
     owner_allowed_tools:
-      - tool: "regex_pattern"
+      - a-preset-name                # string = tool_presets reference
+      - tool: "regex_pattern"        # object = inline rule; the two mix freely
         params: "optional_regex_pattern"
 
     guest_allowed_tools:
@@ -490,10 +533,11 @@ agents:
 
 | Path | Type | Default | Description |
 |------|------|---------|-------------|
-| `agents[*].owner_allowed_tools` | list[ToolRule] | `[]` | Tools owner can execute without approval |
+| `tool_presets` | map[string, list[ToolRule]] | `{}` | Named, reusable tool-rule lists |
+| `agents[*].owner_allowed_tools` | list[ToolRule \| preset name] | `[]` | Tools owner can execute without approval |
 | `agents[*].owner_allowed_tools[*].tool` | regex string | (required) | Case-insensitive regex on tool name |
 | `agents[*].owner_allowed_tools[*].params` | regex string | (optional) | Case-insensitive regex on primary parameter |
-| `agents[*].guest_allowed_tools` | list[ToolRule] | `[]` | Tools guest can execute (auto-approved) |
+| `agents[*].guest_allowed_tools` | list[ToolRule \| preset name] | `[]` | Tools guest can execute (auto-approved) |
 | `agents[*].guest_allowed_tools[*].tool` | regex string | (required) | Case-insensitive regex on tool name |
 | `agents[*].guest_allowed_tools[*].params` | regex string | (optional) | Case-insensitive regex on primary parameter |
 | `agents[*].permissions.enabled` | bool | `false` | Enable approval workflow for this agent |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -235,6 +235,18 @@ The gateway SHALL:
 2. If permission timeouts are enabled, require that the overall agent timeout is greater than the permission timeout
 3. Prevent distinct watchers from reusing the same fixed session ID in a way that would create ambiguous routing
 
+### 8.4 Defaults Blocks, Tool Presets, and Watcher Room Expansion
+
+The gateway SHALL:
+1. Support top-level `connector_defaults`, `agent_defaults`, and `watcher_defaults` blocks that are deep-merged into every entry of the matching kind, with the entry's own fields taking precedence over the inherited default on conflict
+2. Reject a `*_defaults` block that sets an identity field belonging to a specific entry (`name` for `connector_defaults`; `name`, `room`, `rooms`, or `session_id` for `watcher_defaults`)
+3. Support a top-level `tool_presets` block of named, reusable tool-rule lists, referenced by name from `owner_allowed_tools`/`guest_allowed_tools`, freely mixable with inline tool-rule entries
+4. Validate every defined tool preset's rules at configuration load time, regardless of whether any agent references it
+5. Reject a tool preset whose rule list itself references another preset by name (presets SHALL be flat)
+6. Support a watcher `rooms` list as an alias that expands one watcher entry into one watcher per listed room, each with an automatically derived name of the form `<connector>-<sanitized-room>`
+7. Reject a watcher entry that sets both `room` and `rooms`, or that sets `name` or `session_id` while `rooms` contains more than one room
+8. Apply the same watcher-name uniqueness requirement to names produced by room expansion as to explicitly configured names
+
 ---
 
 ## 9. Error Handling and Recovery

--- a/docs/supported-features.md
+++ b/docs/supported-features.md
@@ -293,15 +293,31 @@ watchers:
 - ✅ Multi-agent setup (different agents per watcher)
 - ✅ Cross-field validation (e.g., agent timeout > permission timeout)
 - ✅ Relative path resolution (relative to config file location)
+- ✅ `connector_defaults` / `agent_defaults` / `watcher_defaults` — deep-merge
+  shared fields into every entry of the matching kind
+- ✅ `tool_presets` — named, reusable tool-rule lists referenced by name from
+  `owner_allowed_tools` / `guest_allowed_tools`
+- ✅ Watcher `rooms: [a, b, ...]` — one connector+agent pair expands into one
+  watcher per room, with an auto-derived name (`<connector>-<room>`)
+- ✅ JSON Schema (`gateway/schema/config.schema.json`) for editor
+  autocomplete and inline typo-checking
 
 #### Configuration Validation
 - ✅ Connector names must be unique
-- ✅ Watcher names must be unique
+- ✅ Watcher names must be unique (including names auto-derived from `rooms:`)
 - ✅ Watchers must reference existing connectors and agents
 - ✅ Default agent must reference existing agent (if specified)
 - ✅ Required paths must exist at validation time
 - ✅ Queue depth settings reject invalid values
 - ✅ Sticky session IDs validated for uniqueness
+- ✅ `*_defaults` blocks reject identity fields (e.g. `name`, `room`/`rooms`,
+  `session_id`) that must be set per-entry, not inherited
+- ✅ `tool_presets` are regex-validated eagerly at load, even if unused
+- ✅ `agent-chat-gateway config validate [--lint]` — checks config.yaml
+  without starting the daemon: structural validation, per-connector-type
+  credential checks (e.g. empty Rocket.Chat/Mattermost `server:` fields),
+  and a warning when persisted `state.<connector>.json` references a watcher
+  name no longer in the config
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -323,6 +323,17 @@ agent-chat-gateway start
 | `connectors` | list | Yes | (none) | Chat platform connections |
 | `agents` | dict | Yes | (none) | AI agent backend definitions |
 | `watchers` | list | Yes | (none) | Room→agent mappings |
+| `tool_presets` | dict | No | `{}` | Named, reusable tool-rule lists — see [Tool Allow-Lists](#tool-allow-lists) |
+| `connector_defaults` | dict | No | `{}` | Deep-merged into every entry under `connectors:` |
+| `agent_defaults` | dict | No | `{}` | Deep-merged into every entry under `agents:` |
+| `watcher_defaults` | dict | No | `{}` | Deep-merged into every entry under `watchers:` |
+
+None of the four defaults/preset fields above are required — a single
+connector/agent/watcher setup rarely needs them. They exist to avoid
+repeating the same block across many connectors/agents/watchers in larger
+deployments. See `config.example.yaml` for a worked example and
+`docs/migration-0.2.md` if you're upgrading a config.yaml that predates them.
+Check your config any time with `agent-chat-gateway config validate --lint`.
 
 ### Connectors
 
@@ -458,32 +469,59 @@ watchers:
     connector: rc-main
     room: general
     agent: claude
-    session_id: null
-    context_inject_files: []
-    online_notification: "✅ _Agent online_"
-    offline_notification: "❌ _Agent offline_"
 ```
+
+Binding the same connector+agent to several rooms at once: use `rooms:`
+instead of `room:` — it expands into one watcher per room, with the name
+auto-derived as `<connector>-<room>` (a `@username` DM room becomes
+`<connector>-dm-<username>`) unless you set `name:` explicitly:
+
+```yaml
+watchers:
+  - connector: rc-main
+    agent: claude
+    rooms: [general, dev, "@alice"]
+    # -> rc-main-general, rc-main-dev, rc-main-dm-alice
+```
+
+`name:` and `session_id:` may only be set when the entry has exactly one
+room (via `room:`, or a single-item `rooms:`) — they pin a specific
+watcher's identity, which is ambiguous across an expanded multi-room entry.
+
+> ⚠️ **Watcher names are persistent identifiers** — they key session state
+> in `state.<connector>.json`, attachment cache directories, and injected
+> system-prompt files, and they're what you type into
+> `agent-chat-gateway pause|resume|reset`. Renaming a watcher (including by
+> switching it from an explicit `name:` to auto-generated `rooms:`) starts a
+> fresh session under the new name and orphans the old one. See
+> `docs/migration-0.2.md` for the safe way to rename a watcher that already
+> has state you care about.
 
 **Watcher Fields:**
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | string | Yes | Unique watcher identifier (used in CLI commands) |
+| `name` | string | No | Watcher identifier used in CLI commands; auto-derived from `connector`+room if omitted. Only settable on a single-room entry. |
 | `connector` | string | Yes | Must match a connector name above |
-| `room` | string | Yes | Room/channel name (as known to the `connector` named above) or `@username` for DMs |
+| `room` | string | One of `room`/`rooms` | Room/channel name (as known to the `connector` named above) or `@username` for DMs |
+| `rooms` | list[string] | One of `room`/`rooms` | Bind this connector+agent pair to several rooms at once; expands into one watcher per room |
 | `agent` | string | No | Agent backend to use; falls back to `default_agent` if omitted |
-| `session_id` | string | No | Optional sticky session ID (e.g., `ses_abc123`); `null` = auto-create |
+| `session_id` | string | No | Optional sticky session ID (e.g., `ses_abc123`); `null` = auto-create. Only settable on a single-room entry. |
 | `context_inject_files` | list | No | Watcher-specific context files |
-| `online_notification` | string | No | Message posted when this watcher starts; `~` to suppress |
-| `offline_notification` | string | No | Message posted when this watcher stops; `~` to suppress |
+| `online_notification` | string | No | Message posted when this watcher starts; default `null` (no message) |
+| `offline_notification` | string | No | Message posted when this watcher stops; default `null` (no message) |
 
 ### Tool Allow-Lists
 
 `owner_allowed_tools` and `guest_allowed_tools` control which tools can be used without requiring permission approval.
 
-Each entry is an object with:
-- **`tool`** (required) — regex matched against the tool name
-- **`params`** (optional) — regex matched against the tool's primary parameter
+Each entry is either:
+- an object with **`tool`** (required, regex matched against the tool name)
+  and **`params`** (optional, regex matched against the tool's primary
+  parameter), or
+- a **string** naming a top-level `tool_presets:` entry — expanded in place,
+  so the same rule set can be shared across agents without repeating it. See
+  [permission-reference.md](permission-reference.md#named-presets) for details.
 
 **Example:**
 

--- a/gateway/cli.py
+++ b/gateway/cli.py
@@ -131,6 +131,24 @@ def main():
         help="Instruction document to print",
     )
 
+    # config (sub-subcommands)
+    config_p = sub.add_parser("config", help="Config file utilities")
+    config_sub = config_p.add_subparsers(dest="config_cmd", help="Config subcommands")
+
+    config_validate_p = config_sub.add_parser(
+        "validate",
+        help="Validate config.yaml without starting the daemon",
+    )
+    config_validate_p.add_argument(
+        "--config", default=DEFAULT_CONFIG,
+        help="Path to config.yaml (default: $ACG_CONFIG or ~/.agent-chat-gateway/config.yaml)",
+    )
+    config_validate_p.add_argument(
+        "--lint", action="store_true",
+        help="Also flag values that just restate a built-in default or duplicate "
+             "a *_defaults entry",
+    )
+
     # schedule (sub-subcommands)
     schedule_p = sub.add_parser("schedule", help="Manage scheduled agent tasks")
     schedule_sub = schedule_p.add_subparsers(dest="schedule_cmd", help="Schedule subcommands")
@@ -327,6 +345,53 @@ def main():
 
     elif args.command == "schedule":
         _run_schedule(args)
+
+    elif args.command == "config":
+        _run_config(args)
+
+
+def _run_config(args) -> None:
+    """Handle 'config' subcommands."""
+    if not getattr(args, "config_cmd", None):
+        print("Usage: agent-chat-gateway config {validate}")
+        sys.exit(1)
+
+    if args.config_cmd == "validate":
+        _run_config_validate(args)
+    else:
+        print(f"Unknown config subcommand: {args.config_cmd}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _run_config_validate(args) -> None:
+    """Handle 'config validate': load + cross-check config.yaml, no daemon needed."""
+    from .config_validate import validate_config
+
+    result = validate_config(args.config, lint=args.lint)
+
+    if result.errors:
+        print(f"✗ {args.config}: {len(result.errors)} error(s)", file=sys.stderr)
+        for err in result.errors:
+            print(f"  - {err}", file=sys.stderr)
+    else:
+        summary = f"✓ {args.config}: valid — {result.watcher_count} watcher(s)"
+        if result.entry_count and result.entry_count != result.watcher_count:
+            summary += f" (expanded from {result.entry_count} entries)"
+        print(summary)
+
+    for warning in result.warnings:
+        print(f"  ⚠ {warning}")
+
+    if args.lint:
+        if result.lint_findings:
+            print(f"\n{len(result.lint_findings)} lint finding(s):")
+            for finding in result.lint_findings:
+                print(f"  - {finding}")
+        else:
+            print("\nlint: no redundant defaults found")
+
+    if not result.ok:
+        sys.exit(1)
 
 
 def _run_instructions(args) -> None:

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -106,14 +106,19 @@ class GatewayConfig:
                 f"config.yaml 'connectors:' must be a list (got {type(connectors_raw).__name__})."
             )
 
+        connector_defaults = _extract_defaults_block(
+            raw, "connector_defaults", frozenset({"name"})
+        )
+
         connectors: list[ConnectorConfig] = []
         seen_connector_names: set[str] = set()
-        for i, cc in enumerate(connectors_raw):
-            if not isinstance(cc, Mapping):
+        for i, cc_raw in enumerate(connectors_raw):
+            if not isinstance(cc_raw, Mapping):
                 raise ValueError(
                     f"Connector entry at index {i} must be a mapping "
-                    f"(got {type(cc).__name__})."
+                    f"(got {type(cc_raw).__name__})."
                 )
+            cc = _deep_merge(connector_defaults, cc_raw)
             name = cc.get("name", "")
             connector_type = cc.get("type", "")
             if not name:
@@ -172,13 +177,17 @@ class GatewayConfig:
             )
         default_agent = raw.get("default_agent", "")
 
+        agent_defaults = _extract_defaults_block(raw, "agent_defaults", frozenset())
+        tool_presets = _parse_tool_presets(raw)
+
         agents: dict[str, AgentConfig] = {}
-        for agent_name, agent_raw in agents_raw.items():
-            if not isinstance(agent_raw, Mapping):
+        for agent_name, agent_raw_entry in agents_raw.items():
+            if not isinstance(agent_raw_entry, Mapping):
                 raise ValueError(
                     f"Agent '{agent_name}' config must be a mapping "
-                    f"(got {type(agent_raw).__name__})."
+                    f"(got {type(agent_raw_entry).__name__})."
                 )
+            agent_raw = _deep_merge(agent_defaults, agent_raw_entry)
             perm_raw = agent_raw.get("permissions", {})
             if perm_raw and not isinstance(perm_raw, Mapping):
                 raise ValueError(
@@ -190,10 +199,14 @@ class GatewayConfig:
             raw_ctx = agent_raw.get("context_inject_files", [])
             ctx_files = _resolve_paths(raw_ctx, config_dir)
 
-            # Resolve working_directory relative to the config file's directory
+            # Resolve working_directory: expand a leading ~ first (matching
+            # the cache_dir_global handling below), then resolve relative to
+            # the config file's directory if still not absolute.
             working_directory = agent_raw.get("working_directory", "")
-            if working_directory and not Path(working_directory).is_absolute():
-                working_directory = str((config_dir / working_directory).resolve())
+            if working_directory:
+                working_directory = str(Path(working_directory).expanduser())
+                if not Path(working_directory).is_absolute():
+                    working_directory = str((config_dir / working_directory).resolve())
 
             # Validate: working_directory is required and must exist
             if not working_directory:
@@ -222,11 +235,17 @@ class GatewayConfig:
                 session_prefix=agent_raw.get("session_prefix", "agent-chat"),
                 lazy_instruction_loading=lazy_instruction_loading,
                 context_inject_files=ctx_files,
-                owner_allowed_tools=_parse_tool_rules(
-                    agent_raw.get("owner_allowed_tools", []), agent_name
+                owner_allowed_tools=_resolve_tool_entries(
+                    agent_raw.get("owner_allowed_tools", []),
+                    tool_presets,
+                    agent_name,
+                    "owner_allowed_tools",
                 ),
-                guest_allowed_tools=_parse_tool_rules(
-                    agent_raw.get("guest_allowed_tools", []), agent_name
+                guest_allowed_tools=_resolve_tool_entries(
+                    agent_raw.get("guest_allowed_tools", []),
+                    tool_presets,
+                    agent_name,
+                    "guest_allowed_tools",
                 ),
                 timeout=agent_raw.get("timeout", 360),
                 permissions=PermissionConfig(
@@ -271,50 +290,88 @@ class GatewayConfig:
             raise ValueError(
                 f"config.yaml 'watchers:' must be a list (got {type(watchers_raw).__name__})."
             )
+
+        watcher_defaults = _extract_defaults_block(
+            raw, "watcher_defaults", frozenset({"name", "room", "rooms", "session_id"})
+        )
+
         seen_watcher_names: set[str] = set()
-        for i, wc in enumerate(watchers_raw):
-            if not isinstance(wc, Mapping):
+        for i, wc_raw in enumerate(watchers_raw):
+            if not isinstance(wc_raw, Mapping):
                 raise ValueError(
                     f"Watcher entry at index {i} must be a mapping "
-                    f"(got {type(wc).__name__})."
+                    f"(got {type(wc_raw).__name__})."
                 )
-            watcher_name = wc.get("name", "")
-            if not watcher_name:
-                raise ValueError("Each watcher entry must have a 'name' field")
-            if "/" in watcher_name:
-                raise ValueError(
-                    f"Watcher name '{watcher_name}' must not contain '/' — "
-                    "watcher names are used as filesystem path components "
-                    "(e.g. <working_directory>/.acg-attachments/<name>, "
-                    "<RUNTIME_DIR>/system-prompts/<name>.md) "
-                    "and a '/' could escape the intended directory."
-                )
-            if watcher_name in seen_watcher_names:
-                raise ValueError(
-                    f"Duplicate watcher name '{watcher_name}' found. "
-                    "Each watcher must use a unique name."
-                )
-            seen_watcher_names.add(watcher_name)
+            wc = _deep_merge(watcher_defaults, wc_raw)
 
-            watcher_room = wc.get("room", "")
-            if not watcher_room:
+            # ── room / rooms: exactly one form, 'room' is a single-item alias ──
+            raw_room = wc.get("room")
+            raw_rooms = wc.get("rooms")
+            if raw_room and raw_rooms:
                 raise ValueError(
-                    f"Watcher '{watcher_name}' must have a non-empty 'room' field"
+                    f"Watcher entry at index {i}: set either 'room' or 'rooms', not both."
                 )
+            if raw_rooms is not None:
+                if not isinstance(raw_rooms, list) or not raw_rooms:
+                    raise ValueError(
+                        f"Watcher entry at index {i}: 'rooms' must be a non-empty list "
+                        "of room names."
+                    )
+                if not all(isinstance(r, str) and r for r in raw_rooms):
+                    raise ValueError(
+                        f"Watcher entry at index {i}: 'rooms' entries must be "
+                        "non-empty strings."
+                    )
+                if len(set(raw_rooms)) != len(raw_rooms):
+                    dupes = sorted({r for r in raw_rooms if raw_rooms.count(r) > 1})
+                    raise ValueError(
+                        f"Watcher entry at index {i}: 'rooms' contains duplicate "
+                        f"room(s): {dupes}."
+                    )
+                rooms_list = list(raw_rooms)
+            elif raw_room:
+                rooms_list = [raw_room]
+            else:
+                raise ValueError(
+                    f"Watcher entry at index {i} must have a non-empty "
+                    "'room' or 'rooms' field"
+                )
+
+            # 'name' / 'session_id' pin a single sticky identity — only meaningful
+            # when the entry expands to exactly one watcher.
+            explicit_name = wc.get("name") or None
+            explicit_session_id = wc.get("session_id") or None
+            if len(rooms_list) > 1:
+                if explicit_name:
+                    raise ValueError(
+                        f"Watcher entry at index {i}: 'name' can only be set when "
+                        f"there is exactly one room (found {len(rooms_list)} in "
+                        "'rooms') — remove 'name' or split into single-room entries."
+                    )
+                if explicit_session_id:
+                    raise ValueError(
+                        f"Watcher entry at index {i}: 'session_id' can only be set "
+                        f"when there is exactly one room (found {len(rooms_list)} in "
+                        "'rooms') — remove 'session_id' or split into single-room "
+                        "entries."
+                    )
 
             watcher_connector = wc.get("connector", "")
             if watcher_connector and watcher_connector not in connector_names:
                 raise ValueError(
-                    f"Watcher '{watcher_name}' references unknown connector '{watcher_connector}'"
+                    f"Watcher entry at index {i} references unknown connector "
+                    f"'{watcher_connector}'"
                 )
+            resolved_connector = watcher_connector or connectors[0].name
 
             watcher_agent = wc.get("agent", default_agent)
             if watcher_agent not in agents:
                 raise ValueError(
-                    f"Watcher '{watcher_name}' references unknown agent '{watcher_agent}'"
+                    f"Watcher entry at index {i} references unknown agent "
+                    f"'{watcher_agent}'"
                 )
 
-            # Resolve watcher-level context_inject_files
+            # Resolve watcher-level context_inject_files (shared across expanded rooms)
             raw_ctx = wc.get("context_inject_files", [])
             ctx_files = _resolve_paths(raw_ctx, config_dir)
 
@@ -325,23 +382,45 @@ class GatewayConfig:
                 verbatim_tail=hh_raw.get("verbatim_tail", 15),
             )
 
-            watchers.append(
-                WatcherConfig(
-                    name=watcher_name,
-                    connector=watcher_connector or connectors[0].name,
-                    room=watcher_room,
-                    agent=watcher_agent,
-                    session_id=wc.get("session_id") or None,
-                    context_inject_files=ctx_files,
-                    online_notification=wc.get(
-                        "online_notification", "✅ _Agent online_"
-                    ),
-                    offline_notification=wc.get(
-                        "offline_notification", "❌ _Agent offline_"
-                    ),
-                    history_handoff=history_handoff,
+            for room in rooms_list:
+                watcher_name = explicit_name or _auto_watcher_name(
+                    resolved_connector, room
                 )
-            )
+                if "/" in watcher_name:
+                    raise ValueError(
+                        f"Watcher name '{watcher_name}' must not contain '/' — "
+                        "watcher names are used as filesystem path components "
+                        "(e.g. <working_directory>/.acg-attachments/<name>, "
+                        "<RUNTIME_DIR>/system-prompts/<name>.md) "
+                        "and a '/' could escape the intended directory."
+                    )
+                if watcher_name in seen_watcher_names:
+                    origin = (
+                        "explicit 'name:'"
+                        if explicit_name
+                        else f"auto-generated from connector '{resolved_connector}' "
+                        f"+ room '{room}'"
+                    )
+                    raise ValueError(
+                        f"Duplicate watcher name '{watcher_name}' found ({origin}). "
+                        "Each watcher must use a unique name — set an explicit "
+                        "'name:' to disambiguate."
+                    )
+                seen_watcher_names.add(watcher_name)
+
+                watchers.append(
+                    WatcherConfig(
+                        name=watcher_name,
+                        connector=resolved_connector,
+                        room=room,
+                        agent=watcher_agent,
+                        session_id=explicit_session_id,
+                        context_inject_files=ctx_files,
+                        online_notification=wc.get("online_notification"),
+                        offline_notification=wc.get("offline_notification"),
+                        history_handoff=history_handoff,
+                    )
+                )
 
         # Validate no duplicate sticky session IDs across watchers — duplicate IDs
         # cause silent overwrite of session→room / session→connector routing maps,
@@ -390,17 +469,163 @@ class GatewayConfig:
         )
 
 
-def _parse_tool_rules(raw_list: list, agent_name: str = "") -> list["ToolRule"]:
-    """Parse a list of raw config entries into ToolRule objects."""
-    rules = []
+def _extract_defaults_block(
+    raw: dict, key: str, forbidden_keys: frozenset[str]
+) -> dict:
+    """Pop and validate a top-level ``<x>_defaults:`` mapping.
+
+    Returns an empty dict if the key is absent. Raises ValueError if the
+    block is not a mapping, or if it sets a key that identifies an
+    individual entry (e.g. ``name``) rather than something safe to inherit
+    across every entry.
+    """
+    block = raw.get(key, {}) or {}
+    if not isinstance(block, Mapping):
+        raise ValueError(
+            f"config.yaml '{key}:' must be a mapping (got {type(block).__name__})."
+        )
+    bad = sorted(forbidden_keys & block.keys())
+    if bad:
+        raise ValueError(
+            f"config.yaml '{key}:' must not set {bad} — these fields identify "
+            "an individual entry and must be set per-entry, not inherited."
+        )
+    return dict(block)
+
+
+def _deep_copy(value):
+    """Recursively copy dicts/lists so merged config entries never alias."""
+    if isinstance(value, Mapping):
+        return {k: _deep_copy(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_deep_copy(v) for v in value]
+    return value
+
+
+def _deep_merge(base: Mapping, override: Mapping) -> dict:
+    """Deep-merge two mappings; ``override`` wins at every level.
+
+    - Both values are dicts -> recursively merged.
+    - Otherwise (list, scalar, or ``None``) -> the override value replaces
+      the base value verbatim. An explicit ``null`` in ``override``
+      intentionally suppresses a base value, rather than being treated as
+      "unset".
+    - Always returns a brand-new nested structure so the result never shares
+      a mutable dict/list with ``base`` or ``override``. This matters
+      because per-entry parsing later mutates dicts in place (e.g. resolving
+      ``attachments.cache_dir_global`` to an absolute path) — without a deep
+      copy, that mutation would leak into a shared ``*_defaults`` block and
+      corrupt every other entry merged against it.
+    """
+    merged = {k: _deep_copy(v) for k, v in base.items()}
+    for k, v in override.items():
+        if k in merged and isinstance(merged[k], dict) and isinstance(v, Mapping):
+            merged[k] = _deep_merge(merged[k], v)
+        else:
+            merged[k] = _deep_copy(v)
+    return merged
+
+
+def _parse_tool_presets(raw: dict) -> dict[str, list["ToolRule"]]:
+    """Parse and validate the top-level ``tool_presets:`` block.
+
+    Each preset is a named list of inline tool-rule dicts (same shape as
+    ``owner_allowed_tools``/``guest_allowed_tools`` entries). Presets are
+    flat: a preset's rule list may not reference another preset by name.
+    All presets are parsed and regex-validated eagerly here, even if unused
+    by any agent, so a broken preset fails fast at config load.
+    """
+    presets_raw = raw.get("tool_presets", {}) or {}
+    if not isinstance(presets_raw, Mapping):
+        raise ValueError(
+            f"config.yaml 'tool_presets:' must be a mapping "
+            f"(got {type(presets_raw).__name__})."
+        )
+    presets: dict[str, list[ToolRule]] = {}
+    for preset_name, rules_raw in presets_raw.items():
+        if not isinstance(rules_raw, list):
+            raise ValueError(
+                f"tool_presets['{preset_name}'] must be a list of tool rules "
+                f"(got {type(rules_raw).__name__})."
+            )
+        rules: list[ToolRule] = []
+        for i, entry in enumerate(rules_raw):
+            if isinstance(entry, str):
+                raise ValueError(
+                    f"tool_presets['{preset_name}'][{i}]: presets cannot reference "
+                    f"another preset ('{entry}') — a preset must be a flat list of "
+                    "inline tool rules."
+                )
+            try:
+                rules.append(ToolRule.from_config(entry))
+            except ValueError as e:
+                raise ValueError(
+                    f"tool_presets['{preset_name}']: invalid tool rule at index {i}: {e}"
+                ) from e
+        presets[preset_name] = rules
+    return presets
+
+
+def _resolve_tool_entries(
+    raw_list: list,
+    presets: dict[str, list["ToolRule"]],
+    agent_name: str,
+    field_name: str,
+) -> list["ToolRule"]:
+    """Resolve one agent's owner/guest_allowed_tools list into ToolRule objects.
+
+    Each entry is either a string (the name of a ``tool_presets:`` entry,
+    expanded in place) or a dict (an inline ``{tool, params}`` rule). Both
+    forms may be freely mixed; list order is preserved.
+    """
+    rules: list[ToolRule] = []
     for i, entry in enumerate(raw_list):
+        if isinstance(entry, str):
+            preset = presets.get(entry)
+            if preset is None:
+                available = ", ".join(sorted(presets)) or "(none defined)"
+                raise ValueError(
+                    f"Agent '{agent_name}': unknown tool preset '{entry}' in "
+                    f"{field_name}[{i}]. Available presets: {available}"
+                )
+            rules.extend(preset)
+            continue
         try:
             rules.append(ToolRule.from_config(entry))
         except ValueError as e:
             raise ValueError(
-                f"Agent '{agent_name}': invalid tool rule at index {i}: {e}"
+                f"Agent '{agent_name}': invalid tool rule at index {i} in "
+                f"{field_name}: {e}"
             ) from e
     return rules
+
+
+_NAME_SANITIZE_RE = re.compile(r"[^A-Za-z0-9._-]")
+_NAME_COLLAPSE_DASH_RE = re.compile(r"-{2,}")
+
+
+def _sanitize_room_for_name(room: str) -> str:
+    """Turn a room identifier into a filesystem/CLI-safe watcher-name fragment.
+
+    - A leading '@' (DM room, e.g. '@alice') becomes a 'dm-' prefix: '@alice' -> 'dm-alice'.
+    - Any character outside [A-Za-z0-9._-] (including '/') becomes '-'.
+    - Runs of '-' collapse to one; leading/trailing '-' and '.' are stripped.
+    """
+    prefix = "dm-" if room.startswith("@") else ""
+    body = room[1:] if room.startswith("@") else room
+    body = _NAME_SANITIZE_RE.sub("-", body)
+    sanitized = _NAME_COLLAPSE_DASH_RE.sub("-", prefix + body).strip("-.")
+    if not sanitized:
+        raise ValueError(
+            f"Could not derive a safe watcher name from room {room!r} — "
+            "set an explicit 'name:' for this entry."
+        )
+    return sanitized
+
+
+def _auto_watcher_name(connector: str, room: str) -> str:
+    """Deterministic watcher name for a (connector, room) pair: '<connector>-<room>'."""
+    return f"{connector}-{_sanitize_room_for_name(room)}"
 
 
 def _resolve_paths(paths: list, base_dir: Path) -> list[str]:

--- a/gateway/config_validate.py
+++ b/gateway/config_validate.py
@@ -1,0 +1,226 @@
+"""Standalone config.yaml validation — no daemon required.
+
+``GatewayConfig.from_file`` (gateway/config.py) already checks structure and
+cross-references (unknown connector/agent, duplicate names, etc.). This module
+adds two things `from_file` alone cannot catch, plus an optional lint pass:
+
+1. Per-connector-type validation. Connector dataclasses (RocketChatConfig,
+   MattermostConfig, VoiceConfig) are normally only built lazily when the
+   daemon actually starts a connector — a bad or empty ``server:`` block goes
+   unnoticed until then. Building them here surfaces those errors immediately.
+2. A state.json orphan check: warns when a connector's persisted watcher
+   state references a watcher name no longer present in the config — that
+   session/pause state is silently dropped on the next gateway start
+   (see gateway/core/watcher_lifecycle.py's state-pruning behavior).
+3. ``--lint``: flags config values that just restate a built-in default, or
+   duplicate a value already provided by the matching ``*_defaults`` block —
+   noise that can be deleted without changing behavior.
+
+Used by the ``acg config validate`` CLI command; written as a plain function
+(not a CLI-only code path) so a future config-editing tool can reuse the same
+save-time check.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import yaml
+
+from .config import GatewayConfig, _extract_defaults_block
+from .connectors.mattermost.config import MattermostConfig
+from .connectors.rocketchat.config import RocketChatConfig
+from .connectors.voice.config import VoiceConfig
+from .core.state import load_state
+
+# Connector types validated via their own dataclass parser. 'script' is
+# intentionally omitted — ScriptConnector never reads ConnectorConfig.raw
+# (see gateway/connectors/__init__.py), so there's nothing to validate.
+_CONNECTOR_VALIDATORS = {
+    "rocketchat": RocketChatConfig.from_connector_config,
+    "mattermost": MattermostConfig.from_connector_config,
+    "voice": VoiceConfig.from_connector_config,
+}
+
+# (key, default_value) pairs checked by --lint against each raw entry. Kept
+# to top-level scalar/list fields — deep nested paths (e.g. permissions.timeout)
+# are intentionally out of scope to keep this a cheap, low-noise pass.
+_AGENT_LINT_DEFAULTS: list[tuple[str, object]] = [
+    ("session_prefix", "agent-chat"),
+    ("lazy_instruction_loading", True),
+    ("new_session_args", []),
+    ("context_inject_files", []),
+    ("timeout", 360),
+]
+_WATCHER_LINT_DEFAULTS: list[tuple[str, object]] = [
+    ("context_inject_files", []),
+    ("online_notification", None),
+    ("offline_notification", None),
+    ("session_id", None),
+]
+_CONNECTOR_LINT_DEFAULTS: list[tuple[str, object]] = [
+    ("reply_in_thread", False),
+    ("permission_reply_in_thread", True),
+]
+
+
+@dataclass
+class ValidationResult:
+    config_path: str
+    entry_count: int = 0
+    watcher_count: int = 0
+    errors: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+    lint_findings: list[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def validate_config(config_path: str, lint: bool = False) -> ValidationResult:
+    """Validate config.yaml without starting the daemon. See module docstring."""
+    result = ValidationResult(config_path=config_path)
+
+    try:
+        config = GatewayConfig.from_file(config_path)
+    except (ValueError, FileNotFoundError) as exc:
+        result.errors.append(str(exc))
+        return result
+
+    result.watcher_count = len(config.watchers)
+
+    try:
+        with open(config_path) as f:
+            raw = yaml.safe_load(f) or {}
+    except OSError as exc:
+        result.errors.append(f"Could not re-read {config_path}: {exc}")
+        return result
+
+    result.entry_count = len(raw.get("watchers") or [])
+
+    _check_connectors(config, result)
+    _check_state_orphans(config, result)
+    if lint:
+        _lint_config(raw, result)
+
+    return result
+
+
+def _check_connectors(config: GatewayConfig, result: ValidationResult) -> None:
+    """Instantiate each connector's own config dataclass and flag empty
+    credentials — fields from_connector_config defaults to "" rather than
+    validating."""
+    for connector in config.connectors:
+        validator = _CONNECTOR_VALIDATORS.get(connector.type)
+        if validator is None:
+            continue
+        try:
+            cfg = validator(connector)
+        except ValueError as exc:
+            result.errors.append(f"Connector '{connector.name}' ({connector.type}): {exc}")
+            continue
+
+        if connector.type == "rocketchat":
+            if not cfg.server_url:
+                result.errors.append(f"Connector '{connector.name}': server.url is empty")
+            if not cfg.username:
+                result.errors.append(f"Connector '{connector.name}': server.username is empty")
+            if not cfg.password:
+                result.errors.append(f"Connector '{connector.name}': server.password is empty")
+        elif connector.type == "mattermost":
+            if not cfg.server_url:
+                result.errors.append(f"Connector '{connector.name}': server.url is empty")
+            if not cfg.team:
+                result.errors.append(f"Connector '{connector.name}': server.team is empty")
+
+
+def _check_state_orphans(config: GatewayConfig, result: ValidationResult) -> None:
+    """Warn when a connector's persisted state.<connector>.json references a
+    watcher name no longer present in the (expanded) config."""
+    configured_by_connector: dict[str, set[str]] = {}
+    for w in config.watchers:
+        configured_by_connector.setdefault(w.connector, set()).add(w.name)
+
+    for connector in config.connectors:
+        try:
+            states = load_state(connector.name)
+        except Exception:
+            continue
+        configured = configured_by_connector.get(connector.name, set())
+        for st in states:
+            if st.watcher_name not in configured:
+                result.warnings.append(
+                    f"Connector '{connector.name}': state.json has watcher "
+                    f"'{st.watcher_name}' with no matching entry in this config — "
+                    "its session/pause state will be dropped on next start. "
+                    "Restore the old watcher name (e.g. an explicit 'name:') "
+                    "if you want to keep it."
+                )
+
+
+def _lint_config(raw: dict, result: ValidationResult) -> None:
+    agent_defaults = _extract_defaults_block(raw, "agent_defaults", frozenset())
+    watcher_defaults = _extract_defaults_block(
+        raw, "watcher_defaults", frozenset({"name", "room", "rooms", "session_id"})
+    )
+    connector_defaults = _extract_defaults_block(raw, "connector_defaults", frozenset({"name"}))
+
+    for agent_name, agent_raw in (raw.get("agents") or {}).items():
+        if isinstance(agent_raw, dict):
+            _lint_entry(
+                f"agents.{agent_name}", agent_raw, "agent_defaults", agent_defaults,
+                _AGENT_LINT_DEFAULTS, result,
+            )
+
+    for i, wc in enumerate(raw.get("watchers") or []):
+        if isinstance(wc, dict):
+            label = wc.get("name") or f"watchers[{i}]"
+            _lint_entry(
+                f"watchers.{label}", wc, "watcher_defaults", watcher_defaults,
+                _WATCHER_LINT_DEFAULTS, result,
+            )
+
+    for cc in raw.get("connectors") or []:
+        if not isinstance(cc, dict):
+            continue
+        name = cc.get("name") or "?"
+        _lint_entry(
+            f"connectors.{name}", cc, "connector_defaults", connector_defaults,
+            _CONNECTOR_LINT_DEFAULTS, result,
+        )
+        attach = cc.get("attachments")
+        if isinstance(attach, dict):
+            if attach.get("max_file_size_mb") == 10:
+                result.lint_findings.append(
+                    f"connectors.{name}.attachments.max_file_size_mb: restates the "
+                    "built-in default (10) — can be omitted."
+                )
+            if attach.get("download_timeout") == 30:
+                result.lint_findings.append(
+                    f"connectors.{name}.attachments.download_timeout: restates the "
+                    "built-in default (30) — can be omitted."
+                )
+
+
+def _lint_entry(
+    label: str,
+    entry: dict,
+    defaults_block_name: str,
+    defaults_block: dict,
+    default_table: list[tuple[str, object]],
+    result: ValidationResult,
+) -> None:
+    for key, default_value in default_table:
+        if key not in entry:
+            continue
+        if entry[key] == default_value:
+            result.lint_findings.append(
+                f"{label}.{key}: restates the built-in default ({default_value!r}) — "
+                "can be omitted."
+            )
+        elif key in defaults_block and entry[key] == defaults_block[key]:
+            result.lint_findings.append(
+                f"{label}.{key}: matches the inherited {defaults_block_name}.{key} "
+                f"value ({entry[key]!r}) — can be omitted from this entry."
+            )

--- a/gateway/core/config.py
+++ b/gateway/core/config.py
@@ -212,8 +212,8 @@ class WatcherConfig:
     agent: str                                       # must match an AgentConfig.name
     session_id: str | None = None                    # sticky session ID; None = auto-create
     context_inject_files: list[str] = field(default_factory=list)  # watcher-level context (layer 3)
-    online_notification: str | None = "✅ _Agent online_"   # message text on startup; None = suppress
-    offline_notification: str | None = "❌ _Agent offline_" # message text on shutdown; None = suppress
+    online_notification: str | None = None   # message text on startup; None = suppress (default: quiet)
+    offline_notification: str | None = None  # message text on shutdown; None = suppress (default: quiet)
     history_handoff: HistoryHandoffConfig = field(default_factory=HistoryHandoffConfig)  # session context recovery
 
 

--- a/gateway/onboard.py
+++ b/gateway/onboard.py
@@ -82,11 +82,18 @@ def generate_config_yaml(
         connector_type: ``"rocketchat"`` (only supported type currently).
         connector_data: Connector-specific fields (owners, server_url, …).
         watchers: List of ``{"name": ..., "room": ...}`` dicts.
-        working_directory: Absolute path to the opencode project directory.
-            Only used when ``agent_type == "opencode"``; ignored otherwise.
+        working_directory: Absolute path to the agent's working directory.
+            ``GatewayConfig.from_file`` requires every agent to have one
+            (checked at config load, regardless of backend) — the caller
+            (``run_onboard``) is responsible for always providing one, not
+            just for opencode.
     """
     owners = connector_data.get("owners", [])
 
+    # Fields matching the built-in dataclass defaults (attachments size/timeout,
+    # reply_in_thread, permission_reply_in_thread, context_inject_files: []) are
+    # intentionally omitted — restating a default adds noise without changing
+    # behavior. Only deliberate, non-default choices are written out.
     connector = {
         "name": "rc-home",
         "type": "rocketchat",
@@ -99,51 +106,40 @@ def generate_config_yaml(
             "owners": list(owners),
             "guests": [],
         },
-        "attachments": {
-            "max_file_size_mb": 10,
-            "download_timeout": 30,
-        },
-        "reply_in_thread": False,
-        "permission_reply_in_thread": True,
-        "context_inject_files": [],  # built-in context files are auto-injected; add user files here
     }
 
     agent_command = agent_type  # "claude" or "opencode"
     agent: dict = {
         "type": agent_type,
         "command": agent_command,
-        "session_prefix": "agent-chat",
-        "context_inject_files": [],
-        "owner_allowed_tools": [],
-        "guest_allowed_tools": [],
-        "timeout": 360,
+        # Permission gating defaults to on for a fresh setup — this is a
+        # deliberate safety choice, not a restated default (AgentConfig
+        # defaults permissions.enabled to False), so it stays explicit.
         "permissions": {
             "enabled": True,
             "timeout": 300,
         },
     }
-    # opencode requires an explicit working_directory so it can find
-    # .opencode/opencode.json (and the role-enforcement plugin).
-    if agent_type == "opencode" and working_directory:
+    # Required for every backend — GatewayConfig.from_file rejects an agent
+    # with no working_directory regardless of type. opencode additionally
+    # needs this to find .opencode/opencode.json and the role-enforcement
+    # plugin; claude just needs a cwd to run in and create files under.
+    if working_directory:
         agent["working_directory"] = working_directory
 
-    watcher_list = []
-    for w in watchers:
-        watcher_list.append({
-            "name": w["name"],
-            "connector": "rc-home",
-            "room": w["room"],
-            "agent": "my-agent",
-            "session_id": None,
-            "context_inject_files": [],
-            "online_notification": "✅ _Agent online_",
-            "offline_notification": "❌ _Agent offline_",
-        })
+    # Group every wizard-collected room into a single watcher entry via
+    # `rooms:` — the gateway expands it into one watcher per room and derives
+    # each watcher's name from connector+room automatically at load time.
+    watcher_entry = {
+        "connector": "rc-home",
+        "agent": "my-agent",
+        "rooms": [w["room"] for w in watchers],
+    }
 
     config = {
         "connectors": [connector],
         "agents": {"my-agent": agent},
-        "watchers": watcher_list,
+        "watchers": [watcher_entry],
     }
 
     return yaml.dump(config, default_flow_style=False, allow_unicode=True, sort_keys=False)
@@ -469,18 +465,23 @@ def run_onboard(repo_path: Path | None = None) -> None:
 
     credentials = _step_rocketchat_credentials()
 
-    # opencode needs a working directory for its config + plugin.
-    opencode_working_dir: Path | None = None
+    # Every agent needs a working_directory (GatewayConfig.from_file requires
+    # it regardless of backend). opencode additionally needs it to find
+    # .opencode/opencode.json and the role-enforcement plugin, so it gets an
+    # explicit interactive step; claude just needs a cwd to run in, so it
+    # defaults quietly to ~/.agent-chat-gateway/work (created if missing).
     if agent_type == "opencode":
-        opencode_working_dir = _step_opencode_working_dir()
+        working_dir = _step_opencode_working_dir()
+    else:
+        working_dir = RUNTIME_DIR / "work"
+        working_dir.mkdir(parents=True, exist_ok=True)
 
     watchers = _step_watchers(credentials["owners"])
 
     # Summary
     console.print("\n[bold cyan]Summary[/bold cyan]")
     console.print(f"  Agent backend : [bold]{agent_type}[/bold]")
-    if opencode_working_dir:
-        console.print(f"  Working dir   : {opencode_working_dir}")
+    console.print(f"  Working dir   : {working_dir}")
     console.print(f"  Connector     : [bold]{connector_type}[/bold]")
     console.print(f"  Server URL    : {credentials['server_url']}")
     console.print(f"  Bot username  : {credentials['bot_username']}")
@@ -495,10 +496,9 @@ def run_onboard(repo_path: Path | None = None) -> None:
     # Write files
     RUNTIME_DIR.mkdir(parents=True, exist_ok=True)
 
-    working_dir_str = str(opencode_working_dir) if opencode_working_dir else None
     config_yaml = generate_config_yaml(
         agent_type, connector_type, credentials, watchers,
-        working_directory=working_dir_str,
+        working_directory=str(working_dir),
     )
     CONFIG_FILE.write_text(config_yaml)
     console.print(f"\n  [green]✓[/green] Wrote {CONFIG_FILE}")

--- a/gateway/schema/config.schema.json
+++ b/gateway/schema/config.schema.json
@@ -1,0 +1,211 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/HammerMei/agent-chat-gateway/main/gateway/schema/config.schema.json",
+  "title": "agent-chat-gateway config.yaml",
+  "description": "Hand-written schema for editor autocomplete / typo-checking of config.yaml. It intentionally does NOT re-validate every connector-type-specific field (server/allowed_users/attachments/agent_chain vary by connector 'type') — that stays the job of `acg config validate`. See docs/migration-0.2.md for the format this schema describes (v0.2+: connector_defaults/agent_defaults/watcher_defaults, tool_presets, watcher rooms:).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["connectors", "agents"],
+  "properties": {
+    "tool_presets": {
+      "type": "object",
+      "description": "Named, reusable lists of inline tool rules. Reference a preset by name from owner_allowed_tools/guest_allowed_tools. A preset's own list may only contain inline rules (no preset-of-presets).",
+      "additionalProperties": {
+        "type": "array",
+        "items": { "$ref": "#/$defs/toolRule" }
+      }
+    },
+    "connector_defaults": {
+      "type": "object",
+      "description": "Deep-merged into every connector entry below (the entry's own fields win on conflict). Must not set 'name' — that identifies a specific connector.",
+      "not": { "required": ["name"] }
+    },
+    "agent_defaults": {
+      "type": "object",
+      "description": "Deep-merged into every entry under 'agents:' (the entry's own fields win on conflict)."
+    },
+    "watcher_defaults": {
+      "type": "object",
+      "description": "Deep-merged into every watcher entry below (the entry's own fields win on conflict). Must not set 'name', 'room', 'rooms', or 'session_id' — those identify a specific watcher.",
+      "not": {
+        "anyOf": [
+          { "required": ["name"] },
+          { "required": ["room"] },
+          { "required": ["rooms"] },
+          { "required": ["session_id"] }
+        ]
+      }
+    },
+    "connectors": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/connector" }
+    },
+    "agents": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": { "$ref": "#/$defs/agent" }
+    },
+    "default_agent": {
+      "type": "string",
+      "description": "Name of the agent used when a watcher omits 'agent:'. Defaults to the first agent defined."
+    },
+    "watchers": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/watcher" }
+    },
+    "max_queue_depth": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Max pending messages per room queue; 0 = unbounded."
+    },
+    "scheduler": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "completed_job_ttl_days": { "type": "integer", "minimum": 0 }
+      }
+    }
+  },
+  "$defs": {
+    "toolRule": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["tool"],
+      "properties": {
+        "tool": {
+          "type": "string",
+          "description": "Regex matched against the tool name (case-insensitive, fullmatch)."
+        },
+        "params": {
+          "type": "string",
+          "description": "Optional regex matched against the tool's primary parameter (command / url / file_path / full JSON, depending on the tool)."
+        }
+      }
+    },
+    "toolEntry": {
+      "description": "Either the name of a 'tool_presets:' entry (string), or an inline tool rule (object). The two forms may be freely mixed in one list.",
+      "oneOf": [
+        { "type": "string" },
+        { "$ref": "#/$defs/toolRule" }
+      ]
+    },
+    "permissions": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "timeout": { "type": "integer", "minimum": 0 },
+        "skip_owner_approval": { "type": "boolean" }
+      }
+    },
+    "historyHandoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": { "type": "boolean" },
+        "fetch_count": { "type": "integer", "minimum": 0 },
+        "verbatim_tail": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "connector": {
+      "type": "object",
+      "description": "additionalProperties is intentionally left open — server/allowed_users/attachments/agent_chain and other fields vary by connector 'type' (rocketchat/mattermost/voice/script) and are validated by each connector's own config parser, not by this schema.",
+      "required": ["name", "type"],
+      "properties": {
+        "name": { "type": "string" },
+        "type": {
+          "type": "string",
+          "enum": ["rocketchat", "mattermost", "voice", "script"]
+        },
+        "context_inject_files": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    },
+    "agent": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["claude", "opencode"]
+        },
+        "command": { "type": "string" },
+        "new_session_args": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "working_directory": {
+          "type": "string",
+          "description": "Required (directly or via agent_defaults); must exist on disk when the gateway loads."
+        },
+        "session_prefix": { "type": "string" },
+        "lazy_instruction_loading": { "type": "boolean" },
+        "context_inject_files": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "owner_allowed_tools": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/toolEntry" }
+        },
+        "guest_allowed_tools": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/toolEntry" }
+        },
+        "timeout": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Must be greater than permissions.timeout."
+        },
+        "permissions": { "$ref": "#/$defs/permissions" }
+      }
+    },
+    "watcher": {
+      "type": "object",
+      "additionalProperties": false,
+      "allOf": [
+        {
+          "anyOf": [
+            { "required": ["room"] },
+            { "required": ["rooms"] }
+          ]
+        },
+        {
+          "not": { "required": ["room", "rooms"] }
+        }
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Only allowed when the entry has exactly one room; auto-derived from connector+room otherwise."
+        },
+        "connector": { "type": "string" },
+        "room": {
+          "type": "string",
+          "description": "Exactly one room; alias for rooms: [<room>]."
+        },
+        "rooms": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Bind this connector+agent pair to several rooms at once; expands into one watcher per room."
+        },
+        "agent": { "type": "string" },
+        "session_id": {
+          "type": ["string", "null"],
+          "description": "Only allowed when the entry has exactly one room."
+        },
+        "context_inject_files": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "online_notification": { "type": ["string", "null"] },
+        "offline_notification": { "type": ["string", "null"] },
+        "history_handoff": { "$ref": "#/$defs/historyHandoff" }
+      }
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "coverage>=7.13.5",
+    "jsonschema>=4.23.0",
     "pytest>=9.0.2",
     "pytest-cov>=7.1.0",
     "pytest-timeout>=2.3",

--- a/tests/e2e/acg-config/config.yaml
+++ b/tests/e2e/acg-config/config.yaml
@@ -30,15 +30,25 @@ connectors:
     permission_reply_in_thread: false
     context_inject_files: []  # rc-gateway-context.md is auto-injected by ACG at layer 0
 
+# All four agents below share the same working_directory/timeout/permissions/
+# guest_allowed_tools — only type/command/session_prefix/owner_allowed_tools differ.
+agent_defaults:
+  new_session_args: []
+  context_inject_files: []
+  working_directory: /root/.agent-chat-gateway/work
+  guest_allowed_tools: []
+  timeout: 180
+  permissions:
+    enabled: true
+    timeout: 60
+    skip_owner_approval: false
+
 agents:
   # ── OpenCode — bound to DM ────────────────────────────────────────────────
   e2e-opencode:
     type: opencode
     command: opencode
-    new_session_args: []
     session_prefix: e2e-oc
-    context_inject_files: []
-    working_directory: /root/.agent-chat-gateway/work
     owner_allowed_tools:
       - tool: "read"
       - tool: "glob"
@@ -46,103 +56,58 @@ agents:
       - tool: "write"
       - tool: "external_directory"
       - tool: "bash"
-    guest_allowed_tools: []
-    timeout: 180
-    permissions:
-      enabled: true
-      timeout: 60
-      skip_owner_approval: false
 
   # ── Claude Code — bound to team channel ───────────────────────────────────
   e2e-claude:
     type: claude
     command: claude
-    new_session_args: []
     session_prefix: e2e-cc
-    context_inject_files: []
-    working_directory: /root/.agent-chat-gateway/work
     owner_allowed_tools:
       - tool: "Read"
       - tool: "Glob"
       - tool: "Grep"
       - tool: "Write"
       - tool: "Bash"
-    guest_allowed_tools: []
-    timeout: 180
-    permissions:
-      enabled: true
-      timeout: 60
-      skip_owner_approval: false
 
   # ── Claude Code — permission test only (empty allowlist) ──────────────────
   e2e-claude-permission:
     type: claude
     command: claude
-    new_session_args: []
     session_prefix: e2e-perm
-    context_inject_files: []
-    working_directory: /root/.agent-chat-gateway/work
-    owner_allowed_tools: []
-    guest_allowed_tools: []
-    timeout: 180
-    permissions:
-      enabled: true
-      timeout: 60
-      skip_owner_approval: false
 
   # ── OpenCode — permission test only (empty allowlist) ─────────────────────
   e2e-opencode-permission:
     type: opencode
     command: opencode
-    new_session_args: []
     session_prefix: e2e-oc-perm
-    context_inject_files: []
-    working_directory: /root/.agent-chat-gateway/work
-    owner_allowed_tools: []
-    guest_allowed_tools: []
-    timeout: 180
-    permissions:
-      enabled: true
-      timeout: 60
-      skip_owner_approval: false
+
+# All watchers share the same connector and an empty context_inject_files list.
+# session_id and online/offline_notification are omitted entirely — they now
+# default to null (auto-create session / quiet) so there's nothing to state.
+# Explicit 'name:' is kept on every entry (rather than relying on rooms:
+# auto-naming) because tests/e2e/test_schedule_e2e.py references watcher names
+# 'e2e-dm' and 'e2e-claude-channel' literally.
+watcher_defaults:
+  connector: rc-e2e
+  context_inject_files: []
 
 watchers:
   # DM: test_user ↔ acg_bot → OpenCode
   - name: e2e-dm
-    connector: rc-e2e
     room: "@test_user"
     agent: e2e-opencode
-    session_id: null
-    context_inject_files: []
-    online_notification: null
-    offline_notification: null
 
   # Team channel → Claude Code
   - name: e2e-claude-channel
-    connector: rc-e2e
     room: "acg-e2e-claude"
     agent: e2e-claude
-    session_id: null
-    context_inject_files: []
-    online_notification: null
-    offline_notification: null
 
   # Permission test channel → Claude Code (empty allowlist)
   - name: e2e-permission
-    connector: rc-e2e
     room: "acg-e2e-permission"
     agent: e2e-claude-permission
-    session_id: null
-    context_inject_files: []
-    online_notification: null
-    offline_notification: null
 
   # Permission test channel → OpenCode (empty allowlist)
   - name: e2e-opencode-permission
-    connector: rc-e2e
     room: "acg-e2e-opencode-permission"
     agent: e2e-opencode-permission
-    session_id: null
-    context_inject_files: []
-    online_notification: null
-    offline_notification: null

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -15,6 +15,7 @@ import json
 import shutil
 import socket
 import tempfile
+import textwrap
 import threading
 import time
 import unittest
@@ -177,6 +178,182 @@ class TestCLIInstructions(_CLITestBase):
         self.assertEqual(stderr, "")
         self.assertIn("# fetch-history", stdout)
         self.assertIn("agent-chat-gateway fetch-history", stdout)
+
+
+# ---------------------------------------------------------------------------
+# Tests: config validate command
+# ---------------------------------------------------------------------------
+
+class TestCLIConfigValidate(_CLITestBase):
+    """config validate: validate config.yaml without contacting the daemon.
+
+    gateway.core.state.RUNTIME_DIR is patched to a per-test temp dir in every
+    case — otherwise the state-orphan check would read this machine's real
+    ~/.agent-chat-gateway/state.*.json files and make the test non-hermetic.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.agent_dir = Path(self.tmp) / "work"
+        self.agent_dir.mkdir()
+        self.runtime_dir = Path(self.tmp) / "runtime"
+
+    def _write(self, yaml_text: str) -> str:
+        path = Path(self.tmp) / "config.yaml"
+        path.write_text(textwrap.dedent(yaml_text))
+        return str(path)
+
+    def _run_validate(self, extra_args: list[str] | None = None, config_path: str | None = None):
+        args = ["config", "validate", "--config", config_path] + (extra_args or [])
+        with patch("gateway.core.state.RUNTIME_DIR", self.runtime_dir):
+            return self._run(args)
+
+    def test_valid_config_exits_zero(self):
+        cfg_path = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        stdout, stderr, code = self._run_validate(config_path=cfg_path)
+
+        self.assertEqual(code, 0)
+        self.assertEqual(stderr, "")
+        self.assertIn("✓", stdout)
+        self.assertIn("1 watcher(s)", stdout)
+
+    def test_missing_working_directory_exits_one(self):
+        cfg_path = self._write("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agents:
+              default:
+                type: claude
+            watchers:
+              - name: w1
+                room: general
+        """)
+        stdout, stderr, code = self._run_validate(config_path=cfg_path)
+
+        self.assertEqual(code, 1)
+        self.assertIn("working_directory is required", stderr)
+
+    def test_empty_rocketchat_credentials_flagged_as_errors(self):
+        """from_connector_config silently defaults server.url/username/password
+        to "" — config_validate.py must catch what from_file alone does not."""
+        cfg_path = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        stdout, stderr, code = self._run_validate(config_path=cfg_path)
+
+        self.assertEqual(code, 1)
+        self.assertIn("server.url is empty", stderr)
+        self.assertIn("server.username is empty", stderr)
+        self.assertIn("server.password is empty", stderr)
+
+    def test_lint_flags_redundant_default(self):
+        cfg_path = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+                timeout: 360
+            watchers:
+              - name: w1
+                room: general
+        """)
+        stdout, stderr, code = self._run_validate(["--lint"], config_path=cfg_path)
+
+        self.assertEqual(code, 0)
+        self.assertIn("agents.default.timeout", stdout)
+        self.assertIn("restates the built-in default", stdout)
+
+    def test_lint_with_no_findings_says_so(self):
+        cfg_path = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        stdout, stderr, code = self._run_validate(["--lint"], config_path=cfg_path)
+
+        self.assertEqual(code, 0)
+        self.assertIn("no redundant defaults found", stdout)
+
+    def test_rooms_expansion_reflected_in_summary(self):
+        cfg_path = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - connector: rc
+                rooms: [general, dev]
+        """)
+        stdout, stderr, code = self._run_validate(config_path=cfg_path)
+
+        self.assertEqual(code, 0)
+        self.assertIn("2 watcher(s)", stdout)
+        self.assertIn("expanded from 1 entries", stdout)
+
+    def test_state_orphan_produces_warning(self):
+        cfg_path = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        self.runtime_dir.mkdir()
+        (self.runtime_dir / "state.rc.json").write_text(json.dumps({
+            "watchers": [{"watcher_name": "stale-watcher", "session_id": "x", "room_id": "y"}]
+        }))
+
+        stdout, stderr, code = self._run_validate(config_path=cfg_path)
+
+        self.assertEqual(code, 0)
+        self.assertIn("stale-watcher", stdout)
+        self.assertIn("dropped on next start", stdout)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_config_loading.py
+++ b/tests/unit/test_config_loading.py
@@ -12,10 +12,12 @@ Run with:
 
 from __future__ import annotations
 
+import os
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from gateway.config import GatewayConfig
 
@@ -84,6 +86,25 @@ class TestWorkingDirectoryValidation(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             GatewayConfig.from_file(path)
         self.assertIn("lazy_instruction_loading", str(ctx.exception))
+
+    def test_tilde_working_directory_is_expanded(self):
+        """Regression: working_directory: ~/foo must expand to the user's home
+        directory, not be treated as a literal relative path segment named
+        '~' under the config file's directory (config.example.yaml and the
+        install-agent.md walkthroughs document `~/...` working_directory
+        values, so this must actually work)."""
+        with tempfile.TemporaryDirectory() as home_dir:
+            subdir = Path(home_dir) / "agent-work"
+            subdir.mkdir()
+            path = self._write_config(
+                "default:\n  type: claude\n  working_directory: ~/agent-work"
+            )
+            with patch.dict(os.environ, {"HOME": home_dir}):
+                config = GatewayConfig.from_file(path)
+            self.assertEqual(
+                config.agents["default"].working_directory,
+                str(subdir),
+            )
 
     def test_relative_directory_resolved_to_config_dir(self):
         """A relative working_directory is resolved relative to the config file's directory."""
@@ -193,7 +214,7 @@ class TestConfigValidationHardening(unittest.TestCase):
         """)
         with self.assertRaises(ValueError) as ctx:
             GatewayConfig.from_file(path)
-        self.assertIn("must have a non-empty 'room' field", str(ctx.exception))
+        self.assertIn("must have a non-empty 'room' or 'rooms' field", str(ctx.exception))
 
     def test_negative_max_queue_depth_raises(self):
         path = self._write_config("""\
@@ -957,6 +978,638 @@ class TestBuildAgentBackendUsesEffectiveMethods(unittest.TestCase):
             any("fetch-history" in (p or "") for p in guest_params),
             f"Built-in fetch-history rule missing from broker guest_allowed_tools: {guest_params}",
         )
+
+
+# ── Tests: _deep_merge helper ─────────────────────────────────────────────────
+
+
+class TestDeepMerge(unittest.TestCase):
+    """Unit tests for the private _deep_merge helper used by *_defaults blocks."""
+
+    def setUp(self):
+        from gateway.config import _deep_merge
+
+        self._deep_merge = _deep_merge
+
+    def test_nested_dicts_merge_recursively(self):
+        base = {"server": {"url": "http://x", "username": "bot"}}
+        override = {"server": {"username": "override-bot"}}
+        merged = self._deep_merge(base, override)
+        self.assertEqual(
+            merged, {"server": {"url": "http://x", "username": "override-bot"}}
+        )
+
+    def test_lists_replace_not_append(self):
+        base = {"tools": [{"tool": "Read"}, {"tool": "Grep"}]}
+        override = {"tools": [{"tool": "Write"}]}
+        merged = self._deep_merge(base, override)
+        self.assertEqual(merged["tools"], [{"tool": "Write"}])
+
+    def test_explicit_null_override_suppresses_default(self):
+        base = {"timezone": "America/Los_Angeles"}
+        override = {"timezone": None}
+        merged = self._deep_merge(base, override)
+        self.assertIsNone(merged["timezone"])
+
+    def test_scalar_override_wins(self):
+        merged = self._deep_merge({"timeout": 360}, {"timeout": 30})
+        self.assertEqual(merged["timeout"], 30)
+
+    def test_result_does_not_alias_base_or_override(self):
+        base = {"attachments": {"cache_dir_global": "shared"}}
+        override = {}
+        merged_a = self._deep_merge(base, override)
+        merged_b = self._deep_merge(base, override)
+        self.assertIsNot(merged_a["attachments"], merged_b["attachments"])
+        self.assertIsNot(merged_a["attachments"], base["attachments"])
+        # Mutating one merged result must not affect the other or the shared base.
+        merged_a["attachments"]["cache_dir_global"] = "mutated"
+        self.assertEqual(merged_b["attachments"]["cache_dir_global"], "shared")
+        self.assertEqual(base["attachments"]["cache_dir_global"], "shared")
+
+
+# ── Tests: connector_defaults / agent_defaults / watcher_defaults ────────────
+
+
+class TestConnectorDefaults(unittest.TestCase):
+    def _write_config(self, body: str) -> str:
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(textwrap.dedent(body))
+            return f.name
+
+    def test_connector_inherits_defaults(self):
+        path = self._write_config("""\
+            connector_defaults:
+              type: rocketchat
+              server: {url: http://localhost:3000, username: bot, password: pw}
+            connectors:
+              - name: rc1
+              - name: rc2
+                server: {username: bot2}
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watchers:
+              - name: w1
+                room: general
+        """)
+        config = GatewayConfig.from_file(path)
+        rc1, rc2 = config.connectors[0], config.connectors[1]
+        self.assertEqual(rc1.type, "rocketchat")
+        self.assertEqual(rc1.raw["server"]["username"], "bot")
+        # rc2 overrides only username; url/password still inherited from defaults.
+        self.assertEqual(rc2.raw["server"]["username"], "bot2")
+        self.assertEqual(rc2.raw["server"]["url"], "http://localhost:3000")
+        self.assertEqual(rc2.raw["server"]["password"], "pw")
+
+    def test_connector_defaults_forbids_name(self):
+        path = self._write_config("""\
+            connector_defaults:
+              name: not-allowed
+            connectors:
+              - name: rc1
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watchers:
+              - name: w1
+                room: general
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("connector_defaults", str(ctx.exception))
+        self.assertIn("name", str(ctx.exception))
+
+    def test_connector_defaults_must_be_mapping(self):
+        path = self._write_config("""\
+            connector_defaults: not-a-mapping
+            connectors:
+              - name: rc1
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watchers:
+              - name: w1
+                room: general
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("connector_defaults", str(ctx.exception))
+
+    def test_attachments_cache_dir_global_default_not_aliased_across_connectors(self):
+        """Regression: cache_dir_global resolution mutates the connector's raw dict
+        in place. Without a deep-copying merge, two connectors sharing
+        connector_defaults.attachments would alias the same nested dict, and
+        resolving/mutating it for the first connector would corrupt the second."""
+        path = self._write_config("""\
+            connector_defaults:
+              type: rocketchat
+              server: {url: http://localhost:3000, username: bot, password: pw}
+              attachments:
+                cache_dir_global: shared-cache
+            connectors:
+              - name: rc1
+              - name: rc2
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watchers:
+              - name: w1
+                room: general
+        """)
+        config = GatewayConfig.from_file(path)
+        a = config.connectors[0].raw["attachments"]
+        b = config.connectors[1].raw["attachments"]
+        self.assertIsNot(a, b)
+        self.assertEqual(a["cache_dir_global"], b["cache_dir_global"])
+        a["cache_dir_global"] = "mutated"
+        self.assertNotEqual(b["cache_dir_global"], "mutated")
+
+
+class TestAgentDefaults(unittest.TestCase):
+    def _write_config(self, body: str) -> str:
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(textwrap.dedent(body))
+            return f.name
+
+    def test_agent_inherits_defaults(self):
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agent_defaults:
+              type: claude
+              working_directory: /tmp
+              timeout: 500
+            agents:
+              default: {}
+              other:
+                timeout: 42
+            watchers:
+              - name: w1
+                room: general
+        """)
+        config = GatewayConfig.from_file(path)
+        self.assertEqual(config.agents["default"].working_directory, "/tmp")
+        self.assertEqual(config.agents["default"].timeout, 500)
+        # 'other' overrides timeout but still inherits working_directory/type.
+        self.assertEqual(config.agents["other"].timeout, 42)
+        self.assertEqual(config.agents["other"].working_directory, "/tmp")
+
+    def test_agent_defaults_permissions_deep_merge(self):
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agent_defaults:
+              type: claude
+              working_directory: /tmp
+              timeout: 500
+              permissions: {enabled: true, timeout: 300}
+            agents:
+              default:
+                permissions: {timeout: 100}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        config = GatewayConfig.from_file(path)
+        perms = config.agents["default"].permissions
+        # enabled inherited from defaults, timeout overridden by the entry.
+        self.assertTrue(perms.enabled)
+        self.assertEqual(perms.timeout, 100)
+
+    def test_agent_defaults_tool_list_replaces_not_appends(self):
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agent_defaults:
+              type: claude
+              working_directory: /tmp
+              owner_allowed_tools:
+                - tool: Read
+                - tool: Grep
+            agents:
+              default:
+                owner_allowed_tools:
+                  - tool: Write
+            watchers:
+              - name: w1
+                room: general
+        """)
+        config = GatewayConfig.from_file(path)
+        tools = [r.tool for r in config.agents["default"].owner_allowed_tools]
+        self.assertEqual(tools, ["Write"])
+
+
+class TestWatcherDefaults(unittest.TestCase):
+    def _write_config(self, body: str) -> str:
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(textwrap.dedent(body))
+            return f.name
+
+    def test_watcher_inherits_connector_and_agent(self):
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watcher_defaults:
+              connector: rc
+              agent: default
+            watchers:
+              - name: w1
+                room: general
+        """)
+        config = GatewayConfig.from_file(path)
+        wc = config.watchers[0]
+        self.assertEqual(wc.connector, "rc")
+        self.assertEqual(wc.agent, "default")
+
+    def test_watcher_defaults_forbids_identity_fields(self):
+        for key, value in (
+            ("name", "shared-name"),
+            ("room", "general"),
+            ("rooms", ["general"]),
+            ("session_id", "sticky-1"),
+        ):
+            with self.subTest(key=key):
+                path = self._write_config(f"""\
+                    connectors:
+                      - name: rc
+                        type: rocketchat
+                        server: {{url: http://localhost:3000, username: bot, password: pw}}
+                    agents:
+                      default:
+                        type: claude
+                        working_directory: /tmp
+                    watcher_defaults:
+                      {key}: {value!r}
+                    watchers:
+                      - name: w1
+                        room: general
+                """)
+                with self.assertRaises(ValueError) as ctx:
+                    GatewayConfig.from_file(path)
+                self.assertIn("watcher_defaults", str(ctx.exception))
+                self.assertIn(key, str(ctx.exception))
+
+
+# ── Tests: tool_presets ────────────────────────────────────────────────────────
+
+
+class TestToolPresets(unittest.TestCase):
+    def _write_config(self, body: str) -> str:
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(textwrap.dedent(body))
+            return f.name
+
+    def test_preset_reference_resolves_to_rules(self):
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            tool_presets:
+              readonly:
+                - tool: Read
+                - tool: Grep
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+                owner_allowed_tools:
+                  - readonly
+            watchers:
+              - name: w1
+                room: general
+        """)
+        config = GatewayConfig.from_file(path)
+        tools = [r.tool for r in config.agents["default"].owner_allowed_tools]
+        self.assertEqual(tools, ["Read", "Grep"])
+
+    def test_preset_and_inline_rules_are_mixable_and_ordered(self):
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            tool_presets:
+              readonly:
+                - tool: Read
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+                owner_allowed_tools:
+                  - tool: Bash
+                    params: "git .*"
+                  - readonly
+                  - tool: Write
+            watchers:
+              - name: w1
+                room: general
+        """)
+        config = GatewayConfig.from_file(path)
+        tools = [r.tool for r in config.agents["default"].owner_allowed_tools]
+        self.assertEqual(tools, ["Bash", "Read", "Write"])
+
+    def test_unknown_preset_reference_raises(self):
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+                owner_allowed_tools:
+                  - nonexistent
+            watchers:
+              - name: w1
+                room: general
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("unknown tool preset 'nonexistent'", str(ctx.exception))
+
+    def test_preset_referencing_another_preset_raises(self):
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            tool_presets:
+              base:
+                - tool: Read
+              wrapper:
+                - base
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watchers:
+              - name: w1
+                room: general
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("presets cannot reference another preset", str(ctx.exception))
+
+    def test_invalid_preset_rule_raises_even_if_unused(self):
+        """Presets are validated eagerly at load, even if no agent references them."""
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            tool_presets:
+              broken:
+                - tool: '[invalid'
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watchers:
+              - name: w1
+                room: general
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("invalid tool rule", str(ctx.exception).lower())
+
+    def test_invalid_inline_rule_raises_with_agent_and_field_context(self):
+        path = self._write_config("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+                guest_allowed_tools:
+                  - tool: '[invalid'
+            watchers:
+              - name: w1
+                room: general
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        msg = str(ctx.exception)
+        self.assertIn("invalid tool rule", msg.lower())
+        self.assertIn("guest_allowed_tools", msg)
+
+
+# ── Tests: watcher rooms: expansion + auto-naming ─────────────────────────────
+
+
+class TestWatcherRoomsExpansion(unittest.TestCase):
+    def _write_config(self, watchers_block: str) -> str:
+        cfg = textwrap.dedent(f"""\
+            connectors:
+              - name: rc-home
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watchers:
+{textwrap.indent(textwrap.dedent(watchers_block), "              ")}
+        """)
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(cfg)
+            return f.name
+
+    def test_rooms_list_expands_to_one_watcher_per_room(self):
+        path = self._write_config("""\
+            - connector: rc-home
+              rooms: [general, dev, '@alice']
+        """)
+        config = GatewayConfig.from_file(path)
+        names = {w.name: w.room for w in config.watchers}
+        self.assertEqual(
+            names,
+            {
+                "rc-home-general": "general",
+                "rc-home-dev": "dev",
+                "rc-home-dm-alice": "@alice",
+            },
+        )
+
+    def test_room_singular_is_alias_for_single_item_rooms(self):
+        path = self._write_config("""\
+            - connector: rc-home
+              room: general
+        """)
+        config = GatewayConfig.from_file(path)
+        self.assertEqual(len(config.watchers), 1)
+        self.assertEqual(config.watchers[0].name, "rc-home-general")
+        self.assertEqual(config.watchers[0].room, "general")
+
+    def test_room_and_rooms_both_set_raises(self):
+        path = self._write_config("""\
+            - connector: rc-home
+              room: general
+              rooms: [dev]
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("set either 'room' or 'rooms', not both", str(ctx.exception))
+
+    def test_rooms_must_be_non_empty_list(self):
+        path = self._write_config("""\
+            - connector: rc-home
+              rooms: []
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("'rooms' must be a non-empty list", str(ctx.exception))
+
+    def test_rooms_with_duplicate_room_raises(self):
+        path = self._write_config("""\
+            - connector: rc-home
+              rooms: [general, general]
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("duplicate room(s)", str(ctx.exception))
+
+    def test_explicit_name_with_multiple_rooms_raises(self):
+        path = self._write_config("""\
+            - connector: rc-home
+              name: my-watcher
+              rooms: [general, dev]
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn("'name' can only be set when there is exactly one room", str(ctx.exception))
+
+    def test_explicit_session_id_with_multiple_rooms_raises(self):
+        path = self._write_config("""\
+            - connector: rc-home
+              session_id: sticky-1
+              rooms: [general, dev]
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        self.assertIn(
+            "'session_id' can only be set when there is exactly one room",
+            str(ctx.exception),
+        )
+
+    def test_explicit_name_preserved_on_single_room_entry(self):
+        path = self._write_config("""\
+            - connector: rc-home
+              name: general-room
+              room: ops
+        """)
+        config = GatewayConfig.from_file(path)
+        self.assertEqual(config.watchers[0].name, "general-room")
+
+    def test_auto_name_collision_across_entries_raises(self):
+        path = self._write_config("""\
+            - connector: rc-home
+              room: general
+            - connector: rc-home
+              room: general
+        """)
+        with self.assertRaises(ValueError) as ctx:
+            GatewayConfig.from_file(path)
+        msg = str(ctx.exception)
+        self.assertIn("Duplicate watcher name 'rc-home-general'", msg)
+        self.assertIn("set an explicit 'name:' to disambiguate", msg)
+
+    def test_room_sanitization_examples(self):
+        from gateway.config import _auto_watcher_name
+
+        for room, expected_fragment in (
+            ("general", "general"),
+            ("@alice", "dm-alice"),
+            ("team/town-square", "team-town-square"),
+        ):
+            with self.subTest(room=room):
+                self.assertEqual(
+                    _auto_watcher_name("mm", room), f"mm-{expected_fragment}"
+                )
+
+
+# ── Tests: quiet notification defaults ────────────────────────────────────────
+
+
+class TestQuietNotificationDefaults(unittest.TestCase):
+    """Migration-0.2 behavior change: online/offline notifications default to
+    quiet (None) instead of posting '_Agent online_'/'_Agent offline_'."""
+
+    def _write_config(self, watcher_extra: str = "") -> str:
+        cfg = textwrap.dedent(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watchers:
+              - name: w1
+                room: general
+{textwrap.indent(textwrap.dedent(watcher_extra), "                ")}
+        """)
+        with tempfile.NamedTemporaryFile("w", suffix=".yaml", delete=False) as f:
+            f.write(cfg)
+            return f.name
+
+    def test_notifications_default_to_none(self):
+        path = self._write_config()
+        config = GatewayConfig.from_file(path)
+        self.assertIsNone(config.watchers[0].online_notification)
+        self.assertIsNone(config.watchers[0].offline_notification)
+
+    def test_watcher_defaults_can_restore_old_behavior_globally(self):
+        path = self._write_config()
+        # Inject watcher_defaults restoring the pre-0.2 notification text.
+        with open(path) as f:
+            body = f.read()
+        body = body.replace(
+            "connectors:",
+            "watcher_defaults:\n"
+            "  online_notification: '✅ _Agent online_'\n"
+            "  offline_notification: '❌ _Agent offline_'\n"
+            "connectors:",
+            1,
+        )
+        with open(path, "w") as f:
+            f.write(body)
+        config = GatewayConfig.from_file(path)
+        self.assertEqual(config.watchers[0].online_notification, "✅ _Agent online_")
+        self.assertEqual(config.watchers[0].offline_notification, "❌ _Agent offline_")
+
+    def test_explicit_notification_overrides_default(self):
+        path = self._write_config(
+            "online_notification: 'hi there'\noffline_notification: 'bye'"
+        )
+        config = GatewayConfig.from_file(path)
+        self.assertEqual(config.watchers[0].online_notification, "hi there")
+        self.assertEqual(config.watchers[0].offline_notification, "bye")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_config_schema.py
+++ b/tests/unit/test_config_schema.py
@@ -1,0 +1,101 @@
+"""Sync tests for gateway/schema/config.schema.json.
+
+The hand-written JSON Schema is not generated from the dataclasses/parser in
+gateway/config.py, so it can silently drift from the format the parser
+actually accepts. These tests are the drift tripwire: they validate the
+canonical example config and the e2e fixture (both exercised elsewhere by
+GatewayConfig.from_file-style tests) against the schema, and spot-check a
+handful of known-invalid documents to confirm the schema is not accidentally
+too permissive to catch anything at all.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parents[2]
+SCHEMA_PATH = REPO_ROOT / "gateway" / "schema" / "config.schema.json"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    with open(SCHEMA_PATH) as f:
+        return json.load(f)
+
+
+@pytest.fixture(scope="module")
+def validator(schema: dict) -> jsonschema.Draft202012Validator:
+    jsonschema.Draft202012Validator.check_schema(schema)
+    return jsonschema.Draft202012Validator(schema)
+
+
+def _load_yaml(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+class TestSchemaIsValid:
+    def test_schema_is_valid_draft_2020_12(self, schema):
+        # Raises if the schema document itself is malformed.
+        jsonschema.Draft202012Validator.check_schema(schema)
+
+
+class TestExampleAndFixtureConfigsMatchSchema:
+    """The two configs the gateway actually loads elsewhere in the test suite
+    must validate cleanly — if this fails, either the schema drifted from a
+    parser change, or the example/fixture drifted from the documented format."""
+
+    def test_config_example_yaml_is_schema_valid(self, validator):
+        doc = _load_yaml(REPO_ROOT / "config.example.yaml")
+        errors = list(validator.iter_errors(doc))
+        assert not errors, "\n".join(str(e) for e in errors)
+
+    def test_e2e_fixture_config_is_schema_valid(self, validator):
+        doc = _load_yaml(REPO_ROOT / "tests" / "e2e" / "acg-config" / "config.yaml")
+        errors = list(validator.iter_errors(doc))
+        assert not errors, "\n".join(str(e) for e in errors)
+
+
+class TestSchemaCatchesKnownMistakes:
+    """Negative controls — if these stop failing, the schema became too
+    permissive (e.g. a stray additionalProperties: true) to catch anything."""
+
+    @pytest.fixture
+    def base_doc(self) -> dict:
+        return _load_yaml(REPO_ROOT / "config.example.yaml")
+
+    def test_typo_top_level_key_is_rejected(self, validator, base_doc):
+        bad = copy.deepcopy(base_doc)
+        bad["watchres"] = bad.pop("watchers")
+        assert list(validator.iter_errors(bad))
+
+    def test_room_and_rooms_both_set_is_rejected(self, validator, base_doc):
+        bad = copy.deepcopy(base_doc)
+        bad["watchers"][0]["room"] = "oops"
+        assert list(validator.iter_errors(bad))
+
+    def test_typo_in_tool_rule_key_is_rejected(self, validator, base_doc):
+        bad = copy.deepcopy(base_doc)
+        bad["agents"]["my-agent"]["owner_allowed_tools"].append({"toool": "Read"})
+        assert list(validator.iter_errors(bad))
+
+    def test_unknown_connector_type_is_rejected(self, validator, base_doc):
+        bad = copy.deepcopy(base_doc)
+        bad["connectors"][0]["type"] = "rocketchatt"
+        assert list(validator.iter_errors(bad))
+
+    def test_connector_defaults_setting_name_is_rejected(self, validator, base_doc):
+        bad = copy.deepcopy(base_doc)
+        bad["connector_defaults"] = {"name": "not-allowed"}
+        assert list(validator.iter_errors(bad))
+
+    def test_watcher_defaults_setting_session_id_is_rejected(self, validator, base_doc):
+        bad = copy.deepcopy(base_doc)
+        bad["watcher_defaults"] = {"session_id": "not-allowed"}
+        assert list(validator.iter_errors(bad))

--- a/tests/unit/test_config_validate.py
+++ b/tests/unit/test_config_validate.py
@@ -1,0 +1,297 @@
+"""Unit tests for gateway/config_validate.py — the standalone (no-daemon)
+config validation used by `acg config validate`.
+
+CLI-level coverage (argument parsing, output formatting, exit codes) lives in
+tests/integration/test_cli.py::TestCLIConfigValidate. These tests exercise
+validate_config() directly.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from gateway.config_validate import validate_config
+
+
+class _ValidateConfigTestBase(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.agent_dir = Path(self.tmp) / "work"
+        self.agent_dir.mkdir()
+        self.runtime_dir = Path(self.tmp) / "runtime"
+
+    def _write(self, yaml_text: str) -> str:
+        path = Path(self.tmp) / "config.yaml"
+        path.write_text(textwrap.dedent(yaml_text))
+        return str(path)
+
+    def _validate(self, config_path: str, lint: bool = False):
+        with patch("gateway.core.state.RUNTIME_DIR", self.runtime_dir):
+            return validate_config(config_path, lint=lint)
+
+
+class TestValidateConfigBasics(_ValidateConfigTestBase):
+    def test_valid_config_has_no_errors(self):
+        cfg = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg)
+        self.assertTrue(result.ok)
+        self.assertEqual(result.errors, [])
+        self.assertEqual(result.watcher_count, 1)
+        self.assertEqual(result.entry_count, 1)
+
+    def test_nonexistent_file_is_an_error(self):
+        result = self._validate("/nonexistent/config.yaml")
+        self.assertFalse(result.ok)
+        self.assertEqual(len(result.errors), 1)
+
+    def test_from_file_error_is_surfaced_verbatim(self):
+        cfg = self._write("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: http://localhost:3000, username: bot, password: pw}
+            agents:
+              default:
+                type: claude
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg)
+        self.assertFalse(result.ok)
+        self.assertTrue(any("working_directory is required" in e for e in result.errors))
+
+
+class TestValidateConfigConnectorChecks(_ValidateConfigTestBase):
+    def test_empty_rocketchat_server_fields_are_errors(self):
+        cfg = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg)
+        self.assertFalse(result.ok)
+        joined = " ".join(result.errors)
+        self.assertIn("server.url is empty", joined)
+        self.assertIn("server.username is empty", joined)
+        self.assertIn("server.password is empty", joined)
+
+    def test_mattermost_missing_auth_mode_is_an_error(self):
+        """MattermostConfig.__post_init__ already raises when neither token
+        nor username+password is set — config_validate must surface that."""
+        cfg = self._write(f"""\
+            connectors:
+              - name: mm
+                type: mattermost
+                server: {{url: http://localhost:8065, team: home}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg)
+        self.assertFalse(result.ok)
+        self.assertTrue(any("mm" in e for e in result.errors))
+
+    def test_script_connector_is_not_validated(self):
+        """ScriptConnector never reads ConnectorConfig.raw — nothing to check."""
+        cfg = self._write(f"""\
+            connectors:
+              - name: sc
+                type: script
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg)
+        self.assertTrue(result.ok)
+
+
+class TestValidateConfigStateOrphans(_ValidateConfigTestBase):
+    def test_orphaned_state_watcher_produces_warning(self):
+        cfg = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        self.runtime_dir.mkdir()
+        (self.runtime_dir / "state.rc.json").write_text(json.dumps({
+            "watchers": [
+                {"watcher_name": "w1", "session_id": "keep", "room_id": "r1"},
+                {"watcher_name": "stale", "session_id": "x", "room_id": "r2"},
+            ]
+        }))
+        result = self._validate(cfg)
+        self.assertTrue(result.ok)  # orphans are warnings, not errors
+        self.assertEqual(len(result.warnings), 1)
+        self.assertIn("stale", result.warnings[0])
+
+    def test_no_state_file_produces_no_warnings(self):
+        cfg = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg)
+        self.assertEqual(result.warnings, [])
+
+
+class TestValidateConfigLint(_ValidateConfigTestBase):
+    def test_lint_off_by_default(self):
+        cfg = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+                timeout: 360
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg, lint=False)
+        self.assertEqual(result.lint_findings, [])
+
+    def test_lint_flags_agent_field_matching_builtin_default(self):
+        cfg = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+                timeout: 360
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg, lint=True)
+        self.assertTrue(
+            any("agents.default.timeout" in f for f in result.lint_findings)
+        )
+
+    def test_lint_flags_entry_matching_agent_defaults(self):
+        cfg = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agent_defaults:
+              type: claude
+              working_directory: {self.agent_dir}
+              timeout: 500
+            agents:
+              default:
+                timeout: 500
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg, lint=True)
+        self.assertTrue(
+            any(
+                "agents.default.timeout" in f and "agent_defaults" in f
+                for f in result.lint_findings
+            )
+        )
+
+    def test_lint_does_not_flag_deliberate_override(self):
+        cfg = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agent_defaults:
+              type: claude
+              working_directory: {self.agent_dir}
+              timeout: 500
+            agents:
+              default:
+                timeout: 999
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg, lint=True)
+        self.assertEqual(
+            [f for f in result.lint_findings if "agents.default.timeout" in f], []
+        )
+
+    def test_lint_flags_connector_attachment_defaults(self):
+        cfg = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+                attachments:
+                  max_file_size_mb: 10
+                  download_timeout: 30
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        result = self._validate(cfg, lint=True)
+        joined = " ".join(result.lint_findings)
+        self.assertIn("max_file_size_mb", joined)
+        self.assertIn("download_timeout", joined)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -154,15 +154,14 @@ class TestGenerateConfigYaml:
         agent = config["agents"]["my-agent"]
         assert agent["type"] == "claude"
         assert agent["command"] == "claude"
-        assert agent["timeout"] == 360
         assert agent["permissions"]["enabled"] is True
 
+        # A single watcher entry using rooms: — the gateway expands it into
+        # one watcher per room (with an auto-derived name) at load time.
         watcher = config["watchers"][0]
-        assert watcher["name"] == "dm-alice"
-        assert watcher["room"] == "@alice"
         assert watcher["connector"] == "rc-home"
         assert watcher["agent"] == "my-agent"
-        assert watcher["session_id"] is None
+        assert watcher["rooms"] == ["@alice"]
 
     def test_generate_config_yaml_opencode_rocketchat(self):
         """Agent type is correctly set to opencode."""
@@ -182,7 +181,7 @@ class TestGenerateConfigYaml:
         assert agent["command"] == "opencode"
 
     def test_generate_config_yaml_multiple_watchers(self):
-        """Multiple watchers are all present in the output."""
+        """Multiple rooms collapse into one watcher entry's rooms: list."""
         connector_data = {
             "server_url": "https://chat.example.com",
             "bot_username": "bot",
@@ -198,11 +197,8 @@ class TestGenerateConfigYaml:
         result = generate_config_yaml("claude", "rocketchat", connector_data, watchers)
         config = self._parse(result)
 
-        assert len(config["watchers"]) == 3
-        names = [w["name"] for w in config["watchers"]]
-        assert "dm-alice" in names
-        assert "general" in names
-        assert "dev-room" in names
+        assert len(config["watchers"]) == 1
+        assert config["watchers"][0]["rooms"] == ["@alice", "general", "dev"]
 
     def test_generate_config_yaml_multiple_owners(self):
         """Multiple owners are listed in allowed_users.owners."""
@@ -235,29 +231,26 @@ class TestGenerateConfigYaml:
         parsed = yaml.safe_load(result)
         # Round-trip: dump and parse again
         reparsed = yaml.safe_load(yaml.dump(parsed))
-        assert reparsed["agents"]["my-agent"]["timeout"] == 360
+        assert reparsed["agents"]["my-agent"]["permissions"]["timeout"] == 300
 
-    def test_generate_config_yaml_session_id_is_null(self):
-        """session_id renders as null in YAML."""
-        connector_data = {"owners": ["alice"], "server_url": "https://x.com", "bot_username": "b", "bot_password": "p"}
-        watchers = [{"name": "dm-alice", "room": "@alice"}]
-        result = generate_config_yaml("claude", "rocketchat", connector_data, watchers)
-        config = self._parse(result)
-        assert config["watchers"][0]["session_id"] is None
-
-    def test_generate_config_yaml_notifications_present(self):
-        """online_notification and offline_notification are set on each watcher."""
+    def test_generate_config_yaml_omits_boilerplate_fields(self):
+        """The minimal-format output must not restate per-watcher boilerplate
+        (name/session_id/notifications) that the pre-0.2 template used to
+        write out for every watcher — those are now either auto-derived at
+        config-load time or default to quiet/None."""
         connector_data = {"owners": ["alice"], "server_url": "https://x.com", "bot_username": "b", "bot_password": "p"}
         watchers = [{"name": "dm-alice", "room": "@alice"}]
         result = generate_config_yaml("claude", "rocketchat", connector_data, watchers)
         config = self._parse(result)
         w = config["watchers"][0]
-        assert "online_notification" in w
-        assert "offline_notification" in w
+        assert "name" not in w
+        assert "session_id" not in w
+        assert "online_notification" not in w
+        assert "offline_notification" not in w
 
 
 # ---------------------------------------------------------------------------
-# generate_config_yaml — opencode working_directory
+# generate_config_yaml — working_directory
 # ---------------------------------------------------------------------------
 
 class TestGenerateConfigYamlOpencode:
@@ -280,8 +273,10 @@ class TestGenerateConfigYamlOpencode:
         config = self._parse(result)
         assert config["agents"]["my-agent"]["working_directory"] == str(tmp_path)
 
-    def test_working_directory_omitted_for_claude(self, tmp_path: Path):
-        """working_directory is NOT included when agent_type is claude."""
+    def test_working_directory_included_for_claude_when_provided(self, tmp_path: Path):
+        """working_directory is included for claude too when given — omitting it
+        made GatewayConfig.from_file reject every claude config the wizard
+        generated (working_directory is required regardless of backend)."""
         connector_data = {
             "owners": ["alice"],
             "server_url": "https://chat.example.com",
@@ -294,7 +289,7 @@ class TestGenerateConfigYamlOpencode:
             working_directory=str(tmp_path),
         )
         config = self._parse(result)
-        assert "working_directory" not in config["agents"]["my-agent"]
+        assert config["agents"]["my-agent"]["working_directory"] == str(tmp_path)
 
     def test_working_directory_omitted_when_none(self):
         """working_directory absent from agent block when not provided."""
@@ -602,6 +597,13 @@ class TestRunOnboard:
         assert "agents" in config
         assert "watchers" in config
 
+        # claude gets a default working_directory (created on disk) even though
+        # it's never prompted for one — GatewayConfig.from_file requires it
+        # for every backend, not just opencode.
+        expected_work_dir = tmp_path / "work"
+        assert config["agents"]["my-agent"]["working_directory"] == str(expected_work_dir)
+        assert expected_work_dir.is_dir()
+
         # .env has the right keys
         env_text = env_file.read_text()
         assert "RC_URL=https://chat.example.com" in env_text
@@ -611,6 +613,12 @@ class TestRunOnboard:
         # install_meta has method set
         meta = json.loads(meta_file.read_text())
         assert meta["method"] in ("git", "unknown")
+
+        # The generated config must actually load — this is the real
+        # regression check for the "claude working_directory missing" bug.
+        from gateway.config import GatewayConfig
+        loaded = GatewayConfig.from_file(str(config_file))
+        assert loaded.agents["my-agent"].working_directory == str(expected_work_dir)
 
     def test_run_onboard_abort_at_confirm(self, tmp_path: Path):
         """run_onboard exits cleanly when user declines to write files."""

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.12"
 
 [[package]]
 name = "agent-chat-gateway"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "croniter" },
@@ -20,6 +20,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "coverage" },
+    { name = "jsonschema" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
@@ -41,6 +42,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "coverage", specifier = ">=7.13.5" },
+    { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-timeout", specifier = ">=2.3" },
@@ -58,6 +60,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -230,6 +241,33 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -387,6 +425,20 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -397,6 +449,102 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/c6/f3b320c27991c46f43ee9d856302c70dc2d0fb2dba4842ff739d5f46b393/rich-14.3.3.tar.gz", hash = "sha256:b8daa0b9e4eef54dd8cf7c86c03713f53241884e814f4e2f5fb342fe520f639b", size = 230582, upload-time = "2026-02-19T17:23:12.474Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/14/25/b208c5683343959b670dc001595f2f3737e051da617f66c31f7c4fa93abc/rich-14.3.3-py3-none-any.whl", hash = "sha256:793431c1f8619afa7d3b52b2cdec859562b950ea0d4b6b505397612db8d5362d", size = 310458, upload-time = "2026-02-19T17:23:13.732Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Simplifies the recurring pain point of `config.yaml` growing into hundreds
of near-duplicate lines once a deployment has several connectors, agents,
or watchers (motivated by a real ~24-watcher, 8-connector, 4-agent
production config).

- **`connector_defaults` / `agent_defaults` / `watcher_defaults`** — deep-merge
  into every entry of the matching kind (entry wins on conflict)
- **`tool_presets`** — named, reusable tool-rule lists referenced by name from
  `owner_allowed_tools`/`guest_allowed_tools`, mixable with inline rules
- **Watcher `rooms: [a, b, ...]`** — expands one connector+agent pair into
  one watcher per room, auto-naming each `<connector>-<room>`
  (`@user` DM → `<connector>-dm-user`)
- **`online_notification`/`offline_notification` now default to quiet
  (`null`)** instead of posting a status message — the one behavior-breaking
  change, documented in `docs/migration-0.2.md`
- **New `agent-chat-gateway config validate [--lint]`** — checks
  `config.yaml` without starting the daemon: structural validation,
  per-connector-type credential checks (previously only caught lazily at
  daemon start), and a warning when persisted `state.<connector>.json`
  references a watcher no longer in the config
- **JSON Schema** (`gateway/schema/config.schema.json`) for editor
  autocomplete/typo-checking, referenced from `config.example.yaml`
- Onboard wizard updated to emit the new minimal format
- `docs/design/config-tool.md` — decision record for a future
  `textual`-based config editor (direction only, no code yet)

Also fixes two pre-existing bugs surfaced while validating this against the
real-world config that motivated the change:
- `working_directory: ~/...` was never tilde-expanded — a literal `~` path
  silently resolved to a nonexistent nested directory instead of `$HOME`
  (now mirrors the existing `cache_dir_global` handling)
- the onboard wizard never set `working_directory` for the `claude` backend,
  so every `claude` config it generated failed `GatewayConfig.from_file`'s
  required-`working_directory` check

## Real-world verification

- All new config-parsing logic is covered by new unit tests
  (`tests/unit/test_config_loading.py`, `test_config_validate.py`,
  `test_config_schema.py`); full suite is green (1800 tests).
- The real production config (8 connectors, 4 agents, 24 watchers) was
  migrated to the new format and verified two ways:
  - a scripted semantic diff (parse old vs. new through `GatewayConfig` and
    each connector's own config class) showed **zero mismatches** across
    every connector/agent/watcher field
  - `agent-chat-gateway config validate --lint` run directly on the target
    machine with real credentials: `✓ valid — 24 watcher(s) (expanded from
    12 entries)`, zero warnings, zero lint findings
  - that production `config.yaml` and its 8 `state.<connector>.json` files
    have already been migrated in place (watcher names renamed
    `state.json`-side to match, `session_id`/`room_id` untouched) with the
    daemon stopped; a backup of the pre-migration files was taken first

## Test plan

- [x] `make test` / `uv run pytest tests/unit tests/integration` — 1800 passed
- [x] `make lint` / `ruff check` — clean
- [x] `agent-chat-gateway config validate --lint config.example.yaml` — clean
- [x] Real production config migrated + validated on target machine (see above)
- [x] Restart the daemon on the migrated production machine and confirm all
      24 watchers come back up with continuous sessions (deferred to the repo
      owner, since restarting is out of scope for this change)