### PR TITLE
Config TUI: clean up items 9/10/8 from the Phase 1 review

### DIFF
--- a/gateway/configtool/app.py
+++ b/gateway/configtool/app.py
@@ -55,7 +55,7 @@ class ConfigToolApp(App):
         or a manual 'refresh' action) and repaint the active screen."""
         self._load()
         if isinstance(self.screen, OverviewScreen):
-            self.screen.refresh_overview()
+            self.screen.repaint_from_memory()
 
     def open_editor_and_reload(self) -> None:
         """Suspend the TUI, open $EDITOR on config.yaml, resume + reload.

--- a/gateway/configtool/model.py
+++ b/gateway/configtool/model.py
@@ -24,7 +24,7 @@ resolved secrets — passwords, tokens — into config.yaml in plain text.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 
@@ -73,6 +73,23 @@ class EditableConfig:
 
     document: dict
     path: Path
+    # Code review item 8: defaults_block() (and, transitively, merged_entry()/
+    # field_provenance()) re-ran _extract_defaults_block from scratch on
+    # every single call — repaint_from_memory() alone calls it once per
+    # connector/agent/watcher row PLUS once per defaults-table row, all for
+    # the same 3 blocks. Cached here, keyed by kind, invalidated by
+    # load()/reload() (the only two places `document` changes). Not part of
+    # equality/repr — it's a memoization detail, not observable state.
+    # NOTE for whoever adds in-place mutation (Phase 2's save() work, item 7):
+    # this cache is only invalidated by load()/reload() today because nothing
+    # currently mutates `document` any other way. Any future code path that
+    # edits `document` directly (e.g. a form committing a field change) MUST
+    # also clear `_defaults_cache` — Phase 1 also holds this same invariant
+    # implicitly today (its accessors were simply always fresh); this comment
+    # keeps it explicit now that there's a cache to forget.
+    _defaults_cache: dict[str, dict] = field(
+        default_factory=dict, init=False, repr=False, compare=False
+    )
 
     @classmethod
     def load(cls, path: str | Path) -> "EditableConfig":
@@ -99,6 +116,7 @@ class EditableConfig:
         round-trip, or a manual 'refresh' action)."""
         fresh = EditableConfig.load(self.path)
         self.document = fresh.document
+        self._defaults_cache.clear()
 
     # ── Raw entry accessors (pre-merge, as-authored) ─────────────────────────
 
@@ -122,9 +140,13 @@ class EditableConfig:
     def defaults_block(self, kind: str) -> dict:
         """Return the named `*_defaults:` block (description stripped, same
         as the real loader) — 'connector_defaults' | 'agent_defaults' |
-        'watcher_defaults'."""
-        forbidden = _DEFAULTS_FORBIDDEN_KEYS[kind]
-        return _extract_defaults_block(self.document, kind, forbidden)
+        'watcher_defaults'. Cached per kind (see `_defaults_cache`); the
+        underlying `document` never changes except via load()/reload(),
+        both of which invalidate the cache."""
+        if kind not in self._defaults_cache:
+            forbidden = _DEFAULTS_FORBIDDEN_KEYS[kind]
+            self._defaults_cache[kind] = _extract_defaults_block(self.document, kind, forbidden)
+        return self._defaults_cache[kind]
 
     # ── Provenance / effective value (reuses the real merge, never reimplemented) ──
 
