### PR TITLE
Config TUI: EditableConfig.save() + dirty tracking + ConfirmModal (Phase 2 foundation)

### DIFF
--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -1,7 +1,11 @@
 # Config editing tool — full design (M1–M3) + implementation status
 
 Status: **Phase 1 shipped** (read-only overview + detail screens + $EDITOR
-escape hatch). Phases 2–3 are designed below but not yet implemented. The
+escape hatch). **Phase 2 in progress:** items 7–10 from the Phase 1 code
+review cleared, plus `EditableConfig.save()`/dirty-tracking/`ConfirmModal`
+foundation shipped; entity create/edit screens, the `.env` writer, and the
+tool-list/preset editor are not yet built. Phase 3 is designed below but not
+yet started. The
 v0.2 format simplification (`connector_defaults`/`agent_defaults`/
 `watcher_defaults`, `tool_presets`, watcher `rooms:`) plus `acg config
 validate` and the JSON Schema (see `docs/migration-0.2.md`) are prerequisites
@@ -66,7 +70,16 @@ EditableConfig
 │     (and sibling-room count) it came from, by replaying the loader's own
 │     room-counting order — no name-generation/merge logic reimplemented
 ├── validated_view() -> GatewayConfig   (read-only; display/cross-ref only)
-└── save()   # phase 2+; not yet implemented
+├── dirty: bool / mark_dirty()   # Phase 2 foundation, shipped
+│     the ONE sanctioned seam after any in-place edit to `document` — clears
+│     the defaults_block() cache and flips `dirty`. There is deliberately no
+│     per-field mutation API (no `set_entry_field()`) on EditableConfig
+│     itself: each Phase 2/3 edit screen mutates `document` (or a raw dict
+│     reachable from it) in whatever shape that screen's form needs, then
+│     calls mark_dirty(). This resolved code review item 7 — the original
+│     open question was what shape a generic accessor API should take;
+│     the answer is that there isn't one, only the invalidation seam.
+└── save()   # Phase 2 foundation, shipped — see decision 5 below
 ```
 
 Shipped in Phase 1: `document`, `provenance`/`field_provenance`,
@@ -112,12 +125,20 @@ per-row status lookups.
    flow, a generic nested tree editor handles the body. Template drift
    degrades guidance only, never correctness — `_check_connectors`' real
    dataclass instantiation is the backstop.
-5. **Save flow: validate-before-write via a same-directory temp file.**
-   Serialize to `config.yaml.tmp` **beside** the real file (not `/tmp` —
-   `working_directory`/`context_inject_files` resolve relative to
-   `config_dir`), run the unchanged `validate_config(tmp)`, block save on
-   errors; on success: timestamped backup, then atomic rename. Never let a
-   transiently-broken config touch the path the daemon reads.
+5. **Save flow: validate-before-write via a same-directory temp file.
+   Shipped** as `EditableConfig.save()`. Serializes to `config.yaml.tmp`
+   **beside** the real file (not `/tmp` — `working_directory`/
+   `context_inject_files` resolve relative to `config_dir`), runs the
+   unchanged `validate_config(tmp)`, blocks save on errors (raises
+   `ValueError`, temp file deleted, real file untouched); on success:
+   timestamped backup (`config.yaml.bak.<unix-ts>`, `shutil.copy2`, matching
+   `onboard.py`'s convention) then `os.replace()` (atomic on POSIX) — the
+   daemon never observes a partially-written config.yaml. `dirty`/
+   `mark_dirty()` also shipped alongside it; `ConfigToolApp.action_quit()`
+   gates on `dirty` via a new `ConfirmModal` (Textual `@work`-decorated,
+   since `push_screen_wait()` requires a worker context) — no edit screen
+   sets `dirty` for real yet, but the mechanism is in place for Phase 2's
+   CRUD screens to use without further plumbing.
 6. **`.env` secret handling:** password/token/secret fields get a per-field
    "store in .env" toggle (default ON) → `${VAR}` placeholder in config,
    value into `.env`. Needs a new merge-by-key `.env` writer (`onboard.py`'s
@@ -134,7 +155,8 @@ per-row status lookups.
 | `ConnectorDetailScreen` / `AgentDetailScreen` / `WatcherDetailScreen` | pushed | **Shipped**, `mode="view"` only. Each already takes a `mode: Literal["view","edit","create"]` param — phase 2/3 flips it, no screen-class rework |
 | `DefaultsScreen` | pushed | **Shipped** (view-only): shows blast radius per key |
 | `ToolPresetsScreen` | pushed | **Shipped** (view-only): rule list + "used by" (checked against the MERGED per-agent tool list, not the raw entry — see gotchas below) |
-| `TypePickerModal`, `EntityPickerModal`, `PresetOrInlineModal`, `InlineToolRuleModal`, `ConfirmModal` | modals | Not yet built (phase 2/3) |
+| `ConfirmModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — yes/no dialog, Cancel focused by default. Gates `ConfigToolApp.action_quit()` on `EditableConfig.dirty` today; Phase 2/3 edit screens will reuse it for their own discard-changes confirmations |
+| `TypePickerModal`, `EntityPickerModal`, `PresetOrInlineModal`, `InlineToolRuleModal` | modals | Not yet built (phase 2/3) |
 | `RoomListEditorScreen` | pushed (2nd level) | Not yet built (phase 3) |
 | `$EDITOR` escape hatch | action | **Shipped.** `App.suspend()` + subprocess; Overview-only |
 | `HelpScreen` | modal or pushed | **Not yet built — owner-requested addition, tracked for phase 2.** On mount, focus starts on the tab bar rather than the list (a real gap a user hit) — Phase 1's fix was surfacing the existing `tab`→focus-next binding in the footer (`Binding("tab", "app.focus_next", "Focus next / enter list", show=True)` on `OverviewScreen`), but a dedicated help screen (`?` binding, listing every screen's keybindings) is the more scalable fix once phase 2/3 add enough screens/actions that the footer alone gets crowded |
