### PR TITLE
Config TUI: agent create/edit screen (first entity CRUD)

### DIFF
--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -2,10 +2,11 @@
 
 Status: **Phase 1 shipped** (read-only overview + detail screens + $EDITOR
 escape hatch). **Phase 2 in progress:** items 7–10 from the Phase 1 code
-review cleared, plus `EditableConfig.save()`/dirty-tracking/`ConfirmModal`
-foundation shipped; entity create/edit screens, the `.env` writer, and the
-tool-list/preset editor are not yet built. Phase 3 is designed below but not
-yet started. The
+review cleared; `EditableConfig.save()`/dirty-tracking/`ConfirmModal`
+foundation shipped; agent create/edit shipped (`AgentDetailScreen`,
+`TypePickerModal`, `n` on the Agents tab). Connector create/edit, the `.env`
+writer, and the tool-list/preset editor are not yet built. Phase 3 is
+designed below but not yet started. The
 v0.2 format simplification (`connector_defaults`/`agent_defaults`/
 `watcher_defaults`, `tool_presets`, watcher `rooms:`) plus `acg config
 validate` and the JSON Schema (see `docs/migration-0.2.md`) are prerequisites
@@ -152,11 +153,13 @@ per-row status lookups.
 | Screen | Kind | Status |
 |---|---|---|
 | `OverviewScreen` | root | **Shipped.** 5 tabs: Connectors, Agents, Watchers, Defaults, Tool Presets |
-| `ConnectorDetailScreen` / `AgentDetailScreen` / `WatcherDetailScreen` | pushed | **Shipped**, `mode="view"` only. Each already takes a `mode: Literal["view","edit","create"]` param — phase 2/3 flips it, no screen-class rework |
+| `AgentDetailScreen` | pushed | **Shipped, all 3 modes.** view/edit/create. Form fields are a manually-maintained mirror of `$defs/agent` (not a runtime schema interpreter — safe since the schema is closed). Nothing is written to `document` until Save; Save diffs every field against its value-at-open and writes only what changed (docs/design/config-tool.md decision 2). Tool-list fields (`owner_allowed_tools`/`guest_allowed_tools`) stay view-only here — separate tool-list-editor work. Escape with unsaved changes routes through `ConfirmModal` |
+| `ConnectorDetailScreen` / `WatcherDetailScreen` | pushed | **Shipped**, `mode="view"` only still — connector edit/create is the next Phase 2 slice; watcher CRUD is Phase 3. Each already takes a `mode: Literal["view","edit","create"]` param — no screen-class rework needed when their turn comes |
 | `DefaultsScreen` | pushed | **Shipped** (view-only): shows blast radius per key |
 | `ToolPresetsScreen` | pushed | **Shipped** (view-only): rule list + "used by" (checked against the MERGED per-agent tool list, not the raw entry — see gotchas below) |