@@ -132,7 +154,14 @@ class EditableConfig:
         """`entry_raw` deep-merged against its matching *_defaults block —
         the exact value GatewayConfig.from_file would compute for this one
         entry before its own further per-entry processing (path resolution,
-        tool-preset resolution, etc). Uses the real _deep_merge."""
+        tool-preset resolution, etc). Uses the real _deep_merge.
+
+        Deliberately NOT cached (unlike defaults_block() above): _deep_merge
+        already deep-copies on every call, so it's cheap; caching it would
+        need a key derived from entry_raw's identity, which stops being safe
+        the moment a later phase starts mutating entries in place for
+        editing. defaults_block() is document-scoped and only invalidated by
+        load()/reload(), which is a much simpler invariant to keep correct."""
         return _deep_merge(self.defaults_block(kind), entry_raw)
 
     def field_provenance(self, kind: str, entry_raw: dict, field: str) -> Provenance:

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -16,14 +16,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.containers import VerticalScroll
-from textual.screen import Screen
-from textual.widgets import Footer, Header, Static
-
 from ..formatting import format_value, provenance_label
 from ..model import EditableConfig
+from .base import DetailScreen
 
 # Top-level agent fields worth a dedicated provenance-annotated line, in the
 # same order as AgentConfig's own fields (gateway/core/config.py).
@@ -34,8 +29,8 @@ _KNOWN_FIELDS = [
 ]
 
 
-class AgentDetailScreen(Screen):
-    BINDINGS = [Binding("escape", "back", "Back")]
+class AgentDetailScreen(DetailScreen):
+    BODY_ID = "agent-detail-body"
 
     def __init__(
         self,
@@ -49,11 +44,6 @@ class AgentDetailScreen(Screen):
         self.agent_name = name
         self.entry = entry
         self.mode = mode
-
-    def compose(self) -> ComposeResult:
-        yield Header()
-        yield VerticalScroll(Static(self._body_text(), id="agent-detail-body"))
-        yield Footer()
 
     def _body_text(self) -> str:
         description = self.entry.get("description")
@@ -95,6 +85,3 @@ class AgentDetailScreen(Screen):
                     lines.append(f"  {tool} / {params or '(any)'}")
 
         return "\n".join(lines)
-
-    def action_back(self) -> None:
-        self.app.pop_screen()

--- a/gateway/configtool/screens/base.py
+++ b/gateway/configtool/screens/base.py
@@ -1,0 +1,40 @@
+"""DetailScreen — shared base for the config TUI's detail/entity screens.
+
+Code review (post Phase 1) flagged that ConnectorDetailScreen, AgentDetailScreen,
+WatcherDetailScreen, DefaultsScreen, and ToolPresetsScreen each hand-duplicated
+the same `BINDINGS = [Binding("escape", "back", "Back")]`, the same
+Header/VerticalScroll(Static)/Footer compose() shape, and the same
+`action_back()`. Extracted here so Phase 2's edit/create additions to these
+screens have one place to change navigation/layout, not five. Purely a
+refactor — no behavior change; each subclass keeps its own widget `id` (tests
+query these directly) via `BODY_ID`.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import VerticalScroll
+from textual.screen import Screen
+from textual.widgets import Footer, Header, Static
+
+
+class DetailScreen(Screen):
+    """Base for every pushed detail screen. Subclasses implement `_body_text()`
+    and set `BODY_ID` to the widget id their tests/callers query for.
+    """
+
+    BINDINGS = [Binding("escape", "back", "Back")]
+
+    BODY_ID: str = "detail-body"
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        yield VerticalScroll(Static(self._body_text(), id=self.BODY_ID))
+        yield Footer()
+
+    def _body_text(self) -> str:
+        raise NotImplementedError
+
+    def action_back(self) -> None:
+        self.app.pop_screen()

--- a/gateway/configtool/screens/connector_detail.py
+++ b/gateway/configtool/screens/connector_detail.py
@@ -12,18 +12,13 @@ from __future__ import annotations
 
 from typing import Literal
 
-from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.containers import VerticalScroll
-from textual.screen import Screen
-from textual.widgets import Footer, Header, Static
-
 from ..formatting import mask_if_secret, provenance_label
 from ..model import EditableConfig
+from .base import DetailScreen
 
 
-class ConnectorDetailScreen(Screen):
-    BINDINGS = [Binding("escape", "back", "Back")]
+class ConnectorDetailScreen(DetailScreen):
+    BODY_ID = "connector-detail-body"
 
     def __init__(
         self,
@@ -35,11 +30,6 @@ class ConnectorDetailScreen(Screen):
         self.cfg = cfg
         self.entry = entry
         self.mode = mode
-
-    def compose(self) -> ComposeResult:
-        yield Header()
-        yield VerticalScroll(Static(self._body_text(), id="connector-detail-body"))
-        yield Footer()
 
     def _body_text(self) -> str:
         name = self.entry.get("name", "?")
@@ -80,6 +70,3 @@ class ConnectorDetailScreen(Screen):
             )
             return f"{prefix}{key}:\n{sub}"
         return f"{prefix}{key}: {mask_if_secret(key, value)}"
-
-    def action_back(self) -> None:
-        self.app.pop_screen()

--- a/gateway/configtool/screens/defaults.py
+++ b/gateway/configtool/screens/defaults.py
@@ -11,14 +11,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.containers import VerticalScroll
-from textual.screen import Screen
-from textual.widgets import Footer, Header, Static
-
 from ..formatting import format_value
 from ..model import EditableConfig