@@ -193,12 +215,26 @@ attribution on expanded watchers specifically.
 CRUD). Rationale: "add a new bot" = connector + agent first, watcher second —
 matches the actual dependency order; creation flows are also where the TUI
 beats `$EDITOR` most (typed forms, credential handling via `.env`, live regex
-validation), so front-loading them delivers value sooner.
-`EditableConfig.save()`, dirty-state tracking + `ConfirmModal`,
-`AgentDetailScreen`/`ConnectorDetailScreen` edit/create, `TypePickerModal` +
-per-type templates + generic tree editor for connector `raw`, `.env`
-merge-by-key writer + secret toggle, tool-list editor + `PresetOrInlineModal`
-+ `InlineToolRuleModal`, `ToolPresetsScreen` made editable (used-by warnings).
+validation), so front-loading them delivers value sooner. Before any new UI,
+Phase 2 first cleared the Phase 1 code review's deferred items 7–10
+(refactor/perf only, no behavior change — see "Implementation notes" below):
+
+- **Shipped:** items 9/10 (renamed `refresh_overview()` →
+  `repaint_from_memory()`; extracted a shared `DetailScreen` base class for
+  the five detail/list screens) and item 8 (`EditableConfig.defaults_block()`
+  cached per kind, invalidated by `load()`/`reload()`/`mark_dirty()`).
+- **Shipped:** item 7 (`EditableConfig` accessor redesign) resolved as
+  `dirty`/`mark_dirty()` — see the keystone diagram above — landing
+  together with `EditableConfig.save()`, since the right shape depended on
+  what the mutation layer needed, per the plan's own risk note.
+- **Shipped:** `EditableConfig.save()` (decision 5) and `ConfirmModal`
+  (`gateway/configtool/modals.py`), gating `ConfigToolApp.action_quit()`.
+
+**Not yet built:** `AgentDetailScreen`/`ConnectorDetailScreen` edit/create,
+`TypePickerModal` + per-type templates + generic tree editor for connector
+`raw`, `.env` merge-by-key writer + secret toggle, tool-list editor +
+`PresetOrInlineModal` + `InlineToolRuleModal`, `ToolPresetsScreen` made
+editable (used-by warnings).
 
 **Phase 3: Watcher CRUD + defaults editing.** `WatcherDetailScreen`
 edit/create; new-watcher flow (pickers now enumerate entities creatable
@@ -230,7 +266,8 @@ split-out insertion position).
   silently shows stale data even though the validation banner looks current.
   Real bug hit and fixed while building the `r` (refresh) binding — the fix
   is `action_refresh()` calling `self.app.reload_config()`, not
