### PR TITLE
Config TUI: merge-by-key .env writer

### DIFF
--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -140,11 +140,21 @@ per-row status lookups.
    since `push_screen_wait()` requires a worker context) — no edit screen
    sets `dirty` for real yet, but the mechanism is in place for Phase 2's
    CRUD screens to use without further plumbing.
-6. **`.env` secret handling:** password/token/secret fields get a per-field
+6. **`.env` secret handling.** Password/token/secret fields get a per-field
    "store in .env" toggle (default ON) → `${VAR}` placeholder in config,
-   value into `.env`. Needs a new merge-by-key `.env` writer (`onboard.py`'s
-   `_write_env` overwrites the whole file with 3 hardcoded keys — insufficient
-   once multiple connectors each need their own secret upserted).
+   value into `.env`. **Writer shipped:** `gateway/configtool/env_writer.py`'s
+   `upsert_env_vars()` (`onboard.py`'s own `_write_env` overwrites the whole
+   file with 3 hardcoded keys — insufficient once multiple connectors each
+   need their own secret upserted independently). Merges by key: an existing
+   `KEY=...` line is replaced in place; a new key is appended; every other
+   line — comments, blank lines, unrelated keys — is preserved verbatim, in
+   its original position. Restricts the file to 0600 after every write.
+   `.env` resolves the same way `gateway/config.py`'s loader itself resolves
+   it — `EditableConfig.path.parent / ".env"` (`load_dotenv(path.parent /
+   ".env")`), NOT `onboard.py`'s hardcoded `~/.agent-chat-gateway/` — since a
+   config file can live anywhere. The toggle UI + connector-form wiring
+   (choosing the env var name, writing the `${VAR}` placeholder into the
+   entry) lands with connector create/edit, the writer's first real caller.
 
 ## Part 2 — Screens / navigation / UX
 