+from .base import DetailScreen
 
 _ENTRY_ACCESSOR = {
     "connector_defaults": lambda cfg: cfg.connectors_raw,
@@ -27,19 +22,14 @@ _ENTRY_ACCESSOR = {
 }
 
 
-class DefaultsScreen(Screen):
-    BINDINGS = [Binding("escape", "back", "Back")]
+class DefaultsScreen(DetailScreen):
+    BODY_ID = "defaults-detail-body"
 
     def __init__(self, cfg: EditableConfig, kind: str, mode: Literal["view", "edit"] = "view"):
         super().__init__()
         self.cfg = cfg
         self.kind = kind
         self.mode = mode
-
-    def compose(self) -> ComposeResult:
-        yield Header()
-        yield VerticalScroll(Static(self._body_text(), id="defaults-detail-body"))
-        yield Footer()
 
     def _body_text(self) -> str:
         entries = _ENTRY_ACCESSOR[self.kind](self.cfg)
@@ -70,6 +60,3 @@ class DefaultsScreen(Screen):
             )
 
         return "\n".join(lines)
-
-    def action_back(self) -> None:
-        self.app.pop_screen()

--- a/gateway/configtool/screens/overview.py
+++ b/gateway/configtool/screens/overview.py
@@ -71,7 +71,7 @@ class OverviewScreen(Screen):
             "#defaults-table", "#presets-table",
         ):
             self.query_one(table_id, DataTable).cursor_type = "row"
-        self.refresh_overview()
+        self.repaint_from_memory()
 
     # ── Actions ──────────────────────────────────────────────────────────────
 
@@ -81,7 +81,7 @@ class OverviewScreen(Screen):
 
     def action_refresh(self) -> None:
         # Must go through app.reload_config() (re-reads EditableConfig.document
-        # from disk), NOT call self.refresh_overview() directly — that only
+        # from disk), NOT call self.repaint_from_memory() directly — that only
         # repaints from whatever EditableConfig already has in memory, which
         # run_validate() (reading the file fresh internally) can silently
         # disagree with once the file has changed on disk since app startup.
@@ -90,7 +90,13 @@ class OverviewScreen(Screen):
 
     # ── Core refresh logic (the one testable seam per docs/design) ──────────
 
-    def refresh_overview(self) -> None:
+    def repaint_from_memory(self) -> None:
+        """Redraw every tab from EditableConfig's CURRENT in-memory document —
+        does not touch disk. Name is deliberate (code review item 9: the prior
+        name `refresh_overview` invited exactly the bug action_refresh's
+        comment above warns against — reaching for "the refresh method" and
+        getting a stale repaint instead of a disk reload). Call
+        `app.reload_config()` when the on-disk file may have changed."""
         app: "ConfigToolApp" = self.app  # type: ignore[assignment]
         banner = self.query_one("#banner", Static)
 
@@ -208,7 +214,7 @@ class OverviewScreen(Screen):
         key = str(event.row_key.value)
 
         if table_id == "connectors-table":
-            # key is the row's list position (see refresh_overview) — not
+            # key is the row's list position (see repaint_from_memory) — not
             # the connector's name, which isn't guaranteed unique/present.
             connectors = cfg.connectors_raw
             index = int(key)
@@ -219,13 +225,13 @@ class OverviewScreen(Screen):
             if entry is not None:
                 self.app.push_screen(AgentDetailScreen(cfg, key, entry, mode="view"))
         elif table_id == "watchers-table":
-            # Unlike refresh_overview()'s population of this same table,
+            # Unlike repaint_from_memory()'s population of this same table,
             # this used to call expanded_watchers() completely unguarded —
             # if the config became invalid on disk after the table was
             # painted (e.g. an external edit), selecting ANY row (including
             # the keyless "(unavailable...)" placeholder row shown in that
             # case) crashed the whole app. Guarded the same way
-            # refresh_overview() already is.
+            # repaint_from_memory() already is.
             try:
                 expanded = cfg.expanded_watchers()
             except (ValueError, FileNotFoundError):

--- a/gateway/configtool/screens/tool_presets.py
+++ b/gateway/configtool/screens/tool_presets.py
@@ -12,28 +12,18 @@ from __future__ import annotations
 
 from typing import Literal
 