-  `self.refresh_overview()` directly.
+  `self.repaint_from_memory()` directly (renamed from `refresh_overview()`
+  in Phase 2's cleanup pass — the old name invited exactly this bug).
 - **Any field that's commonly set via a `*_defaults` block (or via
   `agent_defaults`/`connector_defaults` transitively) must be looked up
   through `merged_entry()`, not the raw entry.** Two real display bugs were
@@ -245,6 +282,25 @@ split-out insertion position).
   `merged_entry()`/`defaults_block()`/`expanded_watchers()` each
   independently call the real loader again and can raise the *same* error a
   second, unhandled time if not guarded per-table/per-screen.
+- **`App.push_screen_wait()` requires a Textual worker context — it calls
+  `get_current_worker()` internally and raises `NoActiveWorker` otherwise.**
+  A plain action method (even an `async def`) triggered by a keybinding is
+  NOT automatically a worker. `ConfigToolApp.action_quit()` needs
+  `await self.push_screen_wait(ConfirmModal(...))` to block on the user's
+  answer, so it's decorated `@work` (from `textual`). Any future action that
+  awaits a modal's result for its own control flow (rather than using
+  `push_screen(..., callback=...)`) needs the same decorator — confirmed
+  empirically while building the quit-confirmation flow (the first version,
+  undecorated, failed every Pilot test with `NoActiveWorker`).
+- **A modal's own `BINDINGS` can silently lose to a focused `Button`'s
+  built-in key handling.** `ConfirmModal` originally bound `enter` to a
+  screen-level `action_confirm`, matching `escape`→`action_cancel` — but
+  Textual auto-focuses the first focusable widget (the Cancel button) on
+  mount, and a focused `Button` handles Enter itself before it ever reaches
+  a screen binding. Fixed by dropping the screen-level Enter binding
+  entirely and explicitly focusing Cancel in `on_mount()` (safe-by-default:
+  a reflexive Enter cancels, not confirms); Tab+Enter reaches Confirm.
+  `escape`→cancel still needs its own binding since `Button` doesn't bind it.
 - Verified against the real, currently-live production config (8 connectors,
   4 agents, 24 watchers expanded from 12 raw entries, 2 tool presets):
   renders correctly, and drilling into all 36 rows (24 watchers + 8

--- a/gateway/configtool/app.py
+++ b/gateway/configtool/app.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import subprocess
 
+from textual import work
 from textual.app import App
 
 from ..config_validate import ValidationResult, validate_config
 from .editor import resolve_editor_command
+from .modals import ConfirmModal
 from .model import EditableConfig
 from .screens.overview import OverviewScreen
 
@@ -42,6 +44,28 @@ class ConfigToolApp(App):
 
     def on_mount(self) -> None:
         self.push_screen(OverviewScreen())
+
+    @work
+    async def action_quit(self) -> None:
+        """Overrides App's default action_quit (bound to ctrl+q, and to the
+        visible 'q' binding on OverviewScreen) to gate on unsaved changes.
+        No Phase 2/3 edit screen exists yet to ever set `dirty`, but this is
+        the mechanism they'll all rely on — built now, alongside save()/
+        dirty tracking, rather than bolted on once the first edit screen
+        needs it.
+
+        `@work` is required here, not optional: `push_screen_wait()` calls
+        `get_current_worker()` internally and raises `NoActiveWorker` if this
+        method runs as a plain action coroutine instead of inside a Textual
+        worker task (confirmed empirically — every keybinding-triggered
+        action normally runs as a bare coroutine, not a worker)."""
+        if self.editable_config is not None and self.editable_config.dirty:
+            discard = await self.push_screen_wait(
+                ConfirmModal("Discard unsaved changes and quit?", confirm_label="Discard")
+            )
+            if not discard:
+                return
+        self.exit()
 
     # ── Shared, non-action helpers (called from OverviewScreen's actions) ───
 

--- a/gateway/configtool/modals.py
+++ b/gateway/configtool/modals.py
@@ -1,0 +1,76 @@
+"""Modal screens for the config TUI (docs/design/config-tool.md's "modals"
+row in the screen inventory). `ConfirmModal` is the first one built, landing
+alongside `EditableConfig.save()`/dirty tracking — everything that needs to
+ask "discard unsaved changes?" before navigating away or quitting shares it.
+Later phases add `TypePickerModal`/`EntityPickerModal`/`PresetOrInlineModal`/
+`InlineToolRuleModal` here too.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static
+
+
+class ConfirmModal(ModalScreen[bool]):
+    """A yes/no confirmation dialog. `dismiss(True)` on confirm, `dismiss(False)`
+    on cancel — callers `await self.app.push_screen_wait(ConfirmModal(...))`
+    to get the result.
+
+    The Cancel button holds focus by default (safe-by-default for a dialog
+    that's always asking about discarding something): pressing Enter presses
+    whichever button is focused — Textual's `Button` handles Enter/Space
+    itself once focused, so there is deliberately no screen-level `Binding`
+    for "confirm" here (it would never fire while a Button has focus, which
+    is always, by construction). Escape still needs its own binding since
+    Button doesn't bind it.
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
+
+    DEFAULT_CSS = """
+    ConfirmModal {
+        align: center middle;
+    }
+    #confirm-dialog {
+        width: auto;
+        max-width: 60;
+        height: auto;
+        border: thick $primary;
+        padding: 1 2;
+        background: $surface;
+    }
+    #confirm-buttons {
+        height: auto;
+        margin-top: 1;
+        align: right middle;
+    }
+    #confirm-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, message: str, confirm_label: str = "Yes", cancel_label: str = "No"):
+        super().__init__()
+        self.message = message
+        self.confirm_label = confirm_label
+        self.cancel_label = cancel_label
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="confirm-dialog"):
+            yield Static(self.message, id="confirm-message")
+            with Horizontal(id="confirm-buttons"):
+                yield Button(self.cancel_label, id="cancel", variant="default")
+                yield Button(self.confirm_label, id="confirm", variant="error")
+
+    def on_mount(self) -> None:
+        self.query_one("#cancel", Button).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(event.button.id == "confirm")
+
+    def action_cancel(self) -> None:
+        self.dismiss(False)

--- a/gateway/configtool/model.py
+++ b/gateway/configtool/model.py
@@ -18,12 +18,17 @@ are still visible:
 Critically, ``EditableConfig`` loads via plain ``yaml.safe_load`` — never via
 ``GatewayConfig.from_file``, which expands ``$VAR``/``${VAR}`` environment
 references (gateway/config.py's ``_expand_env_vars``). If the editor ever
-loaded (or, in a later phase, saved) through that path, a save would write
-resolved secrets — passwords, tokens — into config.yaml in plain text.
+loaded (or saved) through that path, a save would write resolved secrets —
+passwords, tokens — into config.yaml in plain text. ``save()`` writes
+``document`` back out with plain ``yaml.dump`` for the same reason: whatever
+``$VAR`` string was loaded is the same ``$VAR`` string written back.
 """
 
 from __future__ import annotations
 
+import os
+import shutil
+import time
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -31,7 +36,7 @@ from pathlib import Path
 import yaml
 
 from ..config import GatewayConfig, WatcherConfig, _deep_merge, _extract_defaults_block
-from ..config_validate import Finding
+from ..config_validate import Finding, validate_config
 
 # Mirrors the forbidden-key sets GatewayConfig.from_file enforces for each
 # *_defaults block (gateway/config.py's calls to _extract_defaults_block) —
@@ -78,18 +83,21 @@ class EditableConfig:
     # every single call — repaint_from_memory() alone calls it once per
     # connector/agent/watcher row PLUS once per defaults-table row, all for
     # the same 3 blocks. Cached here, keyed by kind, invalidated by
-    # load()/reload() (the only two places `document` changes). Not part of
-    # equality/repr — it's a memoization detail, not observable state.
-    # NOTE for whoever adds in-place mutation (Phase 2's save() work, item 7):
-    # this cache is only invalidated by load()/reload() today because nothing
-    # currently mutates `document` any other way. Any future code path that
-    # edits `document` directly (e.g. a form committing a field change) MUST
-    # also clear `_defaults_cache` — Phase 1 also holds this same invariant
-    # implicitly today (its accessors were simply always fresh); this comment
-    # keeps it explicit now that there's a cache to forget.
+    # load()/reload()/mark_dirty() (the only ways `document` changes). Not
+    # part of equality/repr — it's a memoization detail, not observable state.
     _defaults_cache: dict[str, dict] = field(
         default_factory=dict, init=False, repr=False, compare=False
     )
+    # Code review item 7: whether `document` has unsaved changes since the
+    # last load()/reload()/save(). There is deliberately no per-field mutation
+    # API here (e.g. `set_entry_field()`) — Phase 2's edit screens mutate
+    # `document` (and the raw dicts reachable from it) directly, in whatever
+    # shape each form needs, and then call `mark_dirty()`. That is the ONE
+    # sanctioned seam: it is where cache invalidation and dirty-tracking both
+    # live, so every future mutation path — a single field, a whole entry
+    # replace, a list append/remove — stays correct by calling it, without
+    # this class needing to anticipate each mutation shape up front.
+    dirty: bool = field(default=False, init=False, compare=False)
 
     @classmethod
     def load(cls, path: str | Path) -> "EditableConfig":
@@ -117,6 +125,65 @@ class EditableConfig:
         fresh = EditableConfig.load(self.path)
         self.document = fresh.document
         self._defaults_cache.clear()
+        self.dirty = False
+
+    def mark_dirty(self) -> None:
+        """Call this after mutating `document` (or any raw dict reachable
+        from it) directly. See the `dirty`/`_defaults_cache` field comments
+        above — this is the one required step after any in-place edit."""
+        self._defaults_cache.clear()
+        self.dirty = True
+
+    def save(self) -> None:
+        """Validate-before-write via a same-directory temp file
+        (docs/design/config-tool.md decision 5):
+
+        1. Serialize `document` to `<path>.tmp`, BESIDE the real file (never
+           /tmp — `working_directory`/`context_inject_files` in the config
+           resolve relative to the real file's directory, and a temp file
+           elsewhere would validate paths that don't mean the same thing
+           once moved).
+        2. Run the real `validate_config()` against that temp file. If it
+           doesn't validate, delete the temp file and raise ValueError with
+           the errors — the real config on disk is never touched.
+        3. Only on success: copy the real file to a timestamped backup
+           (`config.yaml.bak.<unix-ts>`, matching gateway/onboard.py's
+           existing convention) and atomically replace it with the temp
+           file (`os.replace` — atomic on POSIX, so a reader/the daemon
+           never observes a partially-written config.yaml).
+
+        Raises FileNotFoundError if `path` doesn't exist yet (nothing to
+        back up) — Phase 2/3 forms only ever call save() on an already-loaded
+        EditableConfig, so this should not happen in practice; surfaced
+        rather than silently skipping the backup step.
+        """
+        if not self.path.exists():
+            raise FileNotFoundError(
+                f"Cannot save: {self.path} no longer exists (nothing to back up)."
+            )
+
+        tmp_path = self.path.with_name(self.path.name + ".tmp")
+        try:
+            with open(tmp_path, "w") as f:
+                yaml.dump(self.document, f, sort_keys=False, allow_unicode=True)
+
+            result = validate_config(str(tmp_path))
+            if not result.ok:
+                raise ValueError(
+                    "Refusing to save — the result would no longer be a "
+                    "valid config:\n" + "\n".join(result.errors)
+                )
+
+            backup_path = self.path.with_name(f"{self.path.name}.bak.{int(time.time())}")
+            shutil.copy2(self.path, backup_path)
+            os.replace(tmp_path, self.path)
+        finally:
+            # Only ever removes OUR OWN temp file, not the real config: if
+            # os.replace() above succeeded, tmp_path no longer exists at this
+            # path (it WAS renamed to self.path) and unlink is a no-op.
+            tmp_path.unlink(missing_ok=True)
+
+        self.dirty = False
 
     # ── Raw entry accessors (pre-merge, as-authored) ─────────────────────────
 

--- a/tests/unit/test_configtool_app.py
+++ b/tests/unit/test_configtool_app.py
@@ -26,6 +26,7 @@ import pytest
 from textual.widgets import DataTable, Static
 
 from gateway.configtool.app import ConfigToolApp
+from gateway.configtool.modals import ConfirmModal
 from gateway.configtool.screens.agent_detail import AgentDetailScreen
 from gateway.configtool.screens.connector_detail import ConnectorDetailScreen
 from gateway.configtool.screens.defaults import DefaultsScreen
@@ -474,6 +475,94 @@ class TestEditorEscapeHatch:
             app.reload_config()
             await pilot.pause()
             assert app.screen.query_one("#watchers-table", DataTable).row_count == 4
+
+
+class TestDirtyQuitGating:
+    """ConfigToolApp.action_quit() (Phase 2 foundation: no edit screen exists
+    yet to ever set `dirty` for real, but the gating mechanism itself is
+    built now, alongside save()/dirty tracking, per docs/design/config-tool.md
+    decision 5's ConfirmModal — exercised here via `mark_dirty()` directly,
+    the same seam a real edit screen will use."""
+
+    async def test_quit_with_no_unsaved_changes_exits_immediately_no_modal(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _valid_config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app.editable_config.dirty is False
+
+            await pilot.press("q")
+            await pilot.pause()
+            assert app.is_running is False
+
+    async def test_quit_with_unsaved_changes_shows_confirm_modal(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _valid_config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.editable_config.mark_dirty()
+
+            await pilot.press("q")
+            await pilot.pause()
+            assert app.is_running is True  # not exited yet — modal is up
+            assert isinstance(app.screen, ConfirmModal)
+
+    async def test_confirming_the_modal_discards_and_quits(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _valid_config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.editable_config.mark_dirty()
+
+            await pilot.press("q")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+            # Cancel holds focus by default (safe-by-default) — tab to the
+            # Confirm button, then Enter presses whichever button is
+            # focused (Button's own key handling, not a screen binding).
+            await pilot.press("tab", "enter")
+            await pilot.pause()
+            assert app.is_running is False
+
+    async def test_cancelling_the_modal_via_its_default_focused_button(
+        self, tmp_path, work_dir
+    ):
+        """Enter with no other input presses the default-focused Cancel
+        button — the safe outcome when a user just reflexively hits Enter."""
+        config_path = _write_config(tmp_path, _valid_config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.editable_config.mark_dirty()
+
+            await pilot.press("q")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+            await pilot.press("enter")
+            await pilot.pause()
+            assert app.is_running is True
+            assert isinstance(app.screen, OverviewScreen)
+
+    async def test_cancelling_the_modal_keeps_the_app_running(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _valid_config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.editable_config.mark_dirty()
+
+            await pilot.press("q")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+            await pilot.press("escape")  # ConfirmModal's "cancel" binding
+            await pilot.pause()
+            assert app.is_running is True
+            assert isinstance(app.screen, OverviewScreen)
+            assert app.editable_config.dirty is True  # unsaved change untouched
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_configtool_model.py
+++ b/tests/unit/test_configtool_model.py
@@ -8,10 +8,13 @@ writing resolved secrets back to disk in a later save-capable phase).
 
 from __future__ import annotations
 
+import os
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+
+import yaml
 
 from gateway.config import GatewayConfig
 from gateway.configtool.model import EditableConfig, Provenance
@@ -381,6 +384,134 @@ class TestEditableConfigValidatedView(_EditableConfigTestBase):
         cfg = EditableConfig.load(path)
         with self.assertRaises(ValueError):
             cfg.validated_view()
+
+
+class TestEditableConfigDirtyTracking(_EditableConfigTestBase):
+    def _cfg(self) -> EditableConfig:
+        path = self._write(f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """)
+        return EditableConfig.load(path)
+
+    def test_freshly_loaded_config_is_not_dirty(self):
+        cfg = self._cfg()
+        self.assertFalse(cfg.dirty)
+
+    def test_mark_dirty_sets_the_flag_and_clears_the_defaults_cache(self):
+        cfg = self._cfg()
+        cached = cfg.defaults_block("agent_defaults")  # populate the cache
+        cfg.document["agent_defaults"] = {"type": "opencode"}
+        cfg.mark_dirty()
+        self.assertTrue(cfg.dirty)
+        self.assertIsNot(cfg.defaults_block("agent_defaults"), cached)
+        self.assertEqual(cfg.defaults_block("agent_defaults")["type"], "opencode")
+
+    def test_reload_clears_dirty(self):
+        cfg = self._cfg()
+        cfg.mark_dirty()
+        self.assertTrue(cfg.dirty)
+        cfg.reload()
+        self.assertFalse(cfg.dirty)
+
+
+class TestEditableConfigSave(_EditableConfigTestBase):
+    """EditableConfig.save() — docs/design/config-tool.md decision 5:
+    validate-before-write via a same-directory temp file, backup, atomic
+    rename. The $VAR-survives-save test is the security keystone (advisor
+    flagged this explicitly): if save() ever wrote a RESOLVED secret back to
+    config.yaml, that's an incident, not a bug.
+    """
+
+    ENV_VAR_NAME = "RC_URL_FOR_CONFIGTOOL_SAVE_TEST"
+
+    def setUp(self):
+        super().setUp()
+        os.environ[self.ENV_VAR_NAME] = "http://localhost:3000"
+        self.addCleanup(os.environ.pop, self.ENV_VAR_NAME, None)
+
+    def _valid_cfg_text(self) -> str:
+        return f"""\
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: "${self.ENV_VAR_NAME}", username: bot, password: pw}}
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            watchers:
+              - name: w1
+                room: general
+        """
+
+    def test_save_preserves_the_unresolved_env_var_placeholder(self):
+        path = self._write(self._valid_cfg_text())
+        cfg = EditableConfig.load(path)
+        cfg.save()
+        # Read back with plain yaml (never the env-expanding loader) — the
+        # literal "$VAR" string must survive, not the resolved URL.
+        raw = yaml.safe_load(path.read_text())
+        self.assertEqual(
+            raw["connectors"][0]["server"]["url"], f"${self.ENV_VAR_NAME}"
+        )
+
+    def test_save_writes_a_timestamped_backup_of_the_prior_contents(self):
+        path = self._write(self._valid_cfg_text())
+        original_text = path.read_text()
+        cfg = EditableConfig.load(path)
+        cfg.save()
+        backups = list(path.parent.glob("config.yaml.bak.*"))
+        self.assertEqual(len(backups), 1)
+        self.assertEqual(backups[0].read_text(), original_text)
+
+    def test_save_clears_the_dirty_flag(self):
+        path = self._write(self._valid_cfg_text())
+        cfg = EditableConfig.load(path)
+        cfg.mark_dirty()
+        self.assertTrue(cfg.dirty)
+        cfg.save()
+        self.assertFalse(cfg.dirty)
+
+    def test_save_leaves_no_leftover_temp_file(self):
+        path = self._write(self._valid_cfg_text())
+        cfg = EditableConfig.load(path)
+        cfg.save()
+        self.assertFalse((path.parent / "config.yaml.tmp").exists())
+
+    def test_save_refuses_an_invalid_document_and_leaves_disk_untouched(self):
+        path = self._write(self._valid_cfg_text())
+        original_text = path.read_text()
+        cfg = EditableConfig.load(path)
+        del cfg.document["agents"]["default"]["working_directory"]
+        cfg.mark_dirty()
+
+        with self.assertRaises(ValueError):
+            cfg.save()
+
+        # The real file must be byte-identical to before the failed save —
+        # no partial/temp/backup artifacts left behind either.
+        self.assertEqual(path.read_text(), original_text)
+        self.assertFalse((path.parent / "config.yaml.tmp").exists())
+        self.assertEqual(list(path.parent.glob("config.yaml.bak.*")), [])
+        # dirty must stay set: the in-memory edit was never actually saved.
+        self.assertTrue(cfg.dirty)
+
+    def test_save_raises_file_not_found_if_the_config_file_is_gone(self):
+        path = self._write(self._valid_cfg_text())
+        cfg = EditableConfig.load(path)
+        path.unlink()
+        with self.assertRaises(FileNotFoundError):
+            cfg.save()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Second slice of Phase 2 (first was #63): the persistence foundation every future entity create/edit screen needs, landed before any of those screens exist. No user-visible feature yet — this is infrastructure only.

- `EditableConfig.save()` — validate-before-write via a same-directory temp file (`docs/design/config-tool.md` decision 5): serialize to `<path>.tmp` beside the real file, run the unchanged `validate_config()` against it, refuse to write (raise `ValueError`, no leftover temp file, real file untouched) if it doesn't validate; on success, timestamped backup (`config.yaml.bak.<unix-ts>`, matching `onboard.py`'s convention) then an atomic `os.replace()`.
- Security keystone, tested explicitly rather than assumed: a `$VAR`/`${VAR}` placeholder survives a `save()` round-trip completely unresolved.
- `EditableConfig.dirty` / `mark_dirty()` — resolves code review item 7 (deferred from the last PR). No generic per-field mutation API is added; each future edit screen mutates `document` directly in whatever shape its form needs and calls `mark_dirty()`, which clears the item-8 cache and flips `dirty`.
- `gateway/configtool/modals.py`: `ConfirmModal`, wired into `ConfigToolApp.action_quit()` to gate quitting on unsaved changes. No edit screen sets `dirty` for real yet, but the mechanism is ready for Phase 2's CRUD screens.
- Two Textual gotchas hit and written up in the design doc's "Implementation notes": `push_screen_wait()` needs a `@work`-decorated action (raises `NoActiveWorker` otherwise), and a modal's own `Enter` binding can silently lose to a focused `Button`'s built-in key handling (fixed by focusing Cancel by default instead).

## Test plan
- [x] `uv run ruff check gateway/ tests/` — all checks passed
- [x] `uv run pytest tests/unit tests/integration -q` — 1880 passed (14 new tests: dirty tracking, save() round-trip/backup/atomicity/rejection, app-level quit-gating flow)