-| `ConfirmModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — yes/no dialog, Cancel focused by default. Gates `ConfigToolApp.action_quit()` on `EditableConfig.dirty` today; Phase 2/3 edit screens will reuse it for their own discard-changes confirmations |
-| `TypePickerModal`, `EntityPickerModal`, `PresetOrInlineModal`, `InlineToolRuleModal` | modals | Not yet built (phase 2/3) |
+| `ConfirmModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — yes/no dialog, Cancel focused by default. Gates `ConfigToolApp.action_quit()` on `EditableConfig.dirty`, and `AgentDetailScreen`'s own per-screen form-dirty flag on Escape |
+| `TypePickerModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — generic list-of-strings picker (`ListView`-based), used today for the agent-type picker (claude/opencode); the connector-type picker (rocketchat/mattermost/voice/script) will reuse the same class |
+| `EntityPickerModal`, `PresetOrInlineModal`, `InlineToolRuleModal` | modals | Not yet built (phase 2/3) |
 | `RoomListEditorScreen` | pushed (2nd level) | Not yet built (phase 3) |
 | `$EDITOR` escape hatch | action | **Shipped.** `App.suspend()` + subprocess; Overview-only |
 | `HelpScreen` | modal or pushed | **Not yet built — owner-requested addition, tracked for phase 2.** On mount, focus starts on the tab bar rather than the list (a real gap a user hit) — Phase 1's fix was surfacing the existing `tab`→focus-next binding in the footer (`Binding("tab", "app.focus_next", "Focus next / enter list", show=True)` on `OverviewScreen`), but a dedicated help screen (`?` binding, listing every screen's keybindings) is the more scalable fix once phase 2/3 add enough screens/actions that the footer alone gets crowded |
@@ -169,9 +172,20 @@ Max stack depth 3 (Overview → detail → modal/RoomListEditor).
   detail screen in create mode, per-type template pre-filled. Mattermost gets
   a token-XOR-user/pass toggle (mirrors `MattermostConfig.__post_init__`);
   secrets masked + `.env` toggle.
-- **New agent:** type picker (claude/opencode) → schema-driven form;
-  `working_directory` existence is a pre-save **warning**, not a blocker
-  (syntactic validity vs. "ready to run" are different questions).
+- **New agent — shipped.** Type picker (claude/opencode, via the generic
+  `TypePickerModal`) → form (`gateway/configtool/screens/agent_detail.py`,
+  a manually-maintained mirror of `$defs/agent`, matching Phase 1's
+  `_KNOWN_FIELDS` pattern rather than a runtime schema interpreter — safe
+  because the schema is closed). **Correction from the original design:**
+  `working_directory` existence is NOT a soft warning at save time —
+  `GatewayConfig.from_file` hard-requires the directory to exist (raises
+  `ValueError`), and `save()` reuses that unchanged validator by design (see
+  decision 5's rationale for never special-casing it), so a missing
+  directory still hard-blocks Save. What's actually built: an early, live,
+  non-blocking inline hint next to the field (updates as you type, resolved
+  the same way the loader resolves it — `expanduser()` then relative to
+  `config_dir`) so the user finds out before hitting Save, not just from a
+  generic validator error after.
 - **New watcher:** connector Select + agent Select + room(s) free text
   (single or comma-list — mirrors the `room`/`rooms` duality already in the
   format). Agent Select pre-suggests the connector's existing pairing
@@ -229,11 +243,19 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
   what the mutation layer needed, per the plan's own risk note.
 - **Shipped:** `EditableConfig.save()` (decision 5) and `ConfirmModal`
   (`gateway/configtool/modals.py`), gating `ConfigToolApp.action_quit()`.
+- **Shipped:** `AgentDetailScreen` edit/create + `TypePickerModal` (generic,
+  built for reuse by the connector-type picker). `n` on the Agents tab of
+  `OverviewScreen` (`action_new_entity`) opens it; other tabs notify rather
+  than doing nothing or crashing, since they don't support creation yet.
+  Tool-list fields stay view-only on this screen (separate work, below).
+  See "Implementation notes" for the write-back diffing mechanism and two
+  Textual gotchas hit while building it (`@work`/`push_screen_wait`, and
+  Input/Select firing `Changed` once at initial mount).
 
-**Not yet built:** `AgentDetailScreen`/`ConnectorDetailScreen` edit/create,
-`TypePickerModal` + per-type templates + generic tree editor for connector
-`raw`, `.env` merge-by-key writer + secret toggle, tool-list editor +
-`PresetOrInlineModal` + `InlineToolRuleModal`, `ToolPresetsScreen` made
+**Not yet built:** `ConnectorDetailScreen` edit/create, `TypePickerModal`'s
+connector-type variant + per-type templates + generic tree editor for
+connector `raw`, `.env` merge-by-key writer + secret toggle, tool-list editor
++ `PresetOrInlineModal` + `InlineToolRuleModal`, `ToolPresetsScreen` made
 editable (used-by warnings).
 
 **Phase 3: Watcher CRUD + defaults editing.** `WatcherDetailScreen`
@@ -301,6 +323,23 @@ split-out insertion position).
   entirely and explicitly focusing Cancel in `on_mount()` (safe-by-default:
   a reflexive Enter cancels, not confirms); Tab+Enter reaches Confirm.
   `escape`→cancel still needs its own binding since `Button` doesn't bind it.
+- **`Input` and `Select` fire their own `Changed` message once at initial
+  mount, using whatever value the constructor was given — `Checkbox` does
+  not.** Confirmed empirically while building `AgentDetailScreen`'s
+  edit/create form: simply opening the edit form (before the user touches
+  anything) immediately marked it dirty and would have wrongly prompted a
+  discard-confirmation on Escape. Fixed with a `self._populating` guard,
+  set before composing the form and cleared via `self.call_after_refresh(...)`
+  (confirmed empirically to run AFTER that initial burst of Changed
+  messages, not before). Important: `Screen.recompose()` does NOT re-run
+  `on_mount()` — only the screen's own first push does — so a screen that
+  recomposes itself between modes (e.g. view → edit) has to re-arm the
+  guard and reschedule `call_after_refresh` at the recompose call site
+  itself, not rely on `on_mount` firing again.
+- **`push_screen_wait()` needs a `@work`-decorated caller**, same gotcha as
+  `ConfigToolApp.action_quit()` — `AgentDetailScreen.action_back()` awaits a
+  `ConfirmModal` result for its own discard-vs-keep-editing decision, so it's
+  `@work`-decorated too.
 - Verified against the real, currently-live production config (8 connectors,
   4 agents, 24 watchers expanded from 12 raw entries, 2 tool presets):
   renders correctly, and drilling into all 36 rows (24 watchers + 8

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -356,16 +356,31 @@ split-out insertion position).
   signal to every current subscriber) right after every `recompose()` in
   `action_edit()`/`action_back()`. Any future screen that recomposes itself
   in place (rather than pushing a new screen) needs this same call.
-- **`VerticalScroll` binds Up/Down to `action_scroll_up`/`action_scroll_down`
-  by default**, which is why a form wrapped in one only supported Tab/
-  Shift+Tab between fields. User-requested Up/Down field navigation: a small
-  `_AgentForm(VerticalScroll)` subclass overrides just those two ACTIONS
-  (not new bindings) to call `self.screen.focus_previous()`/`focus_next()`
-  instead of scrolling — Home/End/PageUp/PageDown and the mouse wheel still
-  scroll if the form doesn't fit the terminal. One caveat, not a bug: while
-  focus is ON the `type` field's `Select` widget, Up/Down are captured by
-  Select's own dropdown (matching ordinary combobox behavior everywhere) —
-  Tab still moves past it.
+- **Up/Down field navigation was tried and reverted.** `VerticalScroll`
+  (the form's container) binds Up/Down to `action_scroll_up`/
+  `action_scroll_down` by default; a small `_AgentForm(VerticalScroll)`
+  subclass overriding just those two actions to call
+  `self.screen.focus_previous()`/`focus_next()` worked under Pilot's
+  headless driver (regression tests passed) but was unreliable in the
+  user's real terminal session — pressing Down sometimes did nothing,
+  sometimes stopped advancing partway through the form. Root cause not
+  isolated (Pilot's key-event simulation apparently doesn't reproduce
+  whatever the real terminal/session does differently); reverted rather
+  than ship a navigation feature that's flaky in exactly the environment it
+  needs to work in. **What shipped instead:** a `tab`→`app.focus_next`
+  binding re-bound with `show=True` (same pattern `OverviewScreen` already
+  uses) so the footer tells the user how to move between fields at all —
+  Tab/Shift+Tab was always the reliable mechanism underneath either way.
+- **The footer showed 'Edit' even while already editing** (where pressing
+  `e` is a no-op — `action_edit()` only does something from view mode),
+  which read as broken rather than merely redundant. Fixed with
+  `check_action()`: BINDINGS don't need to change per mode, just their
+  visibility — `check_action("edit", ...)` returns `mode == "view"`,
+  `check_action("save", ...)` returns `mode != "view"`. Works together with
+  the `refresh_bindings()` fix above: the same call that fixes the
+  went-permanently-blank bug also re-evaluates `check_action` for every
+  binding, so mode-based visibility updates immediately on the same
+  recompose, no separate plumbing needed.
 - Verified against the real, currently-live production config (8 connectors,
   4 agents, 24 watchers expanded from 12 raw entries, 2 tool presets):
   renders correctly, and drilling into all 36 rows (24 watchers + 8

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -340,6 +340,32 @@ split-out insertion position).
   `ConfigToolApp.action_quit()` — `AgentDetailScreen.action_back()` awaits a
   `ConfirmModal` result for its own discard-vs-keep-editing decision, so it's
   `@work`-decorated too.
+- **`Footer` goes permanently blank after `recompose()` unless you call
+  `Screen.refresh_bindings()` afterward.** User-reported: after entering
+  `AgentDetailScreen`'s edit mode once, the footer became a blank bar and
+  stayed blank for the rest of that screen's life — even going back to view
+  mode and re-entering edit. Root cause: `Footer.on_mount()` subscribes to
+  `Screen.bindings_updated_signal`; `Footer.compose()` renders nothing until
+  its `_bindings_ready` reactive is set, which only happens inside its own
+  `bindings_changed` signal callback. `recompose()` mounts a BRAND-NEW
+  `Footer` instance every time (view↔edit), which re-subscribes but never
+  receives that signal on its own — nothing re-fires it just because a new
+  subscriber showed up, since the screen's bindings didn't structurally
+  change from Textual's point of view. Fixed by calling
+  `self.refresh_bindings()` (Screen's own public method — re-publishes the
+  signal to every current subscriber) right after every `recompose()` in
+  `action_edit()`/`action_back()`. Any future screen that recomposes itself
+  in place (rather than pushing a new screen) needs this same call.
+- **`VerticalScroll` binds Up/Down to `action_scroll_up`/`action_scroll_down`
+  by default**, which is why a form wrapped in one only supported Tab/
+  Shift+Tab between fields. User-requested Up/Down field navigation: a small
+  `_AgentForm(VerticalScroll)` subclass overrides just those two ACTIONS
+  (not new bindings) to call `self.screen.focus_previous()`/`focus_next()`
+  instead of scrolling — Home/End/PageUp/PageDown and the mouse wheel still
+  scroll if the form doesn't fit the terminal. One caveat, not a bug: while
+  focus is ON the `type` field's `Select` widget, Up/Down are captured by
+  Select's own dropdown (matching ordinary combobox behavior everywhere) —
+  Tab still moves past it.
 - Verified against the real, currently-live production config (8 connectors,
   4 agents, 24 watchers expanded from 12 raw entries, 2 tool presets):
   renders correctly, and drilling into all 36 rows (24 watchers + 8

--- a/gateway/configtool/modals.py
+++ b/gateway/configtool/modals.py
@@ -12,7 +12,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
-from textual.widgets import Button, Static
+from textual.widgets import Button, Label, ListItem, ListView, Static
 
 
 class ConfirmModal(ModalScreen[bool]):
@@ -74,3 +74,52 @@ class ConfirmModal(ModalScreen[bool]):
 
     def action_cancel(self) -> None:
         self.dismiss(False)
+
+
+class TypePickerModal(ModalScreen[str | None]):
+    """Pick one of a fixed set of string options — e.g. an agent's `type`
+    (claude/opencode) or a connector's `type` (rocketchat/mattermost/voice/
+    script). `dismiss(None)` on cancel/Escape, `dismiss(chosen)` on
+    Enter/click. Generic across both use cases rather than one modal per
+    entity kind — the two callers just differ in `title` and `options`.
+    """
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
+
+    DEFAULT_CSS = """
+    TypePickerModal {
+        align: center middle;
+    }
+    #type-picker-dialog {
+        width: auto;
+        min-width: 30;
+        max-width: 60;
+        height: auto;
+        border: thick $primary;
+        padding: 1 2;
+        background: $surface;
+    }
+    #type-picker-list {
+        height: auto;
+        margin-top: 1;
+    }
+    """
+
+    def __init__(self, title: str, options: list[str]):
+        super().__init__()
+        self.title_text = title
+        self.options = options
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="type-picker-dialog"):
+            yield Static(self.title_text, id="type-picker-title")
+            yield ListView(
+                *[ListItem(Label(option), name=option) for option in self.options],
+                id="type-picker-list",
+            )
+
+    def on_list_view_selected(self, event: ListView.Selected) -> None:
+        self.dismiss(event.item.name)
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -100,6 +100,23 @@ _PERMISSIONS_FORM_FIELDS: list[_FieldSpec] = [
 _ALL_FORM_FIELDS = (*_FORM_FIELDS, *_PERMISSIONS_FORM_FIELDS)
 
 
+class _AgentForm(VerticalScroll):
+    """The form's scroll container — Up/Down move between fields instead of
+    scrolling (VerticalScroll's own inherited action_scroll_up/down, bound
+    to up/down by default). A form is naturally row-oriented, so this reads
+    more like a real form than a scrollable document; Home/End/PageUp/
+    PageDown and the mouse wheel still scroll if the form doesn't fit the
+    terminal. Only overriding the two ACTIONS (not adding new BINDINGS) —
+    Select's own dropdown still handles up/down itself while open, since
+    that's resolved before it ever reaches this container."""
+
+    def action_scroll_up(self) -> None:
+        self.screen.focus_previous()
+
+    def action_scroll_down(self) -> None:
+        self.screen.focus_next()
+
+
 def _widget_id(key: str) -> str:
     return "field-" + key.replace(".", "-")
 
@@ -318,7 +335,7 @@ class AgentDetailScreen(DetailScreen):
             return None
 
     def _compose_form(self) -> ComposeResult:
-        with VerticalScroll(id="agent-form"):
+        with _AgentForm(id="agent-form"):
             if self.mode == "create":
                 yield Static("[bold]New agent[/bold]")
                 with Horizontal(classes="field-row"):
@@ -405,6 +422,17 @@ class AgentDetailScreen(DetailScreen):
         self._populating = True
         await self.recompose()
         self.call_after_refresh(self._stop_populating)
+        # Footer subscribes to Screen.bindings_updated_signal in ITS OWN
+        # on_mount — recompose() mounts a brand-new Footer instance, but
+        # nothing re-publishes that signal just because a new subscriber
+        # showed up, so the fresh Footer's `_bindings_ready` reactive stays
+        # False forever and it renders as a blank bar (confirmed empirically:
+        # reproduced by view -> edit -> back -> edit and inspecting Footer's
+        # FooterKey children directly — 4 at first mount, 0 after this
+        # recompose, permanently). refresh_bindings() is Screen's own public
+        # method for exactly this: it re-publishes the signal so every
+        # current subscriber (including the new Footer) recomputes.
+        self.refresh_bindings()
 
     @work
     async def action_back(self) -> None:
@@ -423,6 +451,7 @@ class AgentDetailScreen(DetailScreen):
             self.mode = "view"
             self._form_dirty = False
             await self.recompose()
+            self.refresh_bindings()  # see action_edit()'s comment — same fix
 
     def _collect_field_updates(self) -> dict[str, object] | None:
         """Diff every form widget against `_initial_values`. Returns

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -100,23 +100,6 @@ _PERMISSIONS_FORM_FIELDS: list[_FieldSpec] = [
 _ALL_FORM_FIELDS = (*_FORM_FIELDS, *_PERMISSIONS_FORM_FIELDS)
 
 
-class _AgentForm(VerticalScroll):
-    """The form's scroll container — Up/Down move between fields instead of
-    scrolling (VerticalScroll's own inherited action_scroll_up/down, bound
-    to up/down by default). A form is naturally row-oriented, so this reads
-    more like a real form than a scrollable document; Home/End/PageUp/
-    PageDown and the mouse wheel still scroll if the form doesn't fit the
-    terminal. Only overriding the two ACTIONS (not adding new BINDINGS) —
-    Select's own dropdown still handles up/down itself while open, since
-    that's resolved before it ever reaches this container."""
-
-    def action_scroll_up(self) -> None:
-        self.screen.focus_previous()
-
-    def action_scroll_down(self) -> None:
-        self.screen.focus_next()
-
-
 def _widget_id(key: str) -> str:
     return "field-" + key.replace(".", "-")
 
@@ -201,6 +184,13 @@ class AgentDetailScreen(DetailScreen):
     BINDINGS = [
         Binding("e", "edit", "Edit", show=True),
         Binding("ctrl+s", "save", "Save", show=True),
+        # Screen already binds tab/shift+tab to app.focus_next/focus_previous
+        # with show=False (textual/screen.py) — re-bound here with show=True,
+        # same pattern OverviewScreen already uses, so the footer tells the
+        # user how to move between fields (user-reported gap: Up/Down was
+        # tried as an alternative and reverted — see git history — Tab is
+        # the one reliable, discoverable way to navigate this form).
+        Binding("tab", "app.focus_next", "Next field", show=True),
     ]
 
     DEFAULT_CSS = """
@@ -257,6 +247,17 @@ class AgentDetailScreen(DetailScreen):
 
     def _stop_populating(self) -> None:
         self._populating = False
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Hide 'Edit' from the footer once already editing/creating (it's a
+        no-op there — action_edit() only does something from view mode —
+        and user-reported that a footer hint for a no-op key is confusing),
+        and hide 'Save' while still in view mode (nothing to save yet)."""
+        if action == "edit":
+            return self.mode == "view"
+        if action == "save":
+            return self.mode != "view"
+        return True
 
     # ── view mode ────────────────────────────────────────────────────────────
 
@@ -335,7 +336,7 @@ class AgentDetailScreen(DetailScreen):
             return None
 
     def _compose_form(self) -> ComposeResult:
-        with _AgentForm(id="agent-form"):
+        with VerticalScroll(id="agent-form"):
             if self.mode == "create":
                 yield Static("[bold]New agent[/bold]")
                 with Horizontal(classes="field-row"):

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -1,36 +1,211 @@
-"""AgentDetailScreen — view (and, in a later phase, edit/create) a single
-agent.
+"""AgentDetailScreen — view, edit, and create a single agent.
 
 Unlike connectors, the agent schema is complete (additionalProperties:
-false in gateway/schema/config.schema.json's $defs/agent), so Phase 1 shows
-a fixed field list with a provenance marker per field (explicit / inherited
+false in gateway/schema/config.schema.json's $defs/agent), so this shows a
+fixed field list with a provenance marker per field (explicit / inherited
 from agent_defaults / explicit-null-suppressing) instead of a generic dump.
+"_FORM_FIELDS"/"_PERMISSIONS_FORM_FIELDS" below are a manually-maintained
+mirror of that schema (matching Phase 1's `_KNOWN_FIELDS`, not a runtime
+JSON-schema interpreter) — safe because the schema is closed
+(`additionalProperties: false`), so there's no drift risk from a field this
+form doesn't know about sneaking in.
 
-Tool lists render the PRE-resolve representation (preset-name strings vs
-inline {tool, params} dicts) — never the flattened list[ToolRule] that
-_resolve_tool_entries produces, since that flattening is one-way and loses
-which items came from a preset (docs/design/config-tool.md, Q3/Q5).
+Tool lists (`owner_allowed_tools`/`guest_allowed_tools`) still render as
+view-only PRE-resolve representation here — editing them is
+docs/design/config-tool.md's separate tool-list-editor work, not this
+screen.
+
+Edit/create semantics (docs/design/config-tool.md decision 2 — "editing an
+inherited field always writes an explicit per-entry override"): nothing is
+written to `EditableConfig.document` until Save. On Save, every field is
+diffed against the value captured when the form opened; only fields that
+actually changed are written to the raw entry (clearing a field back to
+blank reverts it to inherited, rather than writing an explicit null — see
+`_apply_update`). This keeps every untouched field's provenance exactly as
+it was, and keeps a not-yet-saved edit from ever touching disk.
 """
 
 from __future__ import annotations
 
-from typing import Literal
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Literal
+
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, VerticalScroll
+from textual.widgets import Checkbox, Footer, Header, Input, Select, Static
 
 from ..formatting import format_value, provenance_label
-from ..model import EditableConfig
+from ..modals import ConfirmModal
+from ..model import EditableConfig, Provenance
 from .base import DetailScreen
 
+if TYPE_CHECKING:
+    from ..app import ConfigToolApp
+
 # Top-level agent fields worth a dedicated provenance-annotated line, in the
-# same order as AgentConfig's own fields (gateway/core/config.py).
+# same order as AgentConfig's own fields (gateway/core/config.py). View mode
+# only — the form below has its own, edit-oriented field list.
 _KNOWN_FIELDS = [
     "type", "command", "working_directory", "session_prefix",
     "lazy_instruction_loading", "new_session_args", "context_inject_files",
     "timeout", "permissions",
 ]
 
+# AgentConfig/PermissionConfig's own dataclass defaults (gateway/core/
+# config.py) — used ONLY to prefill the form with the true effective value
+# when a field is set by neither the entry nor agent_defaults. Unlike view
+# mode (which simply omits a line for an absent field), a form editing that
+# field needs to show what it would actually evaluate to right now.
+_AGENT_DATACLASS_DEFAULTS: dict[str, object] = {
+    "type": "claude",
+    "command": "claude",
+    "working_directory": "",
+    "session_prefix": "agent-chat",
+    "lazy_instruction_loading": True,
+    "new_session_args": [],
+    "context_inject_files": [],
+    "timeout": 360,
+    "permissions.enabled": False,
+    "permissions.timeout": 300,
+    "permissions.skip_owner_approval": False,
+}
+
+
+@dataclass(frozen=True)
+class _FieldSpec:
+    key: str  # dotted for a permissions sub-field, e.g. "permissions.timeout"
+    kind: Literal["str", "int", "bool", "list", "enum"]
+    label: str
+    options: tuple[str, ...] | None = None
+
+
+_FORM_FIELDS: list[_FieldSpec] = [
+    _FieldSpec("type", "enum", "Type", options=("claude", "opencode")),
+    _FieldSpec("command", "str", "Command"),
+    _FieldSpec("working_directory", "str", "Working directory"),
+    _FieldSpec("session_prefix", "str", "Session prefix"),
+    _FieldSpec("lazy_instruction_loading", "bool", "Lazy instruction loading"),
+    _FieldSpec("new_session_args", "list", "New session args (comma-separated)"),
+    _FieldSpec("context_inject_files", "list", "Context inject files (comma-separated)"),
+    _FieldSpec("timeout", "int", "Timeout (seconds)"),
+]
+_PERMISSIONS_FORM_FIELDS: list[_FieldSpec] = [
+    _FieldSpec("permissions.enabled", "bool", "Permissions enabled"),
+    _FieldSpec("permissions.timeout", "int", "Permissions timeout (seconds)"),
+    _FieldSpec("permissions.skip_owner_approval", "bool", "Skip owner approval"),
+]
+_ALL_FORM_FIELDS = (*_FORM_FIELDS, *_PERMISSIONS_FORM_FIELDS)
+
+
+def _widget_id(key: str) -> str:
+    return "field-" + key.replace(".", "-")
+
+
+def _get_nested(d: dict, dotted_key: str) -> object:
+    if "." not in dotted_key:
+        return d.get(dotted_key)
+    parent_key, sub_key = dotted_key.split(".", 1)
+    parent = d.get(parent_key)
+    return parent.get(sub_key) if isinstance(parent, dict) else None
+
+
+def _list_to_text(value: object) -> str:
+    if not value:
+        return ""
+    return ", ".join(str(v) for v in value)
+
+
+def _text_to_list(text: str) -> list[str]:
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+def _resolve_working_directory(config_path: Path, raw_value: str) -> Path:
+    """Mirror gateway/config.py's own working_directory resolution EXACTLY
+    (expanduser, then resolve relative to the config file's directory if
+    still not absolute) — used only to compute the inline warning below, so
+    it must resolve the same path the real loader would, or the warning
+    fires on paths that are actually fine (e.g. `~/...` or a relative path)."""
+    expanded = Path(raw_value).expanduser()
+    if expanded.is_absolute():
+        return expanded
+    return (config_path.resolve().parent / expanded).resolve()
+
+
+def _working_directory_warning(config_path: Path, raw_value: str) -> str:
+    """Early, non-blocking heads-up only — NOT a substitute for save()'s own
+    validate_config() call, which still hard-fails if the directory is
+    missing at save time (GatewayConfig.from_file requires it to exist;
+    that enforcement is intentionally left alone here, see
+    docs/design/config-tool.md's Phase 2 status notes)."""
+    text = raw_value.strip()
+    if not text:
+        return ""
+    resolved = _resolve_working_directory(config_path, text)
+    if not resolved.is_dir():
+        return f"[yellow]⚠ does not exist yet: {resolved}[/yellow]"
+    return ""
+
+
+def _apply_update(entry: dict, dotted_key: str, value: object) -> None:
+    """Write `value` (or clear, if None) into `entry` at `dotted_key`.
+
+    A top-level key: set it, or pop it entirely if `value` is None (revert
+    to inherited/default). A `permissions.*` key: read-modify-write the
+    `permissions` sub-dict, dropping it entirely once its last explicit
+    sub-key is cleared, so a fully-cleared `permissions` block reverts to
+    inheriting from `agent_defaults.permissions` again, not an empty `{}`
+    stub sitting in the entry forever.
+    """
+    if "." not in dotted_key:
+        if value is None:
+            entry.pop(dotted_key, None)
+        else:
+            entry[dotted_key] = value
+        return
+    parent_key, sub_key = dotted_key.split(".", 1)
+    parent = entry.get(parent_key)
+    parent = dict(parent) if isinstance(parent, dict) else {}
+    if value is None:
+        parent.pop(sub_key, None)
+    else:
+        parent[sub_key] = value
+    if parent:
+        entry[parent_key] = parent
+    else:
+        entry.pop(parent_key, None)
+
 
 class AgentDetailScreen(DetailScreen):
     BODY_ID = "agent-detail-body"
+
+    BINDINGS = [
+        Binding("e", "edit", "Edit", show=True),
+        Binding("ctrl+s", "save", "Save", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    AgentDetailScreen #agent-form {
+        padding: 1 2;
+    }
+    AgentDetailScreen .field-row {
+        height: auto;
+        margin-bottom: 1;
+    }
+    AgentDetailScreen .field-label {
+        width: 30;
+        padding-top: 1;
+    }
+    AgentDetailScreen .field-provenance {
+        padding-top: 1;
+        margin-left: 2;
+    }
+    AgentDetailScreen Checkbox {
+        width: auto;
+    }
+    """
 
     def __init__(
         self,
@@ -44,6 +219,37 @@ class AgentDetailScreen(DetailScreen):
         self.agent_name = name
         self.entry = entry
         self.mode = mode
+        self._form_dirty = False
+        self._initial_values: dict[str, object] = {}
+        # Input/Select fire their own Changed message once at initial mount
+        # with whatever value the constructor was given (confirmed
+        # empirically — Checkbox does not, but Input/Select do). Without this
+        # guard, simply OPENING the edit form would immediately mark it
+        # dirty, incorrectly prompting a discard-confirmation on Escape even
+        # though the user never touched anything. Cleared via
+        # call_after_refresh (see on_mount/action_edit), which runs after
+        # that initial burst of Changed messages has already been processed.
+        self._populating = False
+        if self.mode != "view":
+            self._compute_initial_values()
+            self._populating = True
+
+    def on_mount(self) -> None:
+        if self._populating:
+            self.call_after_refresh(self._stop_populating)
+
+    def _stop_populating(self) -> None:
+        self._populating = False
+
+    # ── view mode ────────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        if self.mode == "view":
+            yield VerticalScroll(Static(self._body_text(), id=self.BODY_ID))
+        else:
+            yield from self._compose_form()
+        yield Footer()
 
     def _body_text(self) -> str:
         description = self.entry.get("description")
@@ -85,3 +291,217 @@ class AgentDetailScreen(DetailScreen):
                     lines.append(f"  {tool} / {params or '(any)'}")
 
         return "\n".join(lines)
+
+    # ── edit/create form ─────────────────────────────────────────────────────
+
+    def _compute_initial_values(self) -> None:
+        """Snapshot the effective value of every form field, exactly as it
+        would display right now — captured once, when entering edit/create
+        mode, and used both to prefill widgets and (on Save) to detect which
+        fields the user actually changed. See module docstring."""
+        try:
+            merged = self.cfg.merged_entry("agent_defaults", self.entry)
+        except (ValueError, FileNotFoundError):
+            merged = dict(self.entry)
+        for spec in _ALL_FORM_FIELDS:
+            value = _get_nested(merged, spec.key)
+            if value is None:
+                value = _AGENT_DATACLASS_DEFAULTS.get(spec.key)
+            self._initial_values[spec.key] = value
+        self._initial_values["description"] = self.entry.get("description")
+
+    def _field_provenance(self, spec: _FieldSpec) -> Provenance | None:
+        top_key = spec.key.split(".", 1)[0]
+        try:
+            return self.cfg.field_provenance("agent_defaults", self.entry, top_key)
+        except (ValueError, FileNotFoundError):
+            return None
+
+    def _compose_form(self) -> ComposeResult:
+        with VerticalScroll(id="agent-form"):
+            if self.mode == "create":
+                yield Static("[bold]New agent[/bold]")
+                with Horizontal(classes="field-row"):
+                    yield Static("Name", classes="field-label")
+                    yield Input(id="field-name", placeholder="agent name")
+            else:
+                yield Static(f"[bold]{self.agent_name}[/bold]  (editing)")
+
+            with Horizontal(classes="field-row"):
+                yield Static("Description", classes="field-label")
+                yield Input(
+                    id="field-description",
+                    value=self._initial_values.get("description") or "",
+                )
+
+            for spec in _FORM_FIELDS:
+                yield from self._compose_field_row(spec)
+                if spec.key == "working_directory":
+                    yield Static(
+                        _working_directory_warning(self.cfg.path, str(self._initial_values.get(spec.key) or "")),
+                        id="wd-warning",
+                    )
+
+            yield Static("[bold]Permissions[/bold]")
+            for spec in _PERMISSIONS_FORM_FIELDS:
+                yield from self._compose_field_row(spec)
+
+    def _compose_field_row(self, spec: _FieldSpec) -> ComposeResult:
+        provenance = self._field_provenance(spec)
+        prov_text = f"[dim]({provenance_label(provenance)})[/dim]" if provenance else ""
+        initial = self._initial_values.get(spec.key)
+        with Horizontal(classes="field-row"):
+            yield Static(spec.label, classes="field-label")
+            if spec.kind == "bool":
+                yield Checkbox(value=bool(initial), id=_widget_id(spec.key))
+            elif spec.kind == "enum":
+                yield Select(
+                    [(o, o) for o in (spec.options or ())],
+                    value=initial if initial in (spec.options or ()) else (spec.options or (None,))[0],
+                    allow_blank=False,
+                    id=_widget_id(spec.key),
+                )
+            elif spec.kind == "list":
+                yield Input(value=_list_to_text(initial), id=_widget_id(spec.key))
+            else:
+                yield Input(value="" if initial is None else str(initial), id=_widget_id(spec.key))
+            yield Static(prov_text, classes="field-provenance")
+
+    # ── dirty tracking (per-screen, not EditableConfig.dirty — nothing is
+    # written to `document` until Save, so cfg.dirty stays False the whole
+    # time the user is mid-form; this local flag is what Escape checks) ──────
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if event.input.id == _widget_id("working_directory"):
+            self.query_one("#wd-warning", Static).update(
+                _working_directory_warning(self.cfg.path, event.input.value)
+            )
+        if self._populating:
+            return
+        self._form_dirty = True
+
+    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
+        if self._populating:
+            return
+        self._form_dirty = True
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if self._populating:
+            return
+        self._form_dirty = True
+
+    # ── actions ──────────────────────────────────────────────────────────────
+
+    async def action_edit(self) -> None:
+        if self.mode != "view":
+            return
+        self.mode = "edit"
+        self._form_dirty = False
+        self._compute_initial_values()
+        # recompose() does NOT re-trigger on_mount (that only fires once, for
+        # the screen's own initial push) — so the populating guard has to be
+        # armed and disarmed around this recompose explicitly, the same way
+        # on_mount handles it for a screen pushed directly in create mode.
+        self._populating = True
+        await self.recompose()
+        self.call_after_refresh(self._stop_populating)
+
+    @work
+    async def action_back(self) -> None:
+        if self.mode == "view":
+            self.app.pop_screen()
+            return
+        if self._form_dirty:
+            discard = await self.app.push_screen_wait(
+                ConfirmModal("Discard unsaved changes to this agent?", confirm_label="Discard")
+            )
+            if not discard:
+                return
+        if self.mode == "create":
+            self.app.pop_screen()
+        else:
+            self.mode = "view"
+            self._form_dirty = False
+            await self.recompose()
+
+    def _collect_field_updates(self) -> dict[str, object] | None:
+        """Diff every form widget against `_initial_values`. Returns
+        {dotted_key: new_value_or_None} for changed fields only (None means
+        "clear it — revert to inherited/default"), or None (having already
+        called self.notify()) if a field fails to parse."""
+        updates: dict[str, object] = {}
+        for spec in _ALL_FORM_FIELDS:
+            widget = self.query_one("#" + _widget_id(spec.key))
+            try:
+                new_value = self._read_widget_value(spec, widget)
+            except ValueError as exc:
+                self.notify(str(exc), severity="error")
+                return None
+            if new_value != self._initial_values.get(spec.key):
+                updates[spec.key] = new_value
+
+        desc_widget = self.query_one("#field-description", Input)
+        new_desc = desc_widget.value.strip() or None
+        if new_desc != self._initial_values.get("description"):
+            updates["description"] = new_desc
+        return updates
+
+    def _read_widget_value(self, spec: _FieldSpec, widget: object) -> object:
+        if spec.kind == "bool":
+            return widget.value
+        if spec.kind == "enum":
+            return widget.value
+        if spec.kind == "list":
+            return _text_to_list(widget.value) or None
+        if spec.kind == "int":
+            text = widget.value.strip()
+            if not text:
+                return None
+            try:
+                return int(text)
+            except ValueError:
+                raise ValueError(f"{spec.label}: must be a whole number, got {text!r}") from None
+        text = widget.value.strip()
+        return text or None
+
+    async def action_save(self) -> None:
+        if self.mode == "view":
+            return
+
+        updates = self._collect_field_updates()
+        if updates is None:
+            return  # a field failed to parse; notify() already shown
+
+        name = self.agent_name
+        if self.mode == "create":
+            name = self.query_one("#field-name", Input).value.strip()
+            if not name:
+                self.notify("Name is required.", severity="error")
+                return
+            if name in self.cfg.agents_raw:
+                self.notify(f"An agent named '{name}' already exists.", severity="error")
+                return
+
+        target_entry = self.entry if self.mode == "edit" else dict(self.entry)
+        for key, value in updates.items():
+            _apply_update(target_entry, key, value)
+
+        if self.mode == "create":
+            self.cfg.document.setdefault("agents", {})[name] = target_entry
+        self.cfg.mark_dirty()
+
+        try:
+            self.cfg.save()
+        except (ValueError, FileNotFoundError) as exc:
+            if self.mode == "create":
+                # Nothing existed under this name before this screen ever
+                # ran — remove it so a failed save doesn't leave a phantom
+                # half-created agent sitting in memory.
+                del self.cfg.document["agents"][name]
+            self.notify(f"Could not save: {exc}", severity="error")
+            return
+
+        self.app.pop_screen()
+        app: "ConfigToolApp" = self.app  # type: ignore[assignment]
+        app.notify(f"Saved agent '{name}'.", severity="information")
+        app.reload_config()

--- a/gateway/configtool/screens/overview.py
+++ b/gateway/configtool/screens/overview.py
@@ -2,14 +2,16 @@
 
 Five tabs: Connectors, Agents, Watchers, Defaults, Tool Presets — the latter
 two are first-class per docs/design/config-tool.md (shared resources, not
-footnotes). Phase 1 is read-only: selecting a row pushes a *DetailScreen in
-view mode; there is no add/edit/delete yet.
+footnotes). Selecting a row pushes a *DetailScreen in view mode. 'n'
+(new_entity) creates an entry on the active tab — so far only Agents
+supports it; other tabs still notify rather than doing nothing or crashing.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
@@ -17,12 +19,15 @@ from textual.screen import Screen
 from textual.widgets import DataTable, Footer, Header, Static, TabbedContent, TabPane
 
 from ..formatting import status_badge
+from ..modals import TypePickerModal
 from ..model import StatusIndex
 from .agent_detail import AgentDetailScreen
 from .connector_detail import ConnectorDetailScreen
 from .defaults import DefaultsScreen
 from .tool_presets import ToolPresetsScreen
 from .watcher_detail import WatcherDetailScreen
+
+_AGENT_TYPES = ("claude", "opencode")
 
 if TYPE_CHECKING:
     from ..app import ConfigToolApp
@@ -46,6 +51,7 @@ class OverviewScreen(Screen):
         # Input widgets on those screens, where a bare 'q' typed into a field
         # must not quit the app.
         Binding("q", "app.quit", "Quit", show=True),
+        Binding("n", "new_entity", "New", show=True),
     ]
 
     def compose(self) -> ComposeResult:
@@ -78,6 +84,32 @@ class OverviewScreen(Screen):
     def action_edit_config(self) -> None:
         app: "ConfigToolApp" = self.app  # type: ignore[assignment]
         app.open_editor_and_reload()
+
+    @work
+    async def action_new_entity(self) -> None:
+        """'n' — scoped to whichever tab is active. Only Agents supports
+        creation so far (docs/design/config-tool.md's Phase 2 order does
+        connector/agent CRUD together; agent landed first — see the design
+        doc's Phase 2 status). Other tabs just notify, rather than doing
+        nothing silently or crashing."""
+        app: "ConfigToolApp" = self.app  # type: ignore[assignment]
+        if app.editable_config is None:
+            self.notify("Config does not currently load — nothing to add to.", severity="error")
+            return
+
+        active_tab = self.query_one(TabbedContent).active
+        if active_tab != "tab-agents":
+            self.notify("Creating a new entry isn't supported on this tab yet.", severity="warning")
+            return
+
+        agent_type = await self.app.push_screen_wait(
+            TypePickerModal("New agent — pick a type", list(_AGENT_TYPES))
+        )
+        if agent_type is None:
+            return
+        self.app.push_screen(
+            AgentDetailScreen(app.editable_config, "", {"type": agent_type}, mode="create")
+        )
 
     def action_refresh(self) -> None:
         # Must go through app.reload_config() (re-reads EditableConfig.document

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -1,0 +1,505 @@
+"""Pilot-based tests for AgentDetailScreen's create/edit flow — the first
+entity CRUD screen in Phase 2 (docs/design/config-tool.md decision 2:
+"editing an inherited field always writes an explicit per-entry override").
+
+These pin the write-back diffing mechanism specifically (advisor-flagged as
+the highest-risk code in this change): an untouched inherited field must
+never silently become explicit, a changed field must persist, and clearing
+a field must revert it to inherited rather than writing an explicit null.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+from textual.widgets import Checkbox, DataTable, Input, Select, Static
+
+from gateway.configtool.app import ConfigToolApp
+from gateway.configtool.modals import ConfirmModal, TypePickerModal
+from gateway.configtool.screens.agent_detail import AgentDetailScreen
+from gateway.configtool.screens.overview import OverviewScreen
+
+
+def _write_config(tmp_path: Path, yaml_text: str) -> str:
+    path = tmp_path / "config.yaml"
+    path.write_text(textwrap.dedent(yaml_text))
+    return str(path)
+
+
+@pytest.fixture
+def work_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "work"
+    d.mkdir()
+    return d
+
+
+def _config_with_one_agent(work_dir: Path, agent_extra: str = "") -> str:
+    return f"""\
+        agent_defaults:
+          type: claude
+          timeout: 1800
+        agents:
+          existing-agent:
+            working_directory: {work_dir}
+{textwrap.indent(agent_extra, "            ") if agent_extra else ""}
+        connectors:
+          - name: rc
+            type: rocketchat
+            server: {{url: "http://localhost:3000", username: bot, password: pw}}
+        watchers:
+          - connector: rc
+            agent: existing-agent
+            room: general
+    """
+
+
+async def _open_agent_in_edit_mode(pilot, app) -> None:
+    table = app.screen.query_one("#agents-table", DataTable)
+    table.focus()
+    table.move_cursor(row=0)
+    await pilot.press("enter")
+    await pilot.pause()
+    await pilot.press("e")
+    await pilot.pause()
+
+
+class TestNewAgentEntryPoint:
+    async def test_n_key_on_agents_tab_opens_type_picker(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-agents"
+            await pilot.pause()
+
+            await pilot.press("n")
+            await pilot.pause()
+            assert isinstance(app.screen, TypePickerModal)
+
+    async def test_n_key_on_connectors_tab_notifies_instead_of_crashing(
+        self, tmp_path, work_dir
+    ):
+        """Connector creation isn't built yet (separate task) — pressing 'n'
+        on that tab must be a friendly no-op, not a crash or silent no-op."""
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-connectors"
+            await pilot.pause()
+
+            await pilot.press("n")
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)  # did not navigate anywhere
+
+    async def test_cancelling_the_type_picker_returns_to_overview(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-agents"
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            assert isinstance(app.screen, TypePickerModal)
+
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)
+
+
+class TestCreateAgent:
+    async def test_creating_an_agent_persists_it_and_returns_to_overview(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-agents"
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.press("enter")  # first option ("claude")
+            await pilot.pause()
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "create"
+
+            app.screen.query_one("#field-name", Input).value = "brand-new"
+            app.screen.query_one("#field-working_directory", Input).value = str(work_dir)
+            await pilot.pause()
+
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["agents"]["brand-new"]["type"] == "claude"
+            assert raw["agents"]["brand-new"]["working_directory"] == str(work_dir)
+            # A backup of the pre-save file must exist (EditableConfig.save()).
+            assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
+
+    async def test_creating_with_a_duplicate_name_shows_an_error_and_stays_in_the_form(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-agents"
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            app.screen.query_one("#field-name", Input).value = "existing-agent"
+            app.screen.query_one("#field-working_directory", Input).value = str(work_dir)
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "create"
+            # The original agent must be untouched.
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["agents"]["existing-agent"] == {"working_directory": str(work_dir)}
+
+    async def test_creating_with_a_blank_name_shows_an_error_and_stays_in_the_form(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-agents"
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "create"
+
+    async def test_a_save_failure_rolls_back_the_phantom_created_entry(
+        self, tmp_path, work_dir
+    ):
+        """working_directory is required to exist for validate_config() to
+        pass (GatewayConfig.from_file hard-enforces it) — creating an agent
+        pointed at a nonexistent directory must fail save() and must NOT
+        leave a half-created agent sitting in cfg.document."""
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-agents"
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            app.screen.query_one("#field-name", Input).value = "doomed-agent"
+            app.screen.query_one("#field-working_directory", Input).value = str(
+                tmp_path / "does-not-exist"
+            )
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "create"
+            assert "doomed-agent" not in app.editable_config.agents_raw
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert "doomed-agent" not in raw.get("agents", {})
+
+
+class TestEditAgent:
+    async def test_edit_mode_prefills_the_effective_merged_value(self, tmp_path, work_dir):
+        config_path = _write_config(
+            tmp_path, _config_with_one_agent(work_dir, "session_prefix: custom-prefix\n")
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            assert app.screen.query_one("#field-session_prefix", Input).value == "custom-prefix"
+            # timeout is absent from the entry itself but set in agent_defaults —
+            # the form must show the INHERITED effective value (1800), not blank.
+            assert app.screen.query_one("#field-timeout", Input).value == "1800"
+
+    async def test_changing_one_field_writes_only_that_field(self, tmp_path, work_dir):
+        config_path = _write_config(
+            tmp_path, _config_with_one_agent(work_dir, "session_prefix: custom-prefix\n")
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-command", Input).value = "custom-claude-binary"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert entry["command"] == "custom-claude-binary"
+            # untouched fields must be exactly as they were — timeout must
+            # NOT have become an explicit "1800" on the entry just because
+            # it was displayed (that would defeat agent_defaults entirely).
+            assert "timeout" not in entry
+            assert entry["session_prefix"] == "custom-prefix"
+            assert entry["working_directory"] == str(work_dir)
+
+    async def test_clearing_a_field_reverts_it_to_inherited(self, tmp_path, work_dir):
+        config_path = _write_config(
+            tmp_path, _config_with_one_agent(work_dir, "timeout: 500\n")
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            timeout_input = app.screen.query_one("#field-timeout", Input)
+            assert timeout_input.value == "500"
+            timeout_input.value = ""
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert "timeout" not in entry  # reverted to inherited, not explicit null
+
+    async def test_toggling_a_checkbox_and_back_to_its_original_value_is_a_no_op(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            checkbox = app.screen.query_one("#field-lazy_instruction_loading", Checkbox)
+            original = checkbox.value
+            checkbox.value = not original
+            await pilot.pause()
+            checkbox.value = original
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert "lazy_instruction_loading" not in entry
+
+    async def test_permissions_checkbox_subfield_write(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-permissions-enabled", Checkbox).value = True
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert entry["permissions"] == {"enabled": True}
+
+            # Toggling AWAY from the value shown when the form opened always
+            # writes an explicit value — a checkbox has no third "revert to
+            # inherited" state (unlike str/int/list fields, which revert when
+            # cleared to blank; see the int-field test below). Re-opening
+            # with enabled=True shown, then unchecking it, persists an
+            # explicit False, not a cleared key.
+            await _open_agent_in_edit_mode(pilot, app)
+            assert app.screen.query_one("#field-permissions-enabled", Checkbox).value is True
+            app.screen.query_one("#field-permissions-enabled", Checkbox).value = False
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert entry["permissions"] == {"enabled": False}
+
+    async def test_permissions_int_subfield_clears_and_drops_the_whole_dict(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(
+            tmp_path, _config_with_one_agent(work_dir, "permissions: {timeout: 120}\n")
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            timeout_input = app.screen.query_one("#field-permissions-timeout", Input)
+            assert timeout_input.value == "120"
+            timeout_input.value = ""
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            entry = app.editable_config.agents_raw["existing-agent"]
+            # The whole permissions dict is dropped, not left behind as {} —
+            # timeout was its only explicit key.
+            assert "permissions" not in entry
+
+    async def test_invalid_integer_shows_error_and_does_not_touch_document(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-timeout", Input).value = "not-a-number"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "edit"
+            assert app.editable_config.dirty is False
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert "timeout" not in entry
+
+    async def test_working_directory_warning_appears_for_a_missing_directory(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            wd_input = app.screen.query_one("#field-working_directory", Input)
+            wd_input.value = str(tmp_path / "does-not-exist-yet")
+            await pilot.pause()
+            warning = str(app.screen.query_one("#wd-warning", Static).render())
+            assert "does not exist yet" in warning
+
+            wd_input.value = str(work_dir)
+            await pilot.pause()
+            warning = str(app.screen.query_one("#wd-warning", Static).render())
+            assert "does not exist yet" not in warning
+
+    async def test_type_select_supports_switching_and_persists(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            select = app.screen.query_one("#field-type", Select)
+            assert select.value == "claude"
+            select.value = "opencode"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert entry["type"] == "opencode"
+
+
+class TestEscapeConfirmation:
+    async def test_escape_with_no_changes_returns_to_view_with_no_modal(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "view"
+
+    async def test_escape_with_unsaved_changes_shows_confirm_modal(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-command", Input).value = "changed"
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+    async def test_cancelling_the_confirm_modal_keeps_editing(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-command", Input).value = "changed"
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+            await pilot.press("enter")  # Cancel is focused by default
+            await pilot.pause()
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "edit"
+            assert app.screen.query_one("#field-command", Input).value == "changed"
+
+    async def test_confirming_discard_reverts_to_the_original_view(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-command", Input).value = "changed"
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+            await pilot.press("tab", "enter")  # move focus to Discard, press it
+            await pilot.pause()
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "view"
+            # Nothing was ever written — command was never actually saved.
+            assert "command" not in app.editable_config.agents_raw["existing-agent"]
+
+    async def test_create_mode_escape_with_unsaved_changes_pops_the_screen_on_discard(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-agents"
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(app.screen, AgentDetailScreen)
+
+            app.screen.query_one("#field-name", Input).value = "abandoned"
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+            await pilot.press("tab", "enter")
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)
+            assert "abandoned" not in app.editable_config.agents_raw

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -547,39 +547,64 @@ class TestFooterSurvivesRecompose:
             assert footer_key_count() > 0  # re-entered edit — this used to be 0
 
 
-class TestArrowKeyFieldNavigation:
-    """Up/Down move between form fields instead of scrolling the form
-    container (_AgentForm overrides VerticalScroll's inherited
-    action_scroll_up/down) — user-requested, since Tab-only navigation in a
-    long form is tedious. Home/End/PageUp/PageDown and the mouse wheel still
-    scroll if the form doesn't fit the terminal."""
+class TestFooterHintsMatchAvailableActions:
+    """User-reported: the footer showed 'e: Edit' even while already in edit
+    mode, where pressing 'e' is a no-op (action_edit() only does something
+    from view mode) — confusing. Fixed via check_action(): 'Edit' is hidden
+    once mode != "view"; 'Save' is hidden while mode == "view" (nothing to
+    save yet); 'Tab: Next field' is shown throughout, mirroring
+    OverviewScreen's existing tab-hint pattern, as the one reliable,
+    discoverable way to move between fields (an Up/Down alternative was
+    tried and reverted after user testing surfaced inconsistent behavior in
+    a real terminal that Pilot's headless driver didn't catch)."""
 
-    async def test_down_moves_focus_to_the_next_field(self, tmp_path, work_dir):
+    def _visible_keys(self, app) -> set[str]:
+        from textual.widgets import Footer
+        from textual.widgets._footer import FooterKey
+
+        return {k.key for k in app.screen.query_one(Footer).query(FooterKey)}
+
+    async def test_view_mode_shows_edit_not_save(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.screen.query_one("#agents-table", DataTable)
+            table.focus()
+            table.move_cursor(row=0)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            keys = self._visible_keys(app)
+            assert "e" in keys
+            assert "ctrl+s" not in keys
+            assert "tab" in keys
+
+    async def test_edit_mode_shows_save_not_edit(self, tmp_path, work_dir):
         config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
             await pilot.pause()
             await _open_agent_in_edit_mode(pilot, app)
 
-            desc = app.screen.query_one("#field-description", Input)
-            desc.focus()
-            await pilot.pause()
+            keys = self._visible_keys(app)
+            assert "ctrl+s" in keys
+            assert "e" not in keys
+            assert "tab" in keys
 
-            await pilot.press("down")
-            await pilot.pause()
-            assert app.screen.focused.id == "field-type"
-
-    async def test_up_moves_focus_to_the_previous_field(self, tmp_path, work_dir):
+    async def test_create_mode_shows_save_not_edit(self, tmp_path, work_dir):
         config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
             await pilot.pause()
-            await _open_agent_in_edit_mode(pilot, app)
-
-            command_input = app.screen.query_one("#field-command", Input)
-            command_input.focus()
+            app.screen.query_one("TabbedContent").active = "tab-agents"
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.press("enter")
             await pilot.pause()
 
-            await pilot.press("up")
-            await pilot.pause()
-            assert app.screen.focused.id == "field-type"
+            keys = self._visible_keys(app)
+            assert "ctrl+s" in keys
+            assert "e" not in keys
+            assert "tab" in keys

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -15,7 +15,8 @@ from pathlib import Path
 
 import pytest
 import yaml
-from textual.widgets import Checkbox, DataTable, Input, Select, Static
+from textual.widgets import Checkbox, DataTable, Footer, Input, Select, Static
+from textual.widgets._footer import FooterKey
 
 from gateway.configtool.app import ConfigToolApp
 from gateway.configtool.modals import ConfirmModal, TypePickerModal
@@ -503,3 +504,82 @@ class TestEscapeConfirmation:
             await pilot.pause()
             assert isinstance(app.screen, OverviewScreen)
             assert "abandoned" not in app.editable_config.agents_raw
+
+
+class TestFooterSurvivesRecompose:
+    """Regression: Footer subscribes to Screen.bindings_updated_signal in
+    its OWN on_mount — recompose() (used for every view<->edit transition)
+    mounts a brand-new Footer instance, but nothing re-publishes that signal
+    just because a new subscriber showed up, so the fresh Footer's
+    `_bindings_ready` reactive stayed False forever and it rendered as a
+    blank bar with zero FooterKey children, permanently, from the first
+    view->edit transition onward (user-reported). Fixed by calling
+    Screen.refresh_bindings() — its own public API for exactly this — right
+    after every recompose() in action_edit()/action_back()."""
+
+    async def test_footer_keys_survive_view_edit_view_edit_cycle(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.screen.query_one("#agents-table", DataTable)
+            table.focus()
+            table.move_cursor(row=0)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            def footer_key_count() -> int:
+                footer = app.screen.query_one(Footer)
+                return len(list(footer.query(FooterKey)))
+
+            assert footer_key_count() > 0  # initial view mode
+
+            await pilot.press("e")
+            await pilot.pause()
+            assert footer_key_count() > 0  # edit mode — this used to be 0
+
+            await pilot.press("escape")
+            await pilot.pause()
+            assert footer_key_count() > 0  # back to view — this used to be 0
+
+            await pilot.press("e")
+            await pilot.pause()
+            assert footer_key_count() > 0  # re-entered edit — this used to be 0
+
+
+class TestArrowKeyFieldNavigation:
+    """Up/Down move between form fields instead of scrolling the form
+    container (_AgentForm overrides VerticalScroll's inherited
+    action_scroll_up/down) — user-requested, since Tab-only navigation in a
+    long form is tedious. Home/End/PageUp/PageDown and the mouse wheel still
+    scroll if the form doesn't fit the terminal."""
+
+    async def test_down_moves_focus_to_the_next_field(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            desc = app.screen.query_one("#field-description", Input)
+            desc.focus()
+            await pilot.pause()
+
+            await pilot.press("down")
+            await pilot.pause()
+            assert app.screen.focused.id == "field-type"
+
+    async def test_up_moves_focus_to_the_previous_field(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            command_input = app.screen.query_one("#field-command", Input)
+            command_input.focus()
+            await pilot.pause()
+
+            await pilot.press("up")
+            await pilot.pause()
+            assert app.screen.focused.id == "field-type"


### PR DESCRIPTION
## Summary
Third slice of Phase 2 (foundation was #64): the first entity create/edit screen. `AgentDetailScreen` gains edit/create modes, reachable via `n` on the Agents tab (other tabs notify — connector creation is next, not yet built).

- New generic `TypePickerModal` (`ListView`-based), built to be reused by the connector-type picker.
- Write-back implements decision 2 exactly ("editing an inherited field always writes an explicit per-entry override"): nothing touches `document` until Save; every field is diffed against its value when the form opened, and only changed fields are written. Clearing a field reverts it to inherited (pops the key) rather than writing an explicit null; a cleared `permissions.*` sub-field drops the whole `permissions` dict once empty.
- A failed create (duplicate/blank name, or a `save()` validation failure) leaves no trace — no phantom entry left in `document`.
- Tool-list fields (`owner_allowed_tools`/`guest_allowed_tools`) stay view-only here — separate work.

**Two real bugs the tests caught:**
- `Input`/`Select` fire their own `Changed` message once at initial mount (`Checkbox` does not) — simply opening the form was marking it dirty and would wrongly prompt a discard-confirmation on Escape. Fixed with a `_populating` guard cleared via `call_after_refresh`. `Screen.recompose()` does NOT re-trigger `on_mount()`, so the view→edit transition re-arms the guard itself.
- `push_screen_wait()` needs a `@work`-decorated caller (same gotcha `action_quit()` already hit) — `action_back()` is decorated too.

**Discrepancy found and corrected in the design doc:** `working_directory` existence is NOT a soft warning at save time — `GatewayConfig.from_file` hard-requires it, and `save()` intentionally reuses that unchanged validator rather than special-casing this one error. What's built instead: an early, live inline hint (resolved the same way the loader resolves the path) so the user finds out before hitting Save, not just from a generic error after.

## Test plan
- [x] `uv run ruff check gateway/ tests/` — all checks passed
- [x] `uv run pytest tests/unit tests/integration -q` — 1901 passed (21 new tests covering the entry point, create success/duplicate/blank-name/rollback, edit prefill/single-field-write/clear-to-inherit/checkbox-no-op/permissions/invalid-integer/working_directory-warning/type-switching, and the Escape/ConfirmModal flow in both modes)