-from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.containers import VerticalScroll
-from textual.screen import Screen
-from textual.widgets import Footer, Header, Static
-
 from ..model import EditableConfig
+from .base import DetailScreen
 
 
-class ToolPresetsScreen(Screen):
-    BINDINGS = [Binding("escape", "back", "Back")]
+class ToolPresetsScreen(DetailScreen):
+    BODY_ID = "preset-detail-body"
 
     def __init__(self, cfg: EditableConfig, preset_name: str, mode: Literal["view", "edit"] = "view"):
         super().__init__()
         self.cfg = cfg
         self.preset_name = preset_name
         self.mode = mode
-
-    def compose(self) -> ComposeResult:
-        yield Header()
-        yield VerticalScroll(Static(self._body_text(), id="preset-detail-body"))
-        yield Footer()
 
     def _body_text(self) -> str:
         rules = self.cfg.tool_presets_raw.get(self.preset_name, [])
@@ -63,6 +53,3 @@ class ToolPresetsScreen(Screen):
                 params = rule.get("params")
                 lines.append(f"  {tool} / {params or '(any)'}")
         return "\n".join(lines)
-
-    def action_back(self) -> None:
-        self.app.pop_screen()

--- a/gateway/configtool/screens/watcher_detail.py
+++ b/gateway/configtool/screens/watcher_detail.py
@@ -13,14 +13,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from textual.app import ComposeResult
-from textual.binding import Binding
-from textual.containers import VerticalScroll
-from textual.screen import Screen
-from textual.widgets import Footer, Header, Static
-
 from ..formatting import format_value, provenance_label
 from ..model import EditableConfig, ExpandedWatcher
+from .base import DetailScreen
 
 _KNOWN_FIELDS = [
     "session_id", "online_notification", "offline_notification",
@@ -28,8 +23,8 @@ _KNOWN_FIELDS = [
 ]
 
 
-class WatcherDetailScreen(Screen):
-    BINDINGS = [Binding("escape", "back", "Back")]
+class WatcherDetailScreen(DetailScreen):
+    BODY_ID = "watcher-detail-body"
 
     def __init__(
         self,
@@ -41,11 +36,6 @@ class WatcherDetailScreen(Screen):
         self.cfg = cfg
         self.expanded_watcher = expanded_watcher
         self.mode = mode
-
-    def compose(self) -> ComposeResult:
-        yield Header()
-        yield VerticalScroll(Static(self._body_text(), id="watcher-detail-body"))
-        yield Footer()
 
     def _body_text(self) -> str:
         ew = self.expanded_watcher
@@ -86,6 +76,3 @@ class WatcherDetailScreen(Screen):
             )
 
         return "\n".join(lines)
-
-    def action_back(self) -> None:
-        self.app.pop_screen()

--- a/tests/unit/test_configtool_app.py
+++ b/tests/unit/test_configtool_app.py
@@ -12,7 +12,7 @@ building this suite) — so the $EDITOR round-trip's actual suspend+subprocess
 line cannot be exercised here (see `# pragma: no cover` in app.py). What
 *is* tested here: that `open_editor_and_reload()` handles that failure
 gracefully (notifies, doesn't crash) rather than propagating it, and that
-`reload_config()`/`refresh_overview()` — the part of the round-trip that
+`reload_config()`/`repaint_from_memory()` — the part of the round-trip that
 matters for correctness — work correctly on their own.
 """
 
@@ -134,7 +134,7 @@ class TestOverviewRender:
 
     async def test_duplicate_connector_names_do_not_crash_the_table(self, tmp_path, work_dir):
         """Regression: connectors_raw is the raw, pre-validation list — two
-        connectors sharing a name used to crash refresh_overview() with
+        connectors sharing a name used to crash repaint_from_memory() with
         Textual's DuplicateKey (add_row(key=name) on a repeated key). Rows
         are now keyed by list position instead."""
         config_path = _write_config(tmp_path, f"""\
@@ -341,7 +341,7 @@ class TestDetailScreenNavigation:
     ):
         """Regression: on_data_table_row_selected's watchers-table branch
         used to call cfg.expanded_watchers() with no try/except at all,
-        unlike refresh_overview()'s equivalent call — selecting a row (any
+        unlike repaint_from_memory()'s equivalent call — selecting a row (any
         row, including the keyless placeholder shown once the config is
         already known-broken) after an external edit invalidated the file
         crashed the whole app instead of being a no-op."""