--- a/gateway/configtool/env_writer.py
+++ b/gateway/configtool/env_writer.py
@@ -1,0 +1,54 @@
+"""upsert_env_vars() — merge-by-key `.env` writer for the config TUI.
+
+`gateway/config.py`'s loader calls `load_dotenv(path.parent / ".env")` —
+the `.env` file lives beside `config.yaml`, not at some fixed install
+location, so a `.env` write triggered by the TUI must resolve the same way
+(`EditableConfig.path.parent / ".env"`), matching `working_directory`'s own
+"relative to config_dir" convention.
+
+`gateway/onboard.py`'s existing `_write_env()` unconditionally overwrites
+the whole file with 3 hardcoded keys (RC_URL/RC_USERNAME/RC_PASSWORD) — fine
+for the onboarding wizard's one-shot Rocket.Chat setup, but wrong here: the
+config TUI's per-field "store in .env" toggle (docs/design/config-tool.md
+decision 6) needs to upsert ONE secret at a time without clobbering every
+other connector's already-written `.env` entries. `upsert_env_vars()` merges
+by key instead — every other line (comments, blank lines, unrelated keys) is
+preserved exactly as-is, in its original position.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _quote(value: str) -> str:
+    # Matches onboard.py's own _write_env() convention exactly, so a value
+    # written by either path looks the same on disk.
+    return f'"{value}"' if " " in value else value
+
+
+def upsert_env_vars(env_path: Path, updates: dict[str, str]) -> None:
+    """Merge `updates` (key -> plain, unquoted value) into the `.env` file
+    at `env_path`, creating it (and its parent directory) if it doesn't
+    exist yet. A key that already has a `KEY=...` line gets that line
+    REPLACED in place (preserving its position); a key not already present
+    is appended at the end. Every other line is untouched. Restricts the
+    file to 0600 after writing (matching onboard.py's convention — this
+    file holds secrets).
+    """
+    remaining = dict(updates)
+    lines: list[str] = []
+    if env_path.exists():
+        for raw_line in env_path.read_text().splitlines():
+            stripped = raw_line.strip()
+            key = stripped.split("=", 1)[0].strip() if "=" in stripped else ""
+            if key and not stripped.startswith("#") and key in remaining:
+                lines.append(f"{key}={_quote(remaining.pop(key))}")
+            else:
+                lines.append(raw_line)
+    for key, value in remaining.items():
+        lines.append(f"{key}={_quote(value)}")
+
+    env_path.parent.mkdir(parents=True, exist_ok=True)
+    env_path.write_text(("\n".join(lines) + "\n") if lines else "")
+    env_path.chmod(0o600)

--- a/tests/unit/test_configtool_env_writer.py
+++ b/tests/unit/test_configtool_env_writer.py
@@ -1,0 +1,100 @@
+"""Unit tests for gateway/configtool/env_writer.py — upsert_env_vars().
+
+Pins the merge-by-key behavior specifically: onboard.py's existing
+_write_env() clobbers the whole file, which is wrong once more than one
+connector needs its own secret upserted independently.
+"""
+
+from __future__ import annotations
+
+import stat
+import tempfile
+import unittest
+from pathlib import Path
+
+from gateway.configtool.env_writer import upsert_env_vars
+
+
+class TestUpsertEnvVars(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.env_path = self.tmp / ".env"
+
+    def _permissions(self, path: Path) -> str:
+        return oct(stat.S_IMODE(path.stat().st_mode))
+
+    def test_creates_a_new_file_with_the_given_keys(self):
+        upsert_env_vars(self.env_path, {"RC_PASSWORD": "hunter2"})
+        self.assertEqual(self.env_path.read_text(), "RC_PASSWORD=hunter2\n")
+
+    def test_creates_the_parent_directory_if_missing(self):
+        nested = self.tmp / "nested" / "dir" / ".env"
+        upsert_env_vars(nested, {"KEY": "value"})
+        self.assertTrue(nested.exists())
+
+    def test_restricts_permissions_to_0600(self):
+        upsert_env_vars(self.env_path, {"KEY": "value"})
+        self.assertEqual(self._permissions(self.env_path), "0o600")
+
+    def test_quotes_values_containing_spaces(self):
+        upsert_env_vars(self.env_path, {"NAME": "hello world"})
+        self.assertEqual(self.env_path.read_text(), 'NAME="hello world"\n')
+
+    def test_does_not_quote_values_without_spaces(self):
+        upsert_env_vars(self.env_path, {"NAME": "no-spaces-here"})
+        self.assertEqual(self.env_path.read_text(), "NAME=no-spaces-here\n")
+
+    def test_replaces_an_existing_keys_value_in_place(self):
+        self.env_path.write_text("RC_URL=http://old\nRC_PASSWORD=oldpw\n")
+        upsert_env_vars(self.env_path, {"RC_PASSWORD": "newpw"})
+        self.assertEqual(
+            self.env_path.read_text(), "RC_URL=http://old\nRC_PASSWORD=newpw\n"
+        )
+
+    def test_appends_a_new_key_without_touching_existing_ones(self):
+        self.env_path.write_text("RC_URL=http://old\n")
+        upsert_env_vars(self.env_path, {"MM_TOKEN": "abc123"})
+        self.assertEqual(
+            self.env_path.read_text(), "RC_URL=http://old\nMM_TOKEN=abc123\n"
+        )
+
+    def test_preserves_comments_and_blank_lines_and_their_order(self):
+        self.env_path.write_text(
+            "# top comment\n\nRC_URL=http://old\n# another comment\nRC_PASSWORD=oldpw\n"
+        )
+        upsert_env_vars(self.env_path, {"RC_PASSWORD": "newpw"})
+        self.assertEqual(
+            self.env_path.read_text(),
+            "# top comment\n\nRC_URL=http://old\n# another comment\nRC_PASSWORD=newpw\n",
+        )
+
+    def test_a_commented_out_key_line_is_not_treated_as_the_real_key(self):
+        """'# RC_PASSWORD=disabled' must not be matched and replaced — it's
+        a comment, not a live KEY=VALUE line. The real (missing) key is
+        appended instead."""
+        self.env_path.write_text("# RC_PASSWORD=disabled\n")
+        upsert_env_vars(self.env_path, {"RC_PASSWORD": "newpw"})
+        self.assertEqual(
+            self.env_path.read_text(), "# RC_PASSWORD=disabled\nRC_PASSWORD=newpw\n"
+        )
+
+    def test_multiple_keys_mixing_replace_and_append(self):
+        self.env_path.write_text("RC_URL=http://old\nRC_USERNAME=bot\n")
+        upsert_env_vars(
+            self.env_path,
+            {"RC_USERNAME": "newbot", "MM_TOKEN": "xyz"},
+        )
+        self.assertEqual(
+            self.env_path.read_text(),
+            "RC_URL=http://old\nRC_USERNAME=newbot\nMM_TOKEN=xyz\n",
+        )
+
+    def test_permissions_restricted_even_when_merging_into_an_existing_file(self):
+        self.env_path.write_text("RC_URL=http://old\n")
+        self.env_path.chmod(0o644)
+        upsert_env_vars(self.env_path, {"RC_URL": "http://new"})
+        self.assertEqual(self._permissions(self.env_path), "0o600")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Small, self-contained infra piece for Phase 2 — the connector create/edit screen (next chunk) needs a merge-by-key `.env` writer for its "store in .env" secret toggle, per docs/design/config-tool.md decision 6.

- `gateway/configtool/env_writer.py`'s `upsert_env_vars()`. `onboard.py`'s existing `_write_env()` unconditionally overwrites the whole `.env` file with 3 hardcoded keys — fine for the onboarding wizard's one-shot setup, wrong here since the TUI needs to upsert one connector's secret without clobbering every other connector's entries. Merges by key: an existing line is replaced in place, a new key is appended, everything else (comments, blank lines, unrelated keys) survives untouched. Restricts the file to 0600 after every write.
- Path resolution mirrors `gateway/config.py`'s own loader (`EditableConfig.path.parent / ".env"`), not `onboard.py`'s hardcoded `~/.agent-chat-gateway/` — a config passed via `--config` can live anywhere.
- No UI yet — the toggle + connector-form wiring lands with connector create/edit itself, this writer's first real caller.

## Test plan
- [x] `uv run ruff check gateway/ tests/` — all checks passed
- [x] `uv run pytest tests/unit tests/integration -q` — 1916 passed (11 new tests: create/append/replace-in-place, comment/blank-line preservation, quoting, permissions, parent-dir creation)