--- a/tests/unit/test_configtool_model.py
+++ b/tests/unit/test_configtool_model.py
@@ -208,6 +208,74 @@ class TestEditableConfigDefaultsBlock(_EditableConfigTestBase):
             cfg.defaults_block("watcher_defaults")
 
 
+class TestEditableConfigDefaultsBlockCaching(_EditableConfigTestBase):
+    """Code review item 8: defaults_block() is cached per kind (see
+    EditableConfig._defaults_cache) instead of re-running
+    _extract_defaults_block on every call. These tests pin the two things
+    that matter about a cache: repeated calls return the equivalent value,
+    and load()/reload() — the only ways `document` changes — invalidate it."""
+
+    def _cfg(self) -> tuple[EditableConfig, Path]:
+        path = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: "$RC_URL", username: bot, password: pw}}
+            agent_defaults:
+              type: claude
+              working_directory: {self.agent_dir}
+            agents:
+              default: {{}}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        return EditableConfig.load(path), path
+
+    def test_repeated_calls_return_the_same_cached_object(self):
+        cfg, _ = self._cfg()
+        first = cfg.defaults_block("agent_defaults")
+        second = cfg.defaults_block("agent_defaults")
+        self.assertIs(first, second)
+
+    def test_reload_invalidates_the_cache(self):
+        cfg, path = self._cfg()
+        first = cfg.defaults_block("agent_defaults")
+        self.assertEqual(first["type"], "claude")
+
+        path.write_text(
+            path.read_text().replace("type: claude", "type: opencode")
+        )
+        cfg.reload()
+        second = cfg.defaults_block("agent_defaults")
+        self.assertEqual(second["type"], "opencode")
+        self.assertIsNot(first, second)
+
+    def test_a_failed_lookup_is_not_cached_as_a_false_success(self):
+        path = self._write("""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {url: "$RC_URL", username: bot, password: pw}
+            watcher_defaults:
+              session_id: not-allowed
+            agents:
+              default:
+                type: claude
+                working_directory: /tmp
+            watchers:
+              - name: w1
+                room: general
+        """)
+        cfg = EditableConfig.load(path)
+        with self.assertRaises(ValueError):
+            cfg.defaults_block("watcher_defaults")
+        # Calling again must still raise — a cache bug could swallow this
+        # into a stale/absent cached value instead of re-validating.
+        with self.assertRaises(ValueError):
+            cfg.defaults_block("watcher_defaults")
+
+
 class TestEditableConfigProvenance(_EditableConfigTestBase):
     def _cfg(self) -> EditableConfig:
         path = self._write(f"""\


### PR DESCRIPTION
## Summary
First slice of Phase 2, per the plan agreed when Phase 1 merged (#62): land the deferred cleanup/altitude findings from the Phase 1 code review before adding any new UI on top of the same code. This PR covers items 9, 10, and 8; item 7 (EditableConfig accessor redesign) is intentionally left for the next PR, where `EditableConfig.save()` lands — the right accessor contract depends on what the mutation layer needs, so fixing it in isolation now would just be reshaped again once save() exists.

- **Item 10** — `ConnectorDetailScreen`, `AgentDetailScreen`, `WatcherDetailScreen`, `DefaultsScreen`, and `ToolPresetsScreen` each duplicated an identical `BINDINGS`, `compose()` shape, and `action_back()`. Extracted to a shared `DetailScreen` base class in `gateway/configtool/screens/base.py`; each subclass now only implements `_body_text()` and sets `BODY_ID` (kept identical to the existing widget ids, so no test changes needed beyond a couple of comment updates).
- **Item 9** — renamed `OverviewScreen.refresh_overview()` to `repaint_from_memory()`. The old name invited exactly the bug `action_refresh()`'s own comment warned against: calling it directly only repaints from whatever's already in memory and never touches disk, unlike `app.reload_config()`.
- **Item 8** — `EditableConfig.defaults_block()` re-ran `_extract_defaults_block` from scratch on every call, even though `document` only changes via `load()`/`reload()`. Added a per-kind cache invalidated by both. `merged_entry()` is deliberately left uncached (see the comment at both sites for why).

Pure refactor + a perf fix — no behavior change anywhere in this PR.

## Test plan
- [x] `uv run ruff check gateway/ tests/` — all checks passed
- [x] `uv run pytest tests/unit tests/integration -q` — 1866 passed (3 new tests for the defaults_block cache)