### PR TITLE
Config TUI: connector create/edit + delete (agent+connector), shared FormScreen base

### DIFF
--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -3,9 +3,10 @@
 Status: **Phase 1 shipped** (read-only overview + detail screens + $EDITOR
 escape hatch). **Phase 2 in progress:** items 7–10 from the Phase 1 code
 review cleared; `EditableConfig.save()`/dirty-tracking/`ConfirmModal`
-foundation shipped; agent create/edit shipped (`AgentDetailScreen`,
-`TypePickerModal`, `n` on the Agents tab). Connector create/edit, the `.env`
-writer, and the tool-list/preset editor are not yet built. Phase 3 is
+foundation shipped; agent create/edit shipped; connector create/edit shipped
+(per-type field lists — the generic tree editor originally planned is
+deferred, see Part 3); the `.env` writer is shipped but not yet wired to a
+UI toggle. The tool-list/preset editor is not yet built. Phase 3 is
 designed below but not yet started. The
 v0.2 format simplification (`connector_defaults`/`agent_defaults`/
 `watcher_defaults`, `tool_presets`, watcher `rooms:`) plus `acg config
@@ -164,11 +165,12 @@ per-row status lookups.
 |---|---|---|
 | `OverviewScreen` | root | **Shipped.** 5 tabs: Connectors, Agents, Watchers, Defaults, Tool Presets |
 | `AgentDetailScreen` | pushed | **Shipped, all 3 modes.** view/edit/create. Form fields are a manually-maintained mirror of `$defs/agent` (not a runtime schema interpreter — safe since the schema is closed). Nothing is written to `document` until Save; Save diffs every field against its value-at-open and writes only what changed (docs/design/config-tool.md decision 2). Tool-list fields (`owner_allowed_tools`/`guest_allowed_tools`) stay view-only here — separate tool-list-editor work. Escape with unsaved changes routes through `ConfirmModal` |
-| `ConnectorDetailScreen` / `WatcherDetailScreen` | pushed | **Shipped**, `mode="view"` only still — connector edit/create is the next Phase 2 slice; watcher CRUD is Phase 3. Each already takes a `mode: Literal["view","edit","create"]` param — no screen-class rework needed when their turn comes |
+| `ConnectorDetailScreen` | pushed | **Shipped, all 3 modes.** Per-type fixed field lists (tree editor deferred — see Part 3). `type`/`name` immutable in edit mode |
+| `WatcherDetailScreen` | pushed | **Shipped**, `mode="view"` only still — Phase 3. Already takes a `mode: Literal["view","edit","create"]` param — no screen-class rework needed when its turn comes |
 | `DefaultsScreen` | pushed | **Shipped** (view-only): shows blast radius per key |
 | `ToolPresetsScreen` | pushed | **Shipped** (view-only): rule list + "used by" (checked against the MERGED per-agent tool list, not the raw entry — see gotchas below) |
 | `ConfirmModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — yes/no dialog, Cancel focused by default. Gates `ConfigToolApp.action_quit()` on `EditableConfig.dirty`, and `AgentDetailScreen`'s own per-screen form-dirty flag on Escape |
-| `TypePickerModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — generic list-of-strings picker (`ListView`-based), used today for the agent-type picker (claude/opencode); the connector-type picker (rocketchat/mattermost/voice/script) will reuse the same class |
+| `TypePickerModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — generic list-of-strings picker (`ListView`-based), reused as-is for both the agent-type picker (claude/opencode) and the connector-type picker (rocketchat/mattermost/voice/script) |
 | `EntityPickerModal`, `PresetOrInlineModal`, `InlineToolRuleModal` | modals | Not yet built (phase 2/3) |
 | `RoomListEditorScreen` | pushed (2nd level) | Not yet built (phase 3) |
 | `$EDITOR` escape hatch | action | **Shipped.** `App.suspend()` + subprocess; Overview-only |
@@ -262,11 +264,66 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
   Textual gotchas hit while building it (`@work`/`push_screen_wait`, and
   Input/Select firing `Changed` once at initial mount).
 
-**Not yet built:** `ConnectorDetailScreen` edit/create, `TypePickerModal`'s
-connector-type variant + per-type templates + generic tree editor for
-connector `raw`, `.env` merge-by-key writer + secret toggle, tool-list editor
-+ `PresetOrInlineModal` + `InlineToolRuleModal`, `ToolPresetsScreen` made
-editable (used-by warnings).
+- **Shipped:** `gateway/configtool/env_writer.py`'s `upsert_env_vars()` — the
+  merge-by-key `.env` writer (decision 6). No UI wiring yet (see below).
+- **Shipped:** `FormScreen` (`gateway/configtool/screens/form_common.py`) —
+  `AgentDetailScreen`'s edit/create machinery (populating guard,
+  check_action, `@work action_back` + `ConfirmModal`, the generic
+  field-diff/Save collection, `refresh_bindings()` after `recompose()`)
+  extracted into a shared base once `ConnectorDetailScreen` became a second
+  concrete user, rather than guessed at up front. `FieldSpec`/`widget_id`/
+  `get_nested`/`apply_update`/`read_widget_value` moved alongside it as
+  plain reusable functions. Each subclass still owns its own field list,
+  `*_defaults` kind, dataclass-default map, `_compose_form()`, and
+  `action_save()` (insertion semantics differ enough — a dict keyed by name
+  vs. a list where each entry carries its own `name` — that forcing a
+  shared implementation would be more awkward than it's worth).
+- **Shipped:** `ConnectorDetailScreen` edit/create + the connector-type
+  variant of `TypePickerModal` (rocketchat/mattermost/voice/script), wired
+  to `n` on the Connectors tab. **Deliberate scope cut from the original
+  design:** per-type FIXED field lists (`_FIELDS_BY_TYPE` in
+  `connector_detail.py`) instead of the generic nested tree editor
+  originally planned for `raw`. Verified first that every real connector
+  type's raw shape is exactly one level deep (`server.url`,
+  `allowed_users.owners`, `attachments.*`, etc.) — precisely what
+  `FormScreen`'s existing dotted-key machinery already handles, so this
+  isn't a compromise so much as reuse of code already proven correct for
+  agent's `permissions.*`. The tree editor is deferred, not abandoned — it
+  would only earn its complexity for truly arbitrary/unknown keys, and the
+  `$EDITOR` escape hatch already covers that case; build it later if
+  per-type forms + `$EDITOR` turn out not to be enough in practice.
+  `type`/`name` are immutable in edit mode (only chosen at creation, via the
+  type picker) — rocketchat/mattermost's raw shapes differ enough that
+  letting `type` change in place would mean the form reshaping itself
+  around one of its own fields, and a `name` change would silently orphan
+  any watcher referencing the old name. Mattermost's token-XOR-user/pass
+  constraint gets a plain informational `Static` line, not an interactive
+  RadioSet — `save()`'s `validate_config()` (which runs the real
+  `MattermostConfig.__post_init__`) is the actual enforcement either way,
+  so the simpler static hint was chosen over building a stateful widget for
+  guidance alone.
+- **Deferred, not built:** the `.env` "store in .env" toggle itself. Typing
+  a plaintext secret directly into a masked field (`Input(password=True)` —
+  display-only masking; `.value` is always the real string, same as every
+  other field) and saving writes it to config.yaml in plaintext today,
+  exactly like the existing `$EDITOR` escape hatch already allows — not a
+  regression, just not yet automated. The writer (`upsert_env_vars`) and the
+  masked-secret Input widgets are both in place; wiring a toggle to
+  auto-generate an env var name, call the writer, and rewrite the entry's
+  field to a `${VAR}` placeholder is a self-contained follow-up.
+- **Verified (the actual keystone test for this screen, same weight as
+  `EditableConfig.save()`'s $VAR round-trip):** opening an existing
+  connector whose `server.password` is `"${SOME_VAR}"`, editing an
+  unrelated field, and saving leaves the password field's raw value
+  exactly `"${SOME_VAR}"` — never resolved, never masked at the data level.
+  Holds naturally from the existing diff-based Save mechanism (the widget's
+  initial snapshot and its unedited value-at-save are both the same literal
+  placeholder string) — no special-casing needed, confirmed by a dedicated
+  test rather than assumed.
+
+**Not yet built:** the `.env` toggle wiring (above), the generic tree editor
+(deferred, above), tool-list editor + `PresetOrInlineModal` +
+`InlineToolRuleModal`, `ToolPresetsScreen` made editable (used-by warnings).
 
 **Phase 3: Watcher CRUD + defaults editing.** `WatcherDetailScreen`
 edit/create; new-watcher flow (pickers now enumerate entities creatable

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -403,6 +403,19 @@ split-out insertion position).
   recomposes itself between modes (e.g. view → edit) has to re-arm the
   guard and reschedule `call_after_refresh` at the recompose call site
   itself, not rely on `on_mount` firing again.
+- **A `VerticalScroll` is itself focusable by default, and ends up FIRST in
+  the Tab cycle — before any of the widgets inside it.** User-reported:
+  entering edit mode needed Tab pressed TWICE to reach the first real field
+  (once to focus the form's own scroll container, once to move past it).
+  Same root cause hit `AUTO_FOCUS` too (Textual's own default,
+  `App.AUTO_FOCUS = "*"`, which normally auto-focuses the first focusable
+  widget on a screen's first mount): in CREATE mode — a genuine fresh
+  push, so `AUTO_FOCUS` does fire — focus still landed on the container,
+  not the Name field, for the same reason. Fixed both at once with
+  `VerticalScroll(classes="entity-form", can_focus=False)` on the form's own
+  container — it isn't meant to be independently focused; scrolling still
+  works via the mouse wheel/PageUp/PageDown. Worth checking for on any
+  future container that wraps a form's fields.
 - **`push_screen_wait()` needs a `@work`-decorated caller**, same gotcha as
   `ConfigToolApp.action_quit()` — `AgentDetailScreen.action_back()` awaits a
   `ConfirmModal` result for its own discard-vs-keep-editing decision, so it's

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -170,6 +170,7 @@ per-row status lookups.
 | `DefaultsScreen` | pushed | **Shipped** (view-only): shows blast radius per key |
 | `ToolPresetsScreen` | pushed | **Shipped** (view-only): rule list + "used by" (checked against the MERGED per-agent tool list, not the raw entry — see gotchas below) |
 | `ConfirmModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — yes/no dialog, Cancel focused by default. Gates `ConfigToolApp.action_quit()` on `EditableConfig.dirty`, and `AgentDetailScreen`'s own per-screen form-dirty flag on Escape |
+| `MessageModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — dismiss-only error/info dialog; replaces `notify(severity="error")` for anything worth blocking on (validation/save/delete failures) — user-reported that toasts vanish before a multi-line error can be read |
 | `TypePickerModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — generic list-of-strings picker (`ListView`-based), reused as-is for both the agent-type picker (claude/opencode) and the connector-type picker (rocketchat/mattermost/voice/script) |
 | `EntityPickerModal`, `PresetOrInlineModal`, `InlineToolRuleModal` | modals | Not yet built (phase 2/3) |
 | `RoomListEditorScreen` | pushed (2nd level) | Not yet built (phase 3) |
@@ -339,6 +340,28 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
   right list index, since two connectors could in principle share
   byte-identical raw content. Hidden from the footer while
   editing/creating, via the same `check_action()` mechanism as 'Edit'/'Save'.
+  **Refined immediately after user testing:** the generic validator error
+  ("Watcher entry at index 11 references unknown connector 'X'") confused
+  the user, who reasonably expected a delete-specific reason. Added
+  `find_referencing_watcher_labels()` (checked against watchers' MERGED
+  value, since `watcher_defaults` may set `connector`/`agent` too) as a
+  pre-flight check *before* the destructive confirm — a blocked delete now
+  shows "Cannot delete agent 'X' — still used by watcher(s): general, dev."
+  and never even offers the confirm dialog. `save()`'s own rejection stays
+  in place as a belt-and-suspenders backstop for anything the pre-check
+  doesn't anticipate, not replaced by it.
+- **`MessageModal`, a dismiss-only error/info dialog (`gateway/configtool/modals.py`).**
+  User-reported: `self.notify(..., severity="error")` toasts auto-vanish on
+  their own timer, and a save/delete failure's explanation (often several
+  lines) needs more than a glance. Every error-severity `notify()` call
+  across `AgentDetailScreen`/`ConnectorDetailScreen`'s create/edit/delete
+  flows (duplicate/blank name, invalid integer, save() validation failures,
+  delete failures) was converted to `await self.app.push_screen_wait(MessageModal(...))`
+  — stays up until Enter/Escape/click. Success messages ("Saved.",
+  "Deleted.") deliberately stayed as `notify()` toasts — short and don't
+  need blocking review. `action_save()` on both screens is now
+  `@work`-decorated (needed for `push_screen_wait`, same gotcha as
+  `action_back()`/`action_quit()`).
 - **Not yet built:** the `.env` toggle wiring (above), the generic tree
   editor (deferred, above), tool-list editor + `PresetOrInlineModal` +
   `InlineToolRuleModal`, `ToolPresetsScreen` made editable (used-by

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -111,17 +111,21 @@ per-row status lookups.
    "duplicates the default" findings as the nudge to promote repeated
    overrides into defaults. List fields are provenance-binary at the
    whole-list level (merge replaces lists wholesale — no per-item marking).
-   **Known gap, user-reported, not yet fixed:** str/int/list fields can
-   revert an explicit override back to inherited by clearing the field to
-   blank (`apply_update()` pops the key). A `bool` field has no equivalent
-   gesture — a `Checkbox` only has True/False, no third "cleared" state —
-   so once a boolean field becomes explicit (any edit to it, even one that
-   happens to land back on the same value the default already has), there
-   is currently NO way to make it inherited again through this UI; the
-   entry keeps an explicit `true`/`false` forever unless hand-edited via
-   `$EDITOR`. Needs a deliberate UI decision (a tri-state control, a
-   separate "reset to default" affordance per field, etc.) — not fixed
-   opportunistically alongside the item that surfaced it.
+   **Gap fixed:** str/int/list fields could always revert an explicit
+   override back to inherited by clearing the field to blank
+   (`apply_update()` pops the key), but a `bool`/`enum` field had no
+   equivalent — a `Checkbox`/`Select` has no "blank" state, so once touched
+   it stayed explicit forever, even set back to a value matching the
+   default (user-reported, exactly this way). Fixed with `ctrl+r`
+   (`action_reset_field()`, `gateway/configtool/screens/form_common.py`):
+   resets the FOCUSED field to its pure-`*_defaults` value and marks it in
+   `self._reset_keys`; `_collect_field_updates()` writes a field in
+   `_reset_keys` as "clear to inherited" on Save regardless of kind, as
+   long as the widget still shows the reset value (a further real edit
+   supersedes it and falls back to normal diffing). Chosen over a tri-state
+   control or a per-row reset button — one consistent keybinding across
+   every field kind, including str/int/list where it's a faster alternative
+   to clearing the box.
 3. **`rooms:` group editing — two-tier rule:** deleting a room removes it
    from the list (normalizing `rooms: [x]` → `room: x`); editing a
    **per-room** field (`name`/`session_id` — already hard-restricted to

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -111,6 +111,17 @@ per-row status lookups.
    "duplicates the default" findings as the nudge to promote repeated
    overrides into defaults. List fields are provenance-binary at the
    whole-list level (merge replaces lists wholesale — no per-item marking).
+   **Known gap, user-reported, not yet fixed:** str/int/list fields can
+   revert an explicit override back to inherited by clearing the field to
+   blank (`apply_update()` pops the key). A `bool` field has no equivalent
+   gesture — a `Checkbox` only has True/False, no third "cleared" state —
+   so once a boolean field becomes explicit (any edit to it, even one that
+   happens to land back on the same value the default already has), there
+   is currently NO way to make it inherited again through this UI; the
+   entry keeps an explicit `true`/`false` forever unless hand-edited via
+   `$EDITOR`. Needs a deliberate UI decision (a tri-state control, a
+   separate "reset to default" affordance per field, etc.) — not fixed
+   opportunistically alongside the item that surfaced it.
 3. **`rooms:` group editing — two-tier rule:** deleting a room removes it
    from the list (normalizing `rooms: [x]` → `room: x`); editing a
    **per-room** field (`name`/`session_id` — already hard-restricted to
@@ -343,13 +354,20 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
   **Refined immediately after user testing:** the generic validator error
   ("Watcher entry at index 11 references unknown connector 'X'") confused
   the user, who reasonably expected a delete-specific reason. Added
-  `find_referencing_watcher_labels()` (checked against watchers' MERGED
-  value, since `watcher_defaults` may set `connector`/`agent` too) as a
-  pre-flight check *before* the destructive confirm — a blocked delete now
-  shows "Cannot delete agent 'X' — still used by watcher(s): general, dev."
-  and never even offers the confirm dialog. `save()`'s own rejection stays
-  in place as a belt-and-suspenders backstop for anything the pre-check
-  doesn't anticipate, not replaced by it.
+  `find_referencing_watcher_labels()` as a pre-flight check *before* the
+  destructive confirm — a blocked delete now shows "Cannot delete agent
+  'X' — still used by watcher(s): rc-general, rc-dev." and never even
+  offers the confirm dialog. `save()`'s own rejection stays in place as a
+  belt-and-suspenders backstop for anything the pre-check doesn't
+  anticipate, not replaced by it. **Second round, same feature:** the
+  labels initially fell back to the bare `room:`/joined `rooms:` string for
+  an unnamed watcher — inconsistent with the REAL name that watcher gets
+  everywhere else in the TUI (`_auto_watcher_name()`'s `"<connector>-<room>"`,
+  gateway/config.py), and wrong for a `rooms:` group (one joined label
+  instead of N separate real watchers). Rewritten to use
+  `cfg.expanded_watchers()` directly — the same real, already-correct data
+  the Overview's Watchers tab renders from — instead of re-deriving names
+  from the raw entry.
 - **`MessageModal`, a dismiss-only error/info dialog (`gateway/configtool/modals.py`).**
   User-reported: `self.notify(..., severity="error")` toasts auto-vanish on
   their own timer, and a save/delete failure's explanation (often several
@@ -362,6 +380,23 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
   need blocking review. `action_save()` on both screens is now
   `@work`-decorated (needed for `push_screen_wait`, same gotcha as
   `action_back()`/`action_quit()`).
+- **Real bug, user-reported: a rejected Save in edit mode still mutated the
+  live entry.** `action_save()`'s trial-copy logic was
+  `target_entry = self.entry if self.mode == "edit" else dict(self.entry)`
+  — for edit mode, `target_entry` WAS `self.entry`, the SAME dict object
+  already living in `cfg.document` (entries are held by reference
+  throughout this tool, never copied on load). Applying Save's updates to
+  it, then having `save()` reject the result, left the invalid data sitting
+  in `document` — no rollback path existed for edit mode (only create mode
+  deleted its phantom entry on failure). Reported exactly as it would
+  manifest: set an invalid `timeout`, Save fails with a clear error, press
+  Back anyway — the invalid value was still showing, even though nothing
+  had actually been written to disk. Fixed with the same
+  install/rollback-hook pattern delete already uses:
+  `_install_trial_entry(target_entry)` swaps a COPY (with updates applied)
+  into `document` *before* `save()` runs; `_rollback_trial_entry()` restores
+  the untouched original if `save()` rejects it. `self.entry` itself is
+  never mutated until `save()` has actually succeeded.
 - **Not yet built:** the `.env` toggle wiring (above), the generic tree
   editor (deferred, above), tool-list editor + `PresetOrInlineModal` +
   `InlineToolRuleModal`, `ToolPresetsScreen` made editable (used-by

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -321,9 +321,28 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
   placeholder string) — no special-casing needed, confirmed by a dedicated
   test rather than assumed.
 
-**Not yet built:** the `.env` toggle wiring (above), the generic tree editor
-(deferred, above), tool-list editor + `PresetOrInlineModal` +
-`InlineToolRuleModal`, `ToolPresetsScreen` made editable (used-by warnings).
+- **Shipped (added after initial Phase 2 review — user caught that "CRUD"
+  was being used loosely and Delete had never actually been designed for
+  agents/connectors; checked, and they were right, nothing in this
+  document specified it before now):** `d` from view mode on
+  `AgentDetailScreen`/`ConnectorDetailScreen` — `FormScreen.action_delete()`
+  (`gateway/configtool/screens/form_common.py`), shared the same way
+  `action_back()`/`action_edit()` are. `ConfirmModal` first, then remove
+  from `document`, `mark_dirty()`, `save()`. Same "let save() be the
+  backstop" philosophy as everything else in this screen: no reference-
+  counting reimplemented here — deleting an agent/connector still
+  referenced by a watcher fails `save()`'s `validate_config()` with
+  `GatewayConfig.from_file`'s own existing "references unknown agent/
+  connector" error, and the entry is reinserted into `document` so a
+  rejected delete never leaves memory silently out of sync with disk.
+  Connector deletion matches by object IDENTITY (not equality) to find the
+  right list index, since two connectors could in principle share
+  byte-identical raw content. Hidden from the footer while
+  editing/creating, via the same `check_action()` mechanism as 'Edit'/'Save'.
+- **Not yet built:** the `.env` toggle wiring (above), the generic tree
+  editor (deferred, above), tool-list editor + `PresetOrInlineModal` +
+  `InlineToolRuleModal`, `ToolPresetsScreen` made editable (used-by
+  warnings).
 
 **Phase 3: Watcher CRUD + defaults editing.** `WatcherDetailScreen`
 edit/create; new-watcher flow (pickers now enumerate entities creatable

--- a/gateway/configtool/modals.py
+++ b/gateway/configtool/modals.py
@@ -2,7 +2,9 @@
 row in the screen inventory). `ConfirmModal` is the first one built, landing
 alongside `EditableConfig.save()`/dirty tracking — everything that needs to
 ask "discard unsaved changes?" before navigating away or quitting shares it.
-Later phases add `TypePickerModal`/`EntityPickerModal`/`PresetOrInlineModal`/
+`MessageModal` (dismiss-only) followed once user feedback showed `self.notify()`
+toasts auto-vanish before an error message this important can be read.
+Later phases add `EntityPickerModal`/`PresetOrInlineModal`/
 `InlineToolRuleModal` here too.
 """
 
@@ -74,6 +76,70 @@ class ConfirmModal(ModalScreen[bool]):
 
     def action_cancel(self) -> None:
         self.dismiss(False)
+
+
+class MessageModal(ModalScreen[None]):
+    """A dismiss-only informational/error dialog. User-reported:
+    `self.notify(..., severity="error")` toasts auto-vanish on their own
+    timer, and a save/delete failure's explanation (often several lines —
+    e.g. a validator error) needs more than a glance to actually read. This
+    stays up until the user presses Enter/Escape or clicks OK — callers
+    `await self.app.push_screen_wait(MessageModal(...))`. Use for anything
+    the user needs time to read (validation/save/delete failures); routine
+    short confirmations ("Saved.") stay as `self.notify()` toasts — this
+    isn't a blanket replacement, just for messages worth blocking on.
+    """
+
+    BINDINGS = [
+        Binding("escape", "dismiss_modal", "OK", show=False),
+        Binding("enter", "dismiss_modal", "OK", show=False),
+    ]
+
+    DEFAULT_CSS = """
+    MessageModal {
+        align: center middle;
+    }
+    #message-dialog {
+        width: auto;
+        max-width: 80;
+        height: auto;
+        border: thick $error;
+        padding: 1 2;
+        background: $surface;
+    }
+    #message-title {
+        text-style: bold;
+    }
+    #message-body {
+        margin-top: 1;
+    }
+    #message-buttons {
+        height: auto;
+        margin-top: 1;
+        align: right middle;
+    }
+    """
+
+    def __init__(self, message: str, title: str = "Error"):
+        super().__init__()
+        self.message = message
+        self.title_text = title
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="message-dialog"):
+            yield Static(self.title_text, id="message-title")
+            yield Static(self.message, id="message-body")
+            with Horizontal(id="message-buttons"):
+                yield Button("OK", id="ok", variant="primary")
+
+    def on_mount(self) -> None:
+        self.query_one("#ok", Button).focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        self.dismiss(None)
+
+    def action_dismiss_modal(self) -> None:
+        self.dismiss(None)
 
 
 class TypePickerModal(ModalScreen[str | None]):

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -147,6 +147,12 @@ class AgentDetailScreen(FormScreen):
     def _referencing_watcher_labels(self) -> list[str]:
         return find_referencing_watcher_labels(self.cfg, agent_name=self.agent_name)
 
+    def _install_trial_entry(self, target_entry: dict) -> None:
+        self.cfg.document.setdefault("agents", {})[self.agent_name] = target_entry
+
+    def _rollback_trial_entry(self) -> None:
+        self.cfg.document.setdefault("agents", {})[self.agent_name] = self.entry
+
     def _on_enter_edit_mode(self) -> None:
         self._compute_initial_values(self.entry)
 
@@ -275,12 +281,21 @@ class AgentDetailScreen(FormScreen):
                 )
                 return
 
-        target_entry = self.entry if self.mode == "edit" else dict(self.entry)
+        # ALWAYS a trial copy, never self.entry directly — even for "edit",
+        # where self.entry is the SAME object already living in
+        # cfg.document. Mutating it here, before save() has even run, would
+        # leave invalid data sitting in the document if save() then fails
+        # (a real bug: reported as "Save failed, but Back still showed the
+        # invalid value" — the fix is never mutating the original until
+        # save() has actually succeeded).
+        target_entry = dict(self.entry)
         for key, value in updates.items():
             apply_update(target_entry, key, value)
 
         if self.mode == "create":
             self.cfg.document.setdefault("agents", {})[name] = target_entry
+        else:
+            self._install_trial_entry(target_entry)
         self.cfg.mark_dirty()
 
         try:
@@ -291,9 +306,12 @@ class AgentDetailScreen(FormScreen):
                 # ran — remove it so a failed save doesn't leave a phantom
                 # half-created agent sitting in memory.
                 del self.cfg.document["agents"][name]
+            else:
+                self._rollback_trial_entry()
             await self.app.push_screen_wait(MessageModal(str(exc), title="Could not save"))
             return
 
+        self.entry = target_entry
         self.app.pop_screen()
         app: "ConfigToolApp" = self.app  # type: ignore[assignment]
         app.notify(f"Saved agent '{name}'.", severity="information")

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -27,13 +27,15 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from textual import work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Input, Static
 
 from ..formatting import format_value, provenance_label
+from ..modals import MessageModal
 from ..model import EditableConfig
-from .form_common import FieldSpec, FormScreen, apply_update
+from .form_common import FieldSpec, FormScreen, apply_update, find_referencing_watcher_labels
 
 if TYPE_CHECKING:
     from ..app import ConfigToolApp
@@ -142,6 +144,9 @@ class AgentDetailScreen(FormScreen):
     def _reinsert_entry_into_document(self) -> None:
         self.cfg.document.setdefault("agents", {})[self.agent_name] = self.entry
 
+    def _referencing_watcher_labels(self) -> list[str]:
+        return find_referencing_watcher_labels(self.cfg, agent_name=self.agent_name)
+
     def _on_enter_edit_mode(self) -> None:
         self._compute_initial_values(self.entry)
 
@@ -244,22 +249,30 @@ class AgentDetailScreen(FormScreen):
 
     # ── save ─────────────────────────────────────────────────────────────────
 
+    @work
     async def action_save(self) -> None:
         if self.mode == "view":
             return
 
         updates = self._collect_field_updates()
         if updates is None:
-            return  # a field failed to parse; notify() already shown
+            await self.app.push_screen_wait(
+                MessageModal(self._last_field_error or "Invalid field.", title="Could not save")
+            )
+            return
 
         name = self.agent_name
         if self.mode == "create":
             name = self.query_one("#field-name", Input).value.strip()
             if not name:
-                self.notify("Name is required.", severity="error")
+                await self.app.push_screen_wait(
+                    MessageModal("Name is required.", title="Could not save")
+                )
                 return
             if name in self.cfg.agents_raw:
-                self.notify(f"An agent named '{name}' already exists.", severity="error")
+                await self.app.push_screen_wait(
+                    MessageModal(f"An agent named '{name}' already exists.", title="Could not save")
+                )
                 return
 
         target_entry = self.entry if self.mode == "edit" else dict(self.entry)
@@ -278,7 +291,7 @@ class AgentDetailScreen(FormScreen):
                 # ran — remove it so a failed save doesn't leave a phantom
                 # half-created agent sitting in memory.
                 del self.cfg.document["agents"][name]
-            self.notify(f"Could not save: {exc}", severity="error")
+            await self.app.push_screen_wait(MessageModal(str(exc), title="Could not save"))
             return
 
         self.app.pop_screen()

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -4,7 +4,7 @@ Unlike connectors, the agent schema is complete (additionalProperties:
 false in gateway/schema/config.schema.json's $defs/agent), so this shows a
 fixed field list with a provenance marker per field (explicit / inherited
 from agent_defaults / explicit-null-suppressing) instead of a generic dump.
-"_FORM_FIELDS"/"_PERMISSIONS_FORM_FIELDS" below are a manually-maintained
+`_FORM_FIELDS`/`_PERMISSIONS_FORM_FIELDS` below are a manually-maintained
 mirror of that schema (matching Phase 1's `_KNOWN_FIELDS`, not a runtime
 JSON-schema interpreter) — safe because the schema is closed
 (`additionalProperties: false`), so there's no drift risk from a field this
@@ -15,32 +15,25 @@ view-only PRE-resolve representation here — editing them is
 docs/design/config-tool.md's separate tool-list-editor work, not this
 screen.
 
-Edit/create semantics (docs/design/config-tool.md decision 2 — "editing an
-inherited field always writes an explicit per-entry override"): nothing is
-written to `EditableConfig.document` until Save. On Save, every field is
-diffed against the value captured when the form opened; only fields that
-actually changed are written to the raw entry (clearing a field back to
-blank reverts it to inherited, rather than writing an explicit null — see
-`_apply_update`). This keeps every untouched field's provenance exactly as
-it was, and keeps a not-yet-saved edit from ever touching disk.
+Edit/create + Save/dirty/navigation machinery lives in `.form_common`
+(`FormScreen`) — shared with `ConnectorDetailScreen`. This module supplies
+the agent-specific pieces: which fields exist, their dataclass defaults, and
+`action_save()`'s entity-shaped insertion (`document["agents"]` is a dict
+keyed by name, unlike connectors' list).
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from textual import work
 from textual.app import ComposeResult
-from textual.binding import Binding
 from textual.containers import Horizontal, VerticalScroll
-from textual.widgets import Checkbox, Footer, Header, Input, Select, Static
+from textual.widgets import Input, Static
 
 from ..formatting import format_value, provenance_label
-from ..modals import ConfirmModal
-from ..model import EditableConfig, Provenance
-from .base import DetailScreen
+from ..model import EditableConfig
+from .form_common import FieldSpec, FormScreen, apply_update
 
 if TYPE_CHECKING:
     from ..app import ConfigToolApp
@@ -73,53 +66,22 @@ _AGENT_DATACLASS_DEFAULTS: dict[str, object] = {
     "permissions.skip_owner_approval": False,
 }
 
-
-@dataclass(frozen=True)
-class _FieldSpec:
-    key: str  # dotted for a permissions sub-field, e.g. "permissions.timeout"
-    kind: Literal["str", "int", "bool", "list", "enum"]
-    label: str
-    options: tuple[str, ...] | None = None
-
-
-_FORM_FIELDS: list[_FieldSpec] = [
-    _FieldSpec("type", "enum", "Type", options=("claude", "opencode")),
-    _FieldSpec("command", "str", "Command"),
-    _FieldSpec("working_directory", "str", "Working directory"),
-    _FieldSpec("session_prefix", "str", "Session prefix"),
-    _FieldSpec("lazy_instruction_loading", "bool", "Lazy instruction loading"),
-    _FieldSpec("new_session_args", "list", "New session args (comma-separated)"),
-    _FieldSpec("context_inject_files", "list", "Context inject files (comma-separated)"),
-    _FieldSpec("timeout", "int", "Timeout (seconds)"),
+_FORM_FIELDS: list[FieldSpec] = [
+    FieldSpec("type", "enum", "Type", options=("claude", "opencode")),
+    FieldSpec("command", "str", "Command"),
+    FieldSpec("working_directory", "str", "Working directory"),
+    FieldSpec("session_prefix", "str", "Session prefix"),
+    FieldSpec("lazy_instruction_loading", "bool", "Lazy instruction loading"),
+    FieldSpec("new_session_args", "list", "New session args (comma-separated)"),
+    FieldSpec("context_inject_files", "list", "Context inject files (comma-separated)"),
+    FieldSpec("timeout", "int", "Timeout (seconds)"),
 ]
-_PERMISSIONS_FORM_FIELDS: list[_FieldSpec] = [
-    _FieldSpec("permissions.enabled", "bool", "Permissions enabled"),
-    _FieldSpec("permissions.timeout", "int", "Permissions timeout (seconds)"),
-    _FieldSpec("permissions.skip_owner_approval", "bool", "Skip owner approval"),
+_PERMISSIONS_FORM_FIELDS: list[FieldSpec] = [
+    FieldSpec("permissions.enabled", "bool", "Permissions enabled"),
+    FieldSpec("permissions.timeout", "int", "Permissions timeout (seconds)"),
+    FieldSpec("permissions.skip_owner_approval", "bool", "Skip owner approval"),
 ]
 _ALL_FORM_FIELDS = (*_FORM_FIELDS, *_PERMISSIONS_FORM_FIELDS)
-
-
-def _widget_id(key: str) -> str:
-    return "field-" + key.replace(".", "-")
-
-
-def _get_nested(d: dict, dotted_key: str) -> object:
-    if "." not in dotted_key:
-        return d.get(dotted_key)
-    parent_key, sub_key = dotted_key.split(".", 1)
-    parent = d.get(parent_key)
-    return parent.get(sub_key) if isinstance(parent, dict) else None
-
-
-def _list_to_text(value: object) -> str:
-    if not value:
-        return ""
-    return ", ".join(str(v) for v in value)
-
-
-def _text_to_list(text: str) -> list[str]:
-    return [part.strip() for part in text.split(",") if part.strip()]
 
 
 def _resolve_working_directory(config_path: Path, raw_value: str) -> Path:
@@ -149,70 +111,8 @@ def _working_directory_warning(config_path: Path, raw_value: str) -> str:
     return ""
 
 
-def _apply_update(entry: dict, dotted_key: str, value: object) -> None:
-    """Write `value` (or clear, if None) into `entry` at `dotted_key`.
-
-    A top-level key: set it, or pop it entirely if `value` is None (revert
-    to inherited/default). A `permissions.*` key: read-modify-write the
-    `permissions` sub-dict, dropping it entirely once its last explicit
-    sub-key is cleared, so a fully-cleared `permissions` block reverts to
-    inheriting from `agent_defaults.permissions` again, not an empty `{}`
-    stub sitting in the entry forever.
-    """
-    if "." not in dotted_key:
-        if value is None:
-            entry.pop(dotted_key, None)
-        else:
-            entry[dotted_key] = value
-        return
-    parent_key, sub_key = dotted_key.split(".", 1)
-    parent = entry.get(parent_key)
-    parent = dict(parent) if isinstance(parent, dict) else {}
-    if value is None:
-        parent.pop(sub_key, None)
-    else:
-        parent[sub_key] = value
-    if parent:
-        entry[parent_key] = parent
-    else:
-        entry.pop(parent_key, None)
-
-
-class AgentDetailScreen(DetailScreen):
+class AgentDetailScreen(FormScreen):
     BODY_ID = "agent-detail-body"
-
-    BINDINGS = [
-        Binding("e", "edit", "Edit", show=True),
-        Binding("ctrl+s", "save", "Save", show=True),
-        # Screen already binds tab/shift+tab to app.focus_next/focus_previous
-        # with show=False (textual/screen.py) — re-bound here with show=True,
-        # same pattern OverviewScreen already uses, so the footer tells the
-        # user how to move between fields (user-reported gap: Up/Down was
-        # tried as an alternative and reverted — see git history — Tab is
-        # the one reliable, discoverable way to navigate this form).
-        Binding("tab", "app.focus_next", "Next field", show=True),
-    ]
-
-    DEFAULT_CSS = """
-    AgentDetailScreen #agent-form {
-        padding: 1 2;
-    }
-    AgentDetailScreen .field-row {
-        height: auto;
-        margin-bottom: 1;
-    }
-    AgentDetailScreen .field-label {
-        width: 30;
-        padding-top: 1;
-    }
-    AgentDetailScreen .field-provenance {
-        padding-top: 1;
-        margin-left: 2;
-    }
-    AgentDetailScreen Checkbox {
-        width: auto;
-    }
-    """
 
     def __init__(
         self,
@@ -226,48 +126,26 @@ class AgentDetailScreen(DetailScreen):
         self.agent_name = name
         self.entry = entry
         self.mode = mode
-        self._form_dirty = False
-        self._initial_values: dict[str, object] = {}
-        # Input/Select fire their own Changed message once at initial mount
-        # with whatever value the constructor was given (confirmed
-        # empirically — Checkbox does not, but Input/Select do). Without this
-        # guard, simply OPENING the edit form would immediately mark it
-        # dirty, incorrectly prompting a discard-confirmation on Escape even
-        # though the user never touched anything. Cleared via
-        # call_after_refresh (see on_mount/action_edit), which runs after
-        # that initial burst of Changed messages has already been processed.
-        self._populating = False
         if self.mode != "view":
-            self._compute_initial_values()
+            self._compute_initial_values(self.entry)
             self._populating = True
 
-    def on_mount(self) -> None:
-        if self._populating:
-            self.call_after_refresh(self._stop_populating)
+    def _entity_noun(self) -> str:
+        return "agent"
 
-    def _stop_populating(self) -> None:
-        self._populating = False
+    def _on_enter_edit_mode(self) -> None:
+        self._compute_initial_values(self.entry)
 
-    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        """Hide 'Edit' from the footer once already editing/creating (it's a
-        no-op there — action_edit() only does something from view mode —
-        and user-reported that a footer hint for a no-op key is confusing),
-        and hide 'Save' while still in view mode (nothing to save yet)."""
-        if action == "edit":
-            return self.mode == "view"
-        if action == "save":
-            return self.mode != "view"
-        return True
+    def _field_specs(self) -> tuple[FieldSpec, ...]:
+        return _ALL_FORM_FIELDS
+
+    def _defaults_kind(self) -> str:
+        return "agent_defaults"
+
+    def _dataclass_defaults(self) -> dict[str, object]:
+        return _AGENT_DATACLASS_DEFAULTS
 
     # ── view mode ────────────────────────────────────────────────────────────
-
-    def compose(self) -> ComposeResult:
-        yield Header()
-        if self.mode == "view":
-            yield VerticalScroll(Static(self._body_text(), id=self.BODY_ID))
-        else:
-            yield from self._compose_form()
-        yield Footer()
 
     def _body_text(self) -> str:
         description = self.entry.get("description")
@@ -312,31 +190,8 @@ class AgentDetailScreen(DetailScreen):
 
     # ── edit/create form ─────────────────────────────────────────────────────
 
-    def _compute_initial_values(self) -> None:
-        """Snapshot the effective value of every form field, exactly as it
-        would display right now — captured once, when entering edit/create
-        mode, and used both to prefill widgets and (on Save) to detect which
-        fields the user actually changed. See module docstring."""
-        try:
-            merged = self.cfg.merged_entry("agent_defaults", self.entry)
-        except (ValueError, FileNotFoundError):
-            merged = dict(self.entry)
-        for spec in _ALL_FORM_FIELDS:
-            value = _get_nested(merged, spec.key)
-            if value is None:
-                value = _AGENT_DATACLASS_DEFAULTS.get(spec.key)
-            self._initial_values[spec.key] = value
-        self._initial_values["description"] = self.entry.get("description")
-
-    def _field_provenance(self, spec: _FieldSpec) -> Provenance | None:
-        top_key = spec.key.split(".", 1)[0]
-        try:
-            return self.cfg.field_provenance("agent_defaults", self.entry, top_key)
-        except (ValueError, FileNotFoundError):
-            return None
-
     def _compose_form(self) -> ComposeResult:
-        with VerticalScroll(id="agent-form"):
+        with VerticalScroll(classes="entity-form"):
             if self.mode == "create":
                 yield Static("[bold]New agent[/bold]")
                 with Horizontal(classes="field-row"):
@@ -353,146 +208,27 @@ class AgentDetailScreen(DetailScreen):
                 )
 
             for spec in _FORM_FIELDS:
-                yield from self._compose_field_row(spec)
+                yield from self._compose_field_row(spec, self.entry)
                 if spec.key == "working_directory":
                     yield Static(
-                        _working_directory_warning(self.cfg.path, str(self._initial_values.get(spec.key) or "")),
+                        _working_directory_warning(
+                            self.cfg.path, str(self._initial_values.get(spec.key) or "")
+                        ),
                         id="wd-warning",
                     )
 
             yield Static("[bold]Permissions[/bold]")
             for spec in _PERMISSIONS_FORM_FIELDS:
-                yield from self._compose_field_row(spec)
-
-    def _compose_field_row(self, spec: _FieldSpec) -> ComposeResult:
-        provenance = self._field_provenance(spec)
-        prov_text = f"[dim]({provenance_label(provenance)})[/dim]" if provenance else ""
-        initial = self._initial_values.get(spec.key)
-        with Horizontal(classes="field-row"):
-            yield Static(spec.label, classes="field-label")
-            if spec.kind == "bool":
-                yield Checkbox(value=bool(initial), id=_widget_id(spec.key))
-            elif spec.kind == "enum":
-                yield Select(
-                    [(o, o) for o in (spec.options or ())],
-                    value=initial if initial in (spec.options or ()) else (spec.options or (None,))[0],
-                    allow_blank=False,
-                    id=_widget_id(spec.key),
-                )
-            elif spec.kind == "list":
-                yield Input(value=_list_to_text(initial), id=_widget_id(spec.key))
-            else:
-                yield Input(value="" if initial is None else str(initial), id=_widget_id(spec.key))
-            yield Static(prov_text, classes="field-provenance")
-
-    # ── dirty tracking (per-screen, not EditableConfig.dirty — nothing is
-    # written to `document` until Save, so cfg.dirty stays False the whole
-    # time the user is mid-form; this local flag is what Escape checks) ──────
+                yield from self._compose_field_row(spec, self.entry)
 
     def on_input_changed(self, event: Input.Changed) -> None:
-        if event.input.id == _widget_id("working_directory"):
+        if event.input.id == "field-working_directory":
             self.query_one("#wd-warning", Static).update(
                 _working_directory_warning(self.cfg.path, event.input.value)
             )
-        if self._populating:
-            return
-        self._form_dirty = True
+        super().on_input_changed(event)
 
-    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
-        if self._populating:
-            return
-        self._form_dirty = True
-
-    def on_select_changed(self, event: Select.Changed) -> None:
-        if self._populating:
-            return
-        self._form_dirty = True
-
-    # ── actions ──────────────────────────────────────────────────────────────
-
-    async def action_edit(self) -> None:
-        if self.mode != "view":
-            return
-        self.mode = "edit"
-        self._form_dirty = False
-        self._compute_initial_values()
-        # recompose() does NOT re-trigger on_mount (that only fires once, for
-        # the screen's own initial push) — so the populating guard has to be
-        # armed and disarmed around this recompose explicitly, the same way
-        # on_mount handles it for a screen pushed directly in create mode.
-        self._populating = True
-        await self.recompose()
-        self.call_after_refresh(self._stop_populating)
-        # Footer subscribes to Screen.bindings_updated_signal in ITS OWN
-        # on_mount — recompose() mounts a brand-new Footer instance, but
-        # nothing re-publishes that signal just because a new subscriber
-        # showed up, so the fresh Footer's `_bindings_ready` reactive stays
-        # False forever and it renders as a blank bar (confirmed empirically:
-        # reproduced by view -> edit -> back -> edit and inspecting Footer's
-        # FooterKey children directly — 4 at first mount, 0 after this
-        # recompose, permanently). refresh_bindings() is Screen's own public
-        # method for exactly this: it re-publishes the signal so every
-        # current subscriber (including the new Footer) recomputes.
-        self.refresh_bindings()
-
-    @work
-    async def action_back(self) -> None:
-        if self.mode == "view":
-            self.app.pop_screen()
-            return
-        if self._form_dirty:
-            discard = await self.app.push_screen_wait(
-                ConfirmModal("Discard unsaved changes to this agent?", confirm_label="Discard")
-            )
-            if not discard:
-                return
-        if self.mode == "create":
-            self.app.pop_screen()
-        else:
-            self.mode = "view"
-            self._form_dirty = False
-            await self.recompose()
-            self.refresh_bindings()  # see action_edit()'s comment — same fix
-
-    def _collect_field_updates(self) -> dict[str, object] | None:
-        """Diff every form widget against `_initial_values`. Returns
-        {dotted_key: new_value_or_None} for changed fields only (None means
-        "clear it — revert to inherited/default"), or None (having already
-        called self.notify()) if a field fails to parse."""
-        updates: dict[str, object] = {}
-        for spec in _ALL_FORM_FIELDS:
-            widget = self.query_one("#" + _widget_id(spec.key))
-            try:
-                new_value = self._read_widget_value(spec, widget)
-            except ValueError as exc:
-                self.notify(str(exc), severity="error")
-                return None
-            if new_value != self._initial_values.get(spec.key):
-                updates[spec.key] = new_value
-
-        desc_widget = self.query_one("#field-description", Input)
-        new_desc = desc_widget.value.strip() or None
-        if new_desc != self._initial_values.get("description"):
-            updates["description"] = new_desc
-        return updates
-
-    def _read_widget_value(self, spec: _FieldSpec, widget: object) -> object:
-        if spec.kind == "bool":
-            return widget.value
-        if spec.kind == "enum":
-            return widget.value
-        if spec.kind == "list":
-            return _text_to_list(widget.value) or None
-        if spec.kind == "int":
-            text = widget.value.strip()
-            if not text:
-                return None
-            try:
-                return int(text)
-            except ValueError:
-                raise ValueError(f"{spec.label}: must be a whole number, got {text!r}") from None
-        text = widget.value.strip()
-        return text or None
+    # ── save ─────────────────────────────────────────────────────────────────
 
     async def action_save(self) -> None:
         if self.mode == "view":
@@ -514,7 +250,7 @@ class AgentDetailScreen(DetailScreen):
 
         target_entry = self.entry if self.mode == "edit" else dict(self.entry)
         for key, value in updates.items():
-            _apply_update(target_entry, key, value)
+            apply_update(target_entry, key, value)
 
         if self.mode == "create":
             self.cfg.document.setdefault("agents", {})[name] = target_entry

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -133,6 +133,15 @@ class AgentDetailScreen(FormScreen):
     def _entity_noun(self) -> str:
         return "agent"
 
+    def _entity_label(self) -> str:
+        return self.agent_name
+
+    def _remove_entry_from_document(self) -> None:
+        del self.cfg.document["agents"][self.agent_name]
+
+    def _reinsert_entry_into_document(self) -> None:
+        self.cfg.document.setdefault("agents", {})[self.agent_name] = self.entry
+
     def _on_enter_edit_mode(self) -> None:
         self._compute_initial_values(self.entry)
 

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -191,7 +191,12 @@ class AgentDetailScreen(FormScreen):
     # ── edit/create form ─────────────────────────────────────────────────────
 
     def _compose_form(self) -> ComposeResult:
-        with VerticalScroll(classes="entity-form"):
+        # can_focus=False: otherwise this container is itself the first
+        # focusable widget (user-reported: needed Tab TWICE to reach the
+        # first real field — once to focus this container, once to move
+        # past it). The container isn't meant to be focused on its own;
+        # scrolling still works via the mouse wheel/PageUp/PageDown.
+        with VerticalScroll(classes="entity-form", can_focus=False):
             if self.mode == "create":
                 yield Static("[bold]New agent[/bold]")
                 with Horizontal(classes="field-row"):

--- a/gateway/configtool/screens/connector_detail.py
+++ b/gateway/configtool/screens/connector_detail.py
@@ -28,13 +28,15 @@ from __future__ import annotations
 
 from typing import Literal
 
+from textual import work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Input, Static
 
 from ..formatting import mask_if_secret, provenance_label
+from ..modals import MessageModal
 from ..model import EditableConfig
-from .form_common import FieldSpec, FormScreen, apply_update
+from .form_common import FieldSpec, FormScreen, apply_update, find_referencing_watcher_labels
 
 CONNECTOR_TYPES = ("rocketchat", "mattermost", "voice", "script")
 
@@ -138,6 +140,9 @@ class ConnectorDetailScreen(FormScreen):
         connectors = self.cfg.document.setdefault("connectors", [])
         connectors.insert(self._deleted_index, self.entry)
 
+    def _referencing_watcher_labels(self) -> list[str]:
+        return find_referencing_watcher_labels(self.cfg, connector_name=self._entity_label())
+
     def _on_enter_edit_mode(self) -> None:
         self._compute_initial_values(self.entry)
 
@@ -240,23 +245,33 @@ class ConnectorDetailScreen(FormScreen):
 
     # ── save ─────────────────────────────────────────────────────────────────
 
+    @work
     async def action_save(self) -> None:
         if self.mode == "view":
             return
 
         updates = self._collect_field_updates()
         if updates is None:
-            return  # a field failed to parse; notify() already shown
+            await self.app.push_screen_wait(
+                MessageModal(self._last_field_error or "Invalid field.", title="Could not save")
+            )
+            return
 
         name = self.entry.get("name")
         if self.mode == "create":
             name = self.query_one("#field-name", Input).value.strip()
             if not name:
-                self.notify("Name is required.", severity="error")
+                await self.app.push_screen_wait(
+                    MessageModal("Name is required.", title="Could not save")
+                )
                 return
             existing_names = {c.get("name") for c in self.cfg.connectors_raw}
             if name in existing_names:
-                self.notify(f"A connector named '{name}' already exists.", severity="error")
+                await self.app.push_screen_wait(
+                    MessageModal(
+                        f"A connector named '{name}' already exists.", title="Could not save"
+                    )
+                )
                 return
 
         target_entry = self.entry if self.mode == "edit" else dict(self.entry)
@@ -279,7 +294,7 @@ class ConnectorDetailScreen(FormScreen):
                 # ran — remove it so a failed save doesn't leave a phantom
                 # half-created connector sitting in memory.
                 del self.cfg.document["connectors"][inserted_index]
-            self.notify(f"Could not save: {exc}", severity="error")
+            await self.app.push_screen_wait(MessageModal(str(exc), title="Could not save"))
             return
 
         self.app.pop_screen()

--- a/gateway/configtool/screens/connector_detail.py
+++ b/gateway/configtool/screens/connector_detail.py
@@ -121,6 +121,23 @@ class ConnectorDetailScreen(FormScreen):
     def _entity_noun(self) -> str:
         return "connector"
 
+    def _entity_label(self) -> str:
+        return self.entry.get("name", "?")
+
+    def _remove_entry_from_document(self) -> None:
+        connectors = self.cfg.document.get("connectors") or []
+        # Matched by object IDENTITY, not equality — connectors_raw is a
+        # fresh list each call but wraps the SAME dict objects living in
+        # `document`, and two connectors could (in a broken config) have
+        # byte-identical raw content; identity is the only way to be sure
+        # this is the exact entry this screen was opened on.
+        self._deleted_index = next(i for i, c in enumerate(connectors) if c is self.entry)
+        del connectors[self._deleted_index]
+
+    def _reinsert_entry_into_document(self) -> None:
+        connectors = self.cfg.document.setdefault("connectors", [])
+        connectors.insert(self._deleted_index, self.entry)
+
     def _on_enter_edit_mode(self) -> None:
         self._compute_initial_values(self.entry)
 

--- a/gateway/configtool/screens/connector_detail.py
+++ b/gateway/configtool/screens/connector_detail.py
@@ -182,7 +182,10 @@ class ConnectorDetailScreen(FormScreen):
 
     def _compose_form(self) -> ComposeResult:
         conn_type = self._connector_type()
-        with VerticalScroll(classes="entity-form"):
+        # can_focus=False: see AgentDetailScreen's identical comment — the
+        # container was itself the first stop in the Tab cycle, needing an
+        # extra Tab press to reach the first real field.
+        with VerticalScroll(classes="entity-form", can_focus=False):
             if self.mode == "create":
                 yield Static(f"[bold]New {conn_type} connector[/bold]")
                 with Horizontal(classes="field-row"):

--- a/gateway/configtool/screens/connector_detail.py
+++ b/gateway/configtool/screens/connector_detail.py
@@ -1,23 +1,107 @@
-"""ConnectorDetailScreen — view (and, in a later phase, edit/create) a
-single connector.
+"""ConnectorDetailScreen — view, edit, and create a single connector.
 
-Phase 1 is view-only: a generic recursive dump of the raw connector entry
-(secrets masked). Connector `raw` is deliberately type-flexible (see
-gateway/schema/config.schema.json's connector definition), so unlike Agent/
-WatcherDetailScreen this does not attempt a fixed per-field layout — that is
-Phase 3's per-type template + generic tree editor (docs/design/config-tool.md).
+Connector `raw` is deliberately type-flexible in the schema
+(gateway/schema/config.schema.json's connector definition has no
+`additionalProperties: false`) — unlike Agent/WatcherDetailScreen, there's
+no single closed field list. The design originally called for a generic
+recursive tree editor to handle arbitrary/unknown keys; **deferred** here in
+favor of per-type fixed field lists (`_FIELDS_BY_TYPE` below), one level of
+nesting matching every real connector type's actual raw shape exactly
+(`server.url`, `allowed_users.owners`, etc. — verified against all 4 types'
+own `from_connector_config()` before choosing this). The generic tree editor
+would only earn its complexity for truly arbitrary/unknown keys, and the
+`$EDITOR` escape hatch already covers that case (docs/design/config-tool.md's
+screen inventory: "covers what forms don't") — build it later if per-type
+forms plus `$EDITOR` turn out not to be enough in practice, not preemptively.
+
+`type` is immutable once a connector exists (only chosen via `TypePickerModal`
+at creation, through `OverviewScreen.action_new_entity`) — rocketchat's and
+mattermost's raw shapes differ enough that letting `type` change in place
+would mean the form reshaping itself around one of its own fields' value.
+Changing a connector's type after creation is a rare, advanced operation;
+`$EDITOR` remains available for it. `name` is likewise immutable in edit
+mode — watchers reference a connector by name (`connector: <name>`), so a
+rename would silently orphan them.
 """
 
 from __future__ import annotations
 
 from typing import Literal
 
+from textual.app import ComposeResult
+from textual.containers import Horizontal, VerticalScroll
+from textual.widgets import Input, Static
+
 from ..formatting import mask_if_secret, provenance_label
 from ..model import EditableConfig
-from .base import DetailScreen
+from .form_common import FieldSpec, FormScreen, apply_update
+
+CONNECTOR_TYPES = ("rocketchat", "mattermost", "voice", "script")
+
+_ROCKETCHAT_FIELDS: tuple[FieldSpec, ...] = (
+    FieldSpec("server.url", "str", "Server URL"),
+    FieldSpec("server.username", "str", "Bot username"),
+    FieldSpec("server.password", "str", "Bot password", secret=True),
+    FieldSpec("allowed_users.owners", "list", "Owners (comma-separated)"),
+    FieldSpec("allowed_users.guests", "list", "Guests (comma-separated)"),
+    FieldSpec("reply_in_thread", "bool", "Reply in thread"),
+    FieldSpec("permission_reply_in_thread", "bool", "Permission replies in thread"),
+    FieldSpec("require_mention", "bool", "Require @mention"),
+    FieldSpec("filter_sender", "bool", "Filter by allow-list"),
+    FieldSpec("timezone", "str", "Timezone (IANA, optional)"),
+)
+_MATTERMOST_FIELDS: tuple[FieldSpec, ...] = (
+    FieldSpec("server.url", "str", "Server URL"),
+    FieldSpec("server.team", "str", "Team"),
+    FieldSpec("server.token", "str", "API token", secret=True),
+    FieldSpec("server.username", "str", "Bot username"),
+    FieldSpec("server.password", "str", "Bot password", secret=True),
+    FieldSpec("allowed_users.owners", "list", "Owners (comma-separated)"),
+    FieldSpec("allowed_users.guests", "list", "Guests (comma-separated)"),
+    FieldSpec("reply_in_thread", "bool", "Reply in thread"),
+    FieldSpec("permission_reply_in_thread", "bool", "Permission replies in thread"),
+    FieldSpec("require_mention", "bool", "Require @mention"),
+    FieldSpec("filter_sender", "bool", "Filter by allow-list"),
+    FieldSpec("timezone", "str", "Timezone (IANA, optional)"),
+)
+_VOICE_FIELDS: tuple[FieldSpec, ...] = (
+    FieldSpec("port", "int", "Port"),
+    FieldSpec("host", "str", "Bind host"),
+    FieldSpec("secret", "str", "Bearer secret (optional)", secret=True),
+    FieldSpec("timeout", "int", "Reply timeout (seconds)"),
+)
+_SCRIPT_FIELDS: tuple[FieldSpec, ...] = ()  # ScriptConnector never reads raw
+
+_FIELDS_BY_TYPE: dict[str, tuple[FieldSpec, ...]] = {
+    "rocketchat": _ROCKETCHAT_FIELDS,
+    "mattermost": _MATTERMOST_FIELDS,
+    "voice": _VOICE_FIELDS,
+    "script": _SCRIPT_FIELDS,
+}
+
+# Each connector type's own dataclass defaults (gateway/connectors/*/config.py)
+# — used ONLY to prefill the form with the true effective value when a field
+# is set by neither the entry nor connector_defaults.
+_DATACLASS_DEFAULTS_BY_TYPE: dict[str, dict[str, object]] = {
+    "rocketchat": {
+        "server.url": "", "server.username": "", "server.password": "",
+        "allowed_users.owners": [], "allowed_users.guests": [],
+        "reply_in_thread": False, "permission_reply_in_thread": True,
+        "require_mention": True, "filter_sender": True, "timezone": "",
+    },
+    "mattermost": {
+        "server.url": "", "server.team": "", "server.token": "",
+        "server.username": "", "server.password": "",
+        "allowed_users.owners": [], "allowed_users.guests": [],
+        "reply_in_thread": False, "permission_reply_in_thread": True,
+        "require_mention": True, "filter_sender": True, "timezone": "",
+    },
+    "voice": {"port": 8765, "host": "0.0.0.0", "secret": "", "timeout": 45},
+    "script": {},
+}
 
 
-class ConnectorDetailScreen(DetailScreen):
+class ConnectorDetailScreen(FormScreen):
     BODY_ID = "connector-detail-body"
 
     def __init__(
@@ -30,6 +114,29 @@ class ConnectorDetailScreen(DetailScreen):
         self.cfg = cfg
         self.entry = entry
         self.mode = mode
+        if self.mode != "view":
+            self._compute_initial_values(self.entry)
+            self._populating = True
+
+    def _entity_noun(self) -> str:
+        return "connector"
+
+    def _on_enter_edit_mode(self) -> None:
+        self._compute_initial_values(self.entry)
+
+    def _connector_type(self) -> str:
+        return self.entry.get("type", "rocketchat")
+
+    def _field_specs(self) -> tuple[FieldSpec, ...]:
+        return _FIELDS_BY_TYPE.get(self._connector_type(), ())
+
+    def _defaults_kind(self) -> str:
+        return "connector_defaults"
+
+    def _dataclass_defaults(self) -> dict[str, object]:
+        return _DATACLASS_DEFAULTS_BY_TYPE.get(self._connector_type(), {})
+
+    # ── view mode ────────────────────────────────────────────────────────────
 
     def _body_text(self) -> str:
         name = self.entry.get("name", "?")
@@ -70,3 +177,92 @@ class ConnectorDetailScreen(DetailScreen):
             )
             return f"{prefix}{key}:\n{sub}"
         return f"{prefix}{key}: {mask_if_secret(key, value)}"
+
+    # ── edit/create form ─────────────────────────────────────────────────────
+
+    def _compose_form(self) -> ComposeResult:
+        conn_type = self._connector_type()
+        with VerticalScroll(classes="entity-form"):
+            if self.mode == "create":
+                yield Static(f"[bold]New {conn_type} connector[/bold]")
+                with Horizontal(classes="field-row"):
+                    yield Static("Name", classes="field-label")
+                    yield Input(id="field-name", placeholder="connector name")
+            else:
+                name = self.entry.get("name", "?")
+                yield Static(f"[bold]{name}[/bold]  (type: {conn_type}, editing)")
+
+            with Horizontal(classes="field-row"):
+                yield Static("Description", classes="field-label")
+                yield Input(
+                    id="field-description",
+                    value=self._initial_values.get("description") or "",
+                )
+
+            if conn_type == "mattermost":
+                # UX guidance only — save()'s validate_config() (which runs
+                # the real MattermostConfig.__post_init__) is the actual
+                # enforcement, not reimplemented here.
+                yield Static(
+                    "[yellow]Configure EITHER 'API token' OR 'username' + "
+                    "'password' below — not both, not neither. Saving with "
+                    "the wrong combination shows a validation error.[/yellow]"
+                )
+
+            if not self._field_specs():
+                yield Static(
+                    f"[dim]'{conn_type}' connectors have no type-specific "
+                    "fields to configure here.[/dim]"
+                )
+
+            for spec in self._field_specs():
+                yield from self._compose_field_row(spec, self.entry)
+
+    # ── save ─────────────────────────────────────────────────────────────────
+
+    async def action_save(self) -> None:
+        if self.mode == "view":
+            return
+
+        updates = self._collect_field_updates()
+        if updates is None:
+            return  # a field failed to parse; notify() already shown
+
+        name = self.entry.get("name")
+        if self.mode == "create":
+            name = self.query_one("#field-name", Input).value.strip()
+            if not name:
+                self.notify("Name is required.", severity="error")
+                return
+            existing_names = {c.get("name") for c in self.cfg.connectors_raw}
+            if name in existing_names:
+                self.notify(f"A connector named '{name}' already exists.", severity="error")
+                return
+
+        target_entry = self.entry if self.mode == "edit" else dict(self.entry)
+        for key, value in updates.items():
+            apply_update(target_entry, key, value)
+
+        inserted_index: int | None = None
+        if self.mode == "create":
+            target_entry["name"] = name
+            connectors = self.cfg.document.setdefault("connectors", [])
+            connectors.append(target_entry)
+            inserted_index = len(connectors) - 1
+        self.cfg.mark_dirty()
+
+        try:
+            self.cfg.save()
+        except (ValueError, FileNotFoundError) as exc:
+            if self.mode == "create" and inserted_index is not None:
+                # Nothing existed under this name before this screen ever
+                # ran — remove it so a failed save doesn't leave a phantom
+                # half-created connector sitting in memory.
+                del self.cfg.document["connectors"][inserted_index]
+            self.notify(f"Could not save: {exc}", severity="error")
+            return
+
+        self.app.pop_screen()
+        app = self.app
+        app.notify(f"Saved connector '{name}'.", severity="information")
+        app.reload_config()  # type: ignore[attr-defined]

--- a/gateway/configtool/screens/connector_detail.py
+++ b/gateway/configtool/screens/connector_detail.py
@@ -126,19 +126,29 @@ class ConnectorDetailScreen(FormScreen):
     def _entity_label(self) -> str:
         return self.entry.get("name", "?")
 
-    def _remove_entry_from_document(self) -> None:
-        connectors = self.cfg.document.get("connectors") or []
+    def _find_own_index(self) -> int:
         # Matched by object IDENTITY, not equality — connectors_raw is a
         # fresh list each call but wraps the SAME dict objects living in
         # `document`, and two connectors could (in a broken config) have
         # byte-identical raw content; identity is the only way to be sure
         # this is the exact entry this screen was opened on.
-        self._deleted_index = next(i for i, c in enumerate(connectors) if c is self.entry)
-        del connectors[self._deleted_index]
+        connectors = self.cfg.document.get("connectors") or []
+        return next(i for i, c in enumerate(connectors) if c is self.entry)
+
+    def _remove_entry_from_document(self) -> None:
+        self._deleted_index = self._find_own_index()
+        del self.cfg.document["connectors"][self._deleted_index]
 
     def _reinsert_entry_into_document(self) -> None:
         connectors = self.cfg.document.setdefault("connectors", [])
         connectors.insert(self._deleted_index, self.entry)
+
+    def _install_trial_entry(self, target_entry: dict) -> None:
+        self._edit_index = self._find_own_index()
+        self.cfg.document["connectors"][self._edit_index] = target_entry
+
+    def _rollback_trial_entry(self) -> None:
+        self.cfg.document["connectors"][self._edit_index] = self.entry
 
     def _referencing_watcher_labels(self) -> list[str]:
         return find_referencing_watcher_labels(self.cfg, connector_name=self._entity_label())
@@ -274,7 +284,14 @@ class ConnectorDetailScreen(FormScreen):
                 )
                 return
 
-        target_entry = self.entry if self.mode == "edit" else dict(self.entry)
+        # ALWAYS a trial copy, never self.entry directly — even for "edit",
+        # where self.entry is the SAME object already living in
+        # cfg.document. Mutating it here, before save() has even run, would
+        # leave invalid data sitting in the document if save() then fails
+        # (a real bug: reported as "Save failed, but Back still showed the
+        # invalid value" — the fix is never mutating the original until
+        # save() has actually succeeded).
+        target_entry = dict(self.entry)
         for key, value in updates.items():
             apply_update(target_entry, key, value)
 
@@ -284,6 +301,8 @@ class ConnectorDetailScreen(FormScreen):
             connectors = self.cfg.document.setdefault("connectors", [])
             connectors.append(target_entry)
             inserted_index = len(connectors) - 1
+        else:
+            self._install_trial_entry(target_entry)
         self.cfg.mark_dirty()
 
         try:
@@ -294,9 +313,12 @@ class ConnectorDetailScreen(FormScreen):
                 # ran — remove it so a failed save doesn't leave a phantom
                 # half-created connector sitting in memory.
                 del self.cfg.document["connectors"][inserted_index]
+            else:
+                self._rollback_trial_entry()
             await self.app.push_screen_wait(MessageModal(str(exc), title="Could not save"))
             return
 
+        self.entry = target_entry
         self.app.pop_screen()
         app = self.app
         app.notify(f"Saved connector '{name}'.", severity="information")

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -47,8 +47,8 @@ from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Checkbox, Footer, Header, Input, Select, Static
 
 from ..formatting import provenance_label
-from ..modals import ConfirmModal
-from ..model import Provenance
+from ..modals import ConfirmModal, MessageModal
+from ..model import EditableConfig, Provenance
 from .base import DetailScreen
 
 
@@ -131,6 +131,35 @@ def read_widget_value(spec: FieldSpec, widget: object) -> object:
     return text or None
 
 
+def find_referencing_watcher_labels(
+    cfg: EditableConfig, *, connector_name: str | None = None, agent_name: str | None = None
+) -> list[str]:
+    """Which watchers currently reference the given connector and/or agent
+    name — checked against the MERGED value (`watcher_defaults` can set
+    `connector`/`agent` too; both are allowed there, unlike `name`/`room`/
+    `rooms`/`session_id`), so a watcher that only inherits its connector/agent
+    from `watcher_defaults` still counts. Used to give a clear pre-delete
+    warning instead of the generic validator error `save()` would otherwise
+    surface after the fact.
+    """
+    labels = []
+    for entry in cfg.watchers_raw:
+        try:
+            merged = cfg.merged_entry("watcher_defaults", entry)
+        except (ValueError, FileNotFoundError):
+            merged = entry
+        if connector_name is not None and merged.get("connector") != connector_name:
+            continue
+        if agent_name is not None and merged.get("agent") != agent_name:
+            continue
+        label = entry.get("name")
+        if not label:
+            rooms = entry.get("rooms")
+            label = ", ".join(rooms) if rooms else entry.get("room", "?")
+        labels.append(label)
+    return labels
+
+
 class FormScreen(DetailScreen):
     """Base for the config TUI's view/edit/create entity screens. See
     module docstring for the subclass contract."""
@@ -176,6 +205,7 @@ class FormScreen(DetailScreen):
         self.mode: Literal["view", "edit", "create"] = "view"
         self._form_dirty = False
         self._initial_values: dict[str, object] = {}
+        self._last_field_error: str | None = None
         # Input/Select fire their own Changed message once at initial mount
         # with whatever value the constructor was given (confirmed
         # empirically — Checkbox does not, but Input/Select do). Without this
@@ -232,6 +262,14 @@ class FormScreen(DetailScreen):
     def _reinsert_entry_into_document(self) -> None:
         """Undo `_remove_entry_from_document()` — called when `save()`
         rejects the deletion (e.g. a watcher still references this entity)."""
+        raise NotImplementedError
+
+    def _referencing_watcher_labels(self) -> list[str]:
+        """Which watchers (if any) currently reference this entity — checked
+        BEFORE the destructive confirm, so a blocked delete gets a clear
+        reason instead of the generic validator error `save()` would
+        otherwise surface. Subclasses call `find_referencing_watcher_labels()`
+        with their own kind of name."""
         raise NotImplementedError
 
     async def action_save(self) -> None:
@@ -376,16 +414,31 @@ class FormScreen(DetailScreen):
 
     @work
     async def action_delete(self) -> None:
-        """'d', view mode only (see check_action). Confirm -> remove from
-        `document` -> save(). If save() rejects the deletion (most commonly:
-        a watcher still references this entity — GatewayConfig.from_file
-        raises a clear "references unknown agent/connector" error, and
-        validate_config() surfaces it unchanged, same as every other
-        validation failure this tool relies on save() to catch rather than
-        reimplementing), the entry is reinserted so a rejected delete never
-        leaves `document` silently missing something that's still on disk."""
+        """'d', view mode only (see check_action). Checks for referencing
+        watchers FIRST (a clear, specific reason beats a generic validator
+        error) — if any exist, shows that reason and stops before even
+        offering the destructive confirm. Otherwise: confirm -> remove from
+        `document` -> save(). save() remains the backstop even after the
+        pre-check (belt-and-suspenders, not a replacement for it) — if it
+        still rejects the deletion for some reason the pre-check didn't
+        anticipate, the entry is reinserted so a rejected delete never
+        leaves `document` silently missing something that's still on disk.
+        """
         if self.mode != "view":
             return
+
+        blockers = self._referencing_watcher_labels()
+        if blockers:
+            await self.app.push_screen_wait(
+                MessageModal(
+                    f"Cannot delete {self._entity_noun()} "
+                    f"'{self._entity_label()}' — still used by watcher(s): "
+                    f"{', '.join(blockers)}.",
+                    title="Cannot delete",
+                )
+            )
+            return
+
         confirmed = await self.app.push_screen_wait(
             ConfirmModal(
                 f"Delete {self._entity_noun()} '{self._entity_label()}'? "
@@ -402,7 +455,7 @@ class FormScreen(DetailScreen):
             self.cfg.save()
         except (ValueError, FileNotFoundError) as exc:
             self._reinsert_entry_into_document()
-            self.notify(f"Could not delete: {exc}", severity="error")
+            await self.app.push_screen_wait(MessageModal(str(exc), title="Could not delete"))
             return
 
         self.app.pop_screen()
@@ -416,15 +469,18 @@ class FormScreen(DetailScreen):
     def _collect_field_updates(self) -> dict[str, object] | None:
         """Diff every form widget against `_initial_values`. Returns
         {dotted_key: new_value_or_None} for changed fields only (None means
-        "clear it — revert to inherited/default"), or None (having already
-        called self.notify()) if a field fails to parse."""
+        "clear it — revert to inherited/default"), or None if a field fails
+        to parse — the message is stashed in `self._last_field_error` rather
+        than shown directly (this method is sync; the caller, action_save(),
+        is the one in a position to `await` a `MessageModal`)."""
+        self._last_field_error: str | None = None
         updates: dict[str, object] = {}
         for spec in self._field_specs():
             widget = self.query_one("#" + widget_id(spec.key))
             try:
                 new_value = read_widget_value(spec, widget)
             except ValueError as exc:
-                self.notify(str(exc), severity="error")
+                self._last_field_error = str(exc)
                 return None
             if new_value != self._initial_values.get(spec.key):
                 updates[spec.key] = new_value

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -131,6 +131,24 @@ def read_widget_value(spec: FieldSpec, widget: object) -> object:
     return text or None
 
 
+def set_widget_value(spec: FieldSpec, widget: object, value: object) -> None:
+    """Set `widget`'s displayed value for `spec` — the inverse of
+    `read_widget_value()`. Used by `action_reset_field()` to show what a
+    field would display with zero explicit override (pure `*_defaults` /
+    dataclass fallback), on an ALREADY-MOUNTED, focused widget — unlike
+    `_compose_field_row()`, which sets the initial value via constructor
+    kwargs before the widget ever mounts."""
+    if spec.kind == "bool":
+        widget.value = bool(value)
+    elif spec.kind == "enum":
+        options = spec.options or ()
+        widget.value = value if value in options else (options or (None,))[0]
+    elif spec.kind == "list":
+        widget.value = list_to_text(value)
+    else:
+        widget.value = "" if value is None else str(value)
+
+
 def find_referencing_watcher_labels(
     cfg: EditableConfig, *, connector_name: str | None = None, agent_name: str | None = None
 ) -> list[str]:
@@ -179,6 +197,15 @@ class FormScreen(DetailScreen):
         # headless driver didn't catch — Tab is the one mechanism proven to
         # actually work everywhere.
         Binding("tab", "app.focus_next", "Next field", show=True),
+        # User-reported gap: str/int/list fields can revert an explicit
+        # override back to inherited by clearing the box to blank, but a
+        # Checkbox/Select has no "blank" state — once touched, a bool/enum
+        # field stayed explicit forever, even set back to the same value
+        # the default already has. ctrl+r (not a plain letter — those get
+        # swallowed by whichever Input has focus, same reason Up/Down
+        # navigation didn't work) resets the FOCUSED field specifically,
+        # regardless of kind.
+        Binding("ctrl+r", "reset_field", "Reset field", show=True),
     ]
 
     DEFAULT_CSS = """
@@ -208,6 +235,15 @@ class FormScreen(DetailScreen):
         self._form_dirty = False
         self._initial_values: dict[str, object] = {}
         self._last_field_error: str | None = None
+        # Fields explicitly reset via ctrl+r (action_reset_field()), mapped
+        # to the value the field was set to display AT reset time. Consulted
+        # by _collect_field_updates(): if the widget's CURRENT value still
+        # matches, the field is written as "clear/revert to inherited"
+        # regardless of what _initial_values says — the fix for the
+        # bool/enum revert-to-inherited gap (str/int/list already had this
+        # via clearing the box to blank). If the widget has since changed
+        # away from the reset value, normal diffing takes back over.
+        self._reset_keys: dict[str, object] = {}
         # Input/Select fire their own Changed message once at initial mount
         # with whatever value the constructor was given (confirmed
         # empirically — Checkbox does not, but Input/Select do). Without this
@@ -232,7 +268,7 @@ class FormScreen(DetailScreen):
         mode (nothing to save yet)."""
         if action in ("edit", "delete"):
             return self.mode == "view"
-        if action == "save":
+        if action in ("save", "reset_field"):
             return self.mode != "view"
         return True
 
@@ -308,6 +344,7 @@ class FormScreen(DetailScreen):
     # ── generic field snapshot / provenance / row rendering ─────────────────
 
     def _compute_initial_values(self, entry: dict) -> None:
+        self._reset_keys = {}  # fresh edit session — no lingering reset markers
         try:
             merged = self.cfg.merged_entry(self._defaults_kind(), entry)
         except (ValueError, FileNotFoundError):
@@ -334,23 +371,29 @@ class FormScreen(DetailScreen):
         with Horizontal(classes="field-row"):
             yield Static(spec.label, classes="field-label")
             if spec.kind == "bool":
-                yield Checkbox(value=bool(initial), id=widget_id(spec.key))
+                widget = Checkbox(value=bool(initial), id=widget_id(spec.key))
             elif spec.kind == "enum":
                 options = spec.options or ()
-                yield Select(
+                widget = Select(
                     [(o, o) for o in options],
                     value=initial if initial in options else (options or (None,))[0],
                     allow_blank=False,
                     id=widget_id(spec.key),
                 )
             elif spec.kind == "list":
-                yield Input(value=list_to_text(initial), id=widget_id(spec.key))
+                widget = Input(value=list_to_text(initial), id=widget_id(spec.key))
             else:
-                yield Input(
+                widget = Input(
                     value="" if initial is None else str(initial),
                     id=widget_id(spec.key),
                     password=spec.secret,
                 )
+            # Tagged so a focused widget can be mapped back to its FieldSpec
+            # (action_reset_field()) without unmunging widget_id()'s
+            # dot-to-dash id transform, which would be ambiguous for any
+            # future field key containing a literal dash.
+            widget.field_key = spec.key
+            yield widget
             yield Static(prov_text, classes="field-provenance")
 
     # ── dirty tracking (per-screen, not EditableConfig.dirty — nothing is
@@ -371,6 +414,34 @@ class FormScreen(DetailScreen):
         if self._populating:
             return
         self._form_dirty = True
+
+    def action_reset_field(self) -> None:
+        """ctrl+r: reset the FOCUSED field to its pure-defaults value (no
+        explicit override) — see the `_reset_keys` field comment for how
+        this becomes an actual "revert to inherited" on Save, regardless of
+        field kind. A no-op if focus isn't on a resettable field (e.g. the
+        Name/Description inputs, which aren't tagged with `field_key` — see
+        `_compose_field_row()` — since neither has a `*_defaults` concept)."""
+        widget = self.focused
+        field_key = getattr(widget, "field_key", None)
+        if field_key is None:
+            return
+        spec = next((s for s in self._field_specs() if s.key == field_key), None)
+        if spec is None:
+            return
+
+        try:
+            defaults_only = self.cfg.merged_entry(self._defaults_kind(), {})
+        except (ValueError, FileNotFoundError):
+            defaults_only = {}
+        value = get_nested(defaults_only, spec.key)
+        if value is None:
+            value = self._dataclass_defaults().get(spec.key)
+
+        set_widget_value(spec, widget, value)
+        self._reset_keys[spec.key] = read_widget_value(spec, widget)
+        self._form_dirty = True
+        self.notify(f"{spec.label}: will revert to inherited on Save.", severity="information")
 
     # ── navigation ───────────────────────────────────────────────────────────
 
@@ -502,6 +573,16 @@ class FormScreen(DetailScreen):
             except ValueError as exc:
                 self._last_field_error = str(exc)
                 return None
+            # A field ctrl+r-reset earlier this session (action_reset_field())
+            # always clears to inherited on Save, REGARDLESS of
+            # _initial_values — this is what makes bool/enum fields able to
+            # revert to inherited at all (they have no "blank" state to
+            # clear, unlike str/int/list). Only holds if the widget still
+            # shows the value reset set it to; if the user changed it again
+            # since, this falls through to the normal diff below.
+            if spec.key in self._reset_keys and new_value == self._reset_keys[spec.key]:
+                updates[spec.key] = None
+                continue
             if new_value != self._initial_values.get(spec.key):
                 updates[spec.key] = new_value
 

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -137,6 +137,7 @@ class FormScreen(DetailScreen):
 
     BINDINGS = [
         Binding("e", "edit", "Edit", show=True),
+        Binding("d", "delete", "Delete", show=True),
         Binding("ctrl+s", "save", "Save", show=True),
         # Screen already binds tab/shift+tab to app.focus_next/focus_previous
         # with show=False (textual/screen.py) — re-bound here with show=True
@@ -193,11 +194,11 @@ class FormScreen(DetailScreen):
         self._populating = False
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        """Hide 'Edit' from the footer once already editing/creating (it's a
-        no-op there — action_edit() only does something from view mode; a
-        footer hint for a no-op key reads as broken, not just redundant),
-        and hide 'Save' while still in view mode (nothing to save yet)."""
-        if action == "edit":
+        """Hide 'Edit'/'Delete' from the footer once already editing/creating
+        (both are no-ops there; a footer hint for a no-op key reads as
+        broken, not just redundant), and hide 'Save' while still in view
+        mode (nothing to save yet)."""
+        if action in ("edit", "delete"):
             return self.mode == "view"
         if action == "save":
             return self.mode != "view"
@@ -215,6 +216,22 @@ class FormScreen(DetailScreen):
         raise NotImplementedError
 
     def _compose_form(self) -> ComposeResult:
+        raise NotImplementedError
+
+    def _entity_label(self) -> str:
+        """Used in the delete-confirmation message and the post-delete
+        notification (e.g. an agent/connector's name)."""
+        raise NotImplementedError
+
+    def _remove_entry_from_document(self) -> None:
+        """Delete this entity's raw entry from `self.cfg.document` in place.
+        Must record whatever this subclass needs (e.g. the entry's index in
+        a list) to support `_reinsert_entry_into_document()` undoing it."""
+        raise NotImplementedError
+
+    def _reinsert_entry_into_document(self) -> None:
+        """Undo `_remove_entry_from_document()` — called when `save()`
+        rejects the deletion (e.g. a watcher still references this entity)."""
         raise NotImplementedError
 
     async def action_save(self) -> None:
@@ -353,9 +370,45 @@ class FormScreen(DetailScreen):
             self.refresh_bindings()  # see action_edit()'s comment — same fix
 
     def _entity_noun(self) -> str:
-        """Used only in the discard-confirmation message ("... to this
-        agent?" / "... to this connector?")."""
+        """Used in the discard- and delete-confirmation messages ("... to
+        this agent?" / "... to this connector?")."""
         return "entry"
+
+    @work
+    async def action_delete(self) -> None:
+        """'d', view mode only (see check_action). Confirm -> remove from
+        `document` -> save(). If save() rejects the deletion (most commonly:
+        a watcher still references this entity — GatewayConfig.from_file
+        raises a clear "references unknown agent/connector" error, and
+        validate_config() surfaces it unchanged, same as every other
+        validation failure this tool relies on save() to catch rather than
+        reimplementing), the entry is reinserted so a rejected delete never
+        leaves `document` silently missing something that's still on disk."""
+        if self.mode != "view":
+            return
+        confirmed = await self.app.push_screen_wait(
+            ConfirmModal(
+                f"Delete {self._entity_noun()} '{self._entity_label()}'? "
+                "This cannot be undone.",
+                confirm_label="Delete",
+            )
+        )
+        if not confirmed:
+            return
+
+        self._remove_entry_from_document()
+        self.cfg.mark_dirty()
+        try:
+            self.cfg.save()
+        except (ValueError, FileNotFoundError) as exc:
+            self._reinsert_entry_into_document()
+            self.notify(f"Could not delete: {exc}", severity="error")
+            return
+
+        self.app.pop_screen()
+        app = self.app
+        app.notify(f"Deleted {self._entity_noun()} '{self._entity_label()}'.", severity="information")
+        app.reload_config()  # type: ignore[attr-defined]
 
     # ── generic diff collection (Save calls this, then applies the result
     # however this entity needs to — see module docstring) ──────────────────

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -1,0 +1,383 @@
+"""Shared machinery for the config TUI's entity edit/create forms.
+
+`AgentDetailScreen` was the first (Phase 2); `ConnectorDetailScreen` is the
+second, and `WatcherDetailScreen` (Phase 3) will be the third. Extracted
+here once a second concrete user existed, rather than guessed at up front —
+code review item 10 already flagged the cost of letting screens duplicate
+this kind of machinery independently.
+
+Implements docs/design/config-tool.md decision 2 ("editing an inherited
+field always writes an explicit per-entry override"): nothing is written to
+`EditableConfig.document` until Save. Every field is snapshotted when the
+form opens (the effective/merged value — an inherited field displays its
+real current value, not blank) and diffed against the widget's value at
+Save time; only fields that actually changed get written. Clearing a field
+back to blank reverts it to inherited (pops the key) rather than writing an
+explicit null — see `apply_update()`.
+
+A subclass provides:
+  - `_field_specs() -> tuple[FieldSpec, ...]` — which fields this form shows
+    right now (may depend on entity-specific state, e.g. connector `type`).
+  - `_defaults_kind() -> str` — the `*_defaults` block this entry merges
+    against (`"agent_defaults"` / `"connector_defaults"` / ...).
+  - `_dataclass_defaults() -> dict[str, object]` — the true effective value
+    for a field set by neither the entry nor its `*_defaults` block (a form
+    needs to show what a field would actually evaluate to; view mode gets
+    away with just omitting the line).
+  - `_compose_form() -> ComposeResult` — the form body (typically a
+    `VerticalScroll` wrapping `_compose_field_row()` calls plus whatever
+    entity-specific chrome — a name Input for create mode, etc.).
+  - `action_save()` — entity-specific: where a new entry gets inserted
+    (`document["agents"][name]` is a dict keyed by name; `document["connectors"]`
+    is a list where each entry carries its own `name` field) differs enough
+    that forcing a shared implementation would be more awkward than it's
+    worth. Call `self._collect_field_updates()` for the generic diff, then
+    apply/insert/save however this entity needs to.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, VerticalScroll
+from textual.widgets import Checkbox, Footer, Header, Input, Select, Static
+
+from ..formatting import provenance_label
+from ..modals import ConfirmModal
+from ..model import Provenance
+from .base import DetailScreen
+
+
+@dataclass(frozen=True)
+class FieldSpec:
+    key: str  # dotted for a one-level-nested sub-field, e.g. "server.password"
+    kind: Literal["str", "int", "bool", "list", "enum"]
+    label: str
+    options: tuple[str, ...] | None = None
+    secret: bool = False  # mask the widget's display (Input(password=True))
+
+
+def widget_id(key: str) -> str:
+    return "field-" + key.replace(".", "-")
+
+
+def get_nested(d: dict, dotted_key: str) -> object:
+    if "." not in dotted_key:
+        return d.get(dotted_key)
+    parent_key, sub_key = dotted_key.split(".", 1)
+    parent = d.get(parent_key)
+    return parent.get(sub_key) if isinstance(parent, dict) else None
+
+
+def list_to_text(value: object) -> str:
+    if not value:
+        return ""
+    return ", ".join(str(v) for v in value)
+
+
+def text_to_list(text: str) -> list[str]:
+    return [part.strip() for part in text.split(",") if part.strip()]
+
+
+def apply_update(entry: dict, dotted_key: str, value: object) -> None:
+    """Write `value` (or clear, if None) into `entry` at `dotted_key`.
+
+    A top-level key: set it, or pop it entirely if `value` is None (revert
+    to inherited/default). A one-level-nested key (`"server.password"`):
+    read-modify-write that sub-dict, dropping it entirely once its last
+    explicit sub-key is cleared, so a fully-cleared sub-dict reverts to
+    inheriting from the matching `*_defaults` block again, not an empty
+    `{}` stub sitting in the entry forever.
+    """
+    if "." not in dotted_key:
+        if value is None:
+            entry.pop(dotted_key, None)
+        else:
+            entry[dotted_key] = value
+        return
+    parent_key, sub_key = dotted_key.split(".", 1)
+    parent = entry.get(parent_key)
+    parent = dict(parent) if isinstance(parent, dict) else {}
+    if value is None:
+        parent.pop(sub_key, None)
+    else:
+        parent[sub_key] = value
+    if parent:
+        entry[parent_key] = parent
+    else:
+        entry.pop(parent_key, None)
+
+
+def read_widget_value(spec: FieldSpec, widget: object) -> object:
+    if spec.kind == "bool":
+        return widget.value
+    if spec.kind == "enum":
+        return widget.value
+    if spec.kind == "list":
+        return text_to_list(widget.value) or None
+    if spec.kind == "int":
+        text = widget.value.strip()
+        if not text:
+            return None
+        try:
+            return int(text)
+        except ValueError:
+            raise ValueError(f"{spec.label}: must be a whole number, got {text!r}") from None
+    text = widget.value.strip()
+    return text or None
+
+
+class FormScreen(DetailScreen):
+    """Base for the config TUI's view/edit/create entity screens. See
+    module docstring for the subclass contract."""
+
+    BINDINGS = [
+        Binding("e", "edit", "Edit", show=True),
+        Binding("ctrl+s", "save", "Save", show=True),
+        # Screen already binds tab/shift+tab to app.focus_next/focus_previous
+        # with show=False (textual/screen.py) — re-bound here with show=True
+        # (same pattern OverviewScreen uses for its own tab hint) so the
+        # footer tells the user how to move between fields. An Up/Down
+        # alternative was tried on AgentDetailScreen and reverted after
+        # real-terminal testing showed it was unreliable in a way Pilot's
+        # headless driver didn't catch — Tab is the one mechanism proven to
+        # actually work everywhere.
+        Binding("tab", "app.focus_next", "Next field", show=True),
+    ]
+
+    DEFAULT_CSS = """
+    FormScreen .entity-form {
+        padding: 1 2;
+    }
+    FormScreen .field-row {
+        height: auto;
+        margin-bottom: 1;
+    }
+    FormScreen .field-label {
+        width: 30;
+        padding-top: 1;
+    }
+    FormScreen .field-provenance {
+        padding-top: 1;
+        margin-left: 2;
+    }
+    FormScreen Checkbox {
+        width: auto;
+    }
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.mode: Literal["view", "edit", "create"] = "view"
+        self._form_dirty = False
+        self._initial_values: dict[str, object] = {}
+        # Input/Select fire their own Changed message once at initial mount
+        # with whatever value the constructor was given (confirmed
+        # empirically — Checkbox does not, but Input/Select do). Without this
+        # guard, simply OPENING the edit form would immediately mark it
+        # dirty, incorrectly prompting a discard-confirmation on Escape even
+        # though the user never touched anything. Cleared via
+        # call_after_refresh, which runs after that initial burst of Changed
+        # messages has already been processed.
+        self._populating = False
+
+    def on_mount(self) -> None:
+        if self._populating:
+            self.call_after_refresh(self._stop_populating)
+
+    def _stop_populating(self) -> None:
+        self._populating = False
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        """Hide 'Edit' from the footer once already editing/creating (it's a
+        no-op there — action_edit() only does something from view mode; a
+        footer hint for a no-op key reads as broken, not just redundant),
+        and hide 'Save' while still in view mode (nothing to save yet)."""
+        if action == "edit":
+            return self.mode == "view"
+        if action == "save":
+            return self.mode != "view"
+        return True
+
+    # ── abstract hooks subclasses must implement ────────────────────────────
+
+    def _field_specs(self) -> tuple[FieldSpec, ...]:
+        raise NotImplementedError
+
+    def _defaults_kind(self) -> str:
+        raise NotImplementedError
+
+    def _dataclass_defaults(self) -> dict[str, object]:
+        raise NotImplementedError
+
+    def _compose_form(self) -> ComposeResult:
+        raise NotImplementedError
+
+    async def action_save(self) -> None:
+        raise NotImplementedError
+
+    # ── compose dispatch ─────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        if self.mode == "view":
+            yield VerticalScroll(Static(self._body_text(), id=self.BODY_ID))
+        else:
+            yield from self._compose_form()
+        yield Footer()
+
+    # ── generic field snapshot / provenance / row rendering ─────────────────
+
+    def _compute_initial_values(self, entry: dict) -> None:
+        try:
+            merged = self.cfg.merged_entry(self._defaults_kind(), entry)
+        except (ValueError, FileNotFoundError):
+            merged = dict(entry)
+        dataclass_defaults = self._dataclass_defaults()
+        for spec in self._field_specs():
+            value = get_nested(merged, spec.key)
+            if value is None:
+                value = dataclass_defaults.get(spec.key)
+            self._initial_values[spec.key] = value
+        self._initial_values["description"] = entry.get("description")
+
+    def _field_provenance(self, spec: FieldSpec, entry: dict) -> Provenance | None:
+        top_key = spec.key.split(".", 1)[0]
+        try:
+            return self.cfg.field_provenance(self._defaults_kind(), entry, top_key)
+        except (ValueError, FileNotFoundError):
+            return None
+
+    def _compose_field_row(self, spec: FieldSpec, entry: dict) -> ComposeResult:
+        provenance = self._field_provenance(spec, entry)
+        prov_text = f"[dim]({provenance_label(provenance)})[/dim]" if provenance else ""
+        initial = self._initial_values.get(spec.key)
+        with Horizontal(classes="field-row"):
+            yield Static(spec.label, classes="field-label")
+            if spec.kind == "bool":
+                yield Checkbox(value=bool(initial), id=widget_id(spec.key))
+            elif spec.kind == "enum":
+                options = spec.options or ()
+                yield Select(
+                    [(o, o) for o in options],
+                    value=initial if initial in options else (options or (None,))[0],
+                    allow_blank=False,
+                    id=widget_id(spec.key),
+                )
+            elif spec.kind == "list":
+                yield Input(value=list_to_text(initial), id=widget_id(spec.key))
+            else:
+                yield Input(
+                    value="" if initial is None else str(initial),
+                    id=widget_id(spec.key),
+                    password=spec.secret,
+                )
+            yield Static(prov_text, classes="field-provenance")
+
+    # ── dirty tracking (per-screen, not EditableConfig.dirty — nothing is
+    # written to `document` until Save, so cfg.dirty stays False the whole
+    # time the user is mid-form; this local flag is what Escape checks) ──────
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if self._populating:
+            return
+        self._form_dirty = True
+
+    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
+        if self._populating:
+            return
+        self._form_dirty = True
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if self._populating:
+            return
+        self._form_dirty = True
+
+    # ── navigation ───────────────────────────────────────────────────────────
+
+    async def action_edit(self) -> None:
+        if self.mode != "view":
+            return
+        self.mode = "edit"
+        self._form_dirty = False
+        self._on_enter_edit_mode()
+        # recompose() does NOT re-trigger on_mount (that only fires once, for
+        # the screen's own initial push) — so the populating guard has to be
+        # armed and disarmed around this recompose explicitly, the same way
+        # on_mount handles it for a screen pushed directly in create mode.
+        self._populating = True
+        await self.recompose()
+        self.call_after_refresh(self._stop_populating)
+        # Footer subscribes to Screen.bindings_updated_signal in ITS OWN
+        # on_mount — recompose() mounts a brand-new Footer instance, but
+        # nothing re-publishes that signal just because a new subscriber
+        # showed up, so the fresh Footer's `_bindings_ready` reactive stays
+        # False forever and it renders as a blank bar (confirmed empirically
+        # while building AgentDetailScreen: 4 FooterKey children at first
+        # mount, 0 after this recompose, permanently, across every later
+        # transition too). refresh_bindings() is Screen's own public method
+        # for exactly this: it re-publishes the signal so every current
+        # subscriber (including the new Footer) recomputes — and also
+        # re-evaluates check_action() for every binding, so the 'e'/'ctrl+s'
+        # visibility flips immediately on this same recompose.
+        self.refresh_bindings()
+
+    def _on_enter_edit_mode(self) -> None:
+        """Hook for subclass-specific setup right before the edit-mode
+        recompose (AgentDetailScreen recomputes _initial_values here)."""
+
+    @work
+    async def action_back(self) -> None:
+        if self.mode == "view":
+            self.app.pop_screen()
+            return
+        if self._form_dirty:
+            discard = await self.app.push_screen_wait(
+                ConfirmModal(
+                    f"Discard unsaved changes to this {self._entity_noun()}?",
+                    confirm_label="Discard",
+                )
+            )
+            if not discard:
+                return
+        if self.mode == "create":
+            self.app.pop_screen()
+        else:
+            self.mode = "view"
+            self._form_dirty = False
+            await self.recompose()
+            self.refresh_bindings()  # see action_edit()'s comment — same fix
+
+    def _entity_noun(self) -> str:
+        """Used only in the discard-confirmation message ("... to this
+        agent?" / "... to this connector?")."""
+        return "entry"
+
+    # ── generic diff collection (Save calls this, then applies the result
+    # however this entity needs to — see module docstring) ──────────────────
+
+    def _collect_field_updates(self) -> dict[str, object] | None:
+        """Diff every form widget against `_initial_values`. Returns
+        {dotted_key: new_value_or_None} for changed fields only (None means
+        "clear it — revert to inherited/default"), or None (having already
+        called self.notify()) if a field fails to parse."""
+        updates: dict[str, object] = {}
+        for spec in self._field_specs():
+            widget = self.query_one("#" + widget_id(spec.key))
+            try:
+                new_value = read_widget_value(spec, widget)
+            except ValueError as exc:
+                self.notify(str(exc), severity="error")
+                return None
+            if new_value != self._initial_values.get(spec.key):
+                updates[spec.key] = new_value
+
+        desc_widget = self.query_one("#field-description", Input)
+        new_desc = desc_widget.value.strip() or None
+        if new_desc != self._initial_values.get("description"):
+            updates["description"] = new_desc
+        return updates

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -134,29 +134,31 @@ def read_widget_value(spec: FieldSpec, widget: object) -> object:
 def find_referencing_watcher_labels(
     cfg: EditableConfig, *, connector_name: str | None = None, agent_name: str | None = None
 ) -> list[str]:
-    """Which watchers currently reference the given connector and/or agent
-    name — checked against the MERGED value (`watcher_defaults` can set
-    `connector`/`agent` too; both are allowed there, unlike `name`/`room`/
-    `rooms`/`session_id`), so a watcher that only inherits its connector/agent
-    from `watcher_defaults` still counts. Used to give a clear pre-delete
-    warning instead of the generic validator error `save()` would otherwise
-    surface after the fact.
+    """Which EXPANDED watchers currently reference the given connector and/or
+    agent name — one label per real watcher, using `expanded_watchers()`
+    (the same real loader that names them everywhere else in the TUI, e.g.
+    the Overview's Watchers tab) rather than re-deriving names from the raw
+    entry. Two things this gets right that a raw-entry-only approach
+    wouldn't: (1) an unnamed watcher's real name is `_auto_watcher_name()`'s
+    `"<connector>-<room>"` (gateway/config.py), not the bare room string;
+    (2) a `rooms: [a, b]` group is N separate real watchers with N separate
+    names, not one joined "a, b" label. If the config doesn't currently
+    load at all, returns [] — `save()`'s own validation remains the backstop
+    for whatever's actually broken; a delete pre-check has nothing useful to
+    say about referencing watchers in a config that doesn't parse.
     """
+    try:
+        expanded = cfg.expanded_watchers()
+    except (ValueError, FileNotFoundError):
+        return []
     labels = []
-    for entry in cfg.watchers_raw:
-        try:
-            merged = cfg.merged_entry("watcher_defaults", entry)
-        except (ValueError, FileNotFoundError):
-            merged = entry
-        if connector_name is not None and merged.get("connector") != connector_name:
+    for ew in expanded:
+        w = ew.watcher
+        if connector_name is not None and w.connector != connector_name:
             continue
-        if agent_name is not None and merged.get("agent") != agent_name:
+        if agent_name is not None and w.agent != agent_name:
             continue
-        label = entry.get("name")
-        if not label:
-            rooms = entry.get("rooms")
-            label = ", ".join(rooms) if rooms else entry.get("room", "?")
-        labels.append(label)
+        labels.append(w.name)
     return labels
 
 
@@ -262,6 +264,24 @@ class FormScreen(DetailScreen):
     def _reinsert_entry_into_document(self) -> None:
         """Undo `_remove_entry_from_document()` — called when `save()`
         rejects the deletion (e.g. a watcher still references this entity)."""
+        raise NotImplementedError
+
+    def _install_trial_entry(self, target_entry: dict) -> None:
+        """EDIT mode only: temporarily substitute `target_entry` (a COPY of
+        `self.entry` with this Save's updates already applied) into
+        `self.cfg.document`, in place of the original. This runs BEFORE
+        `save()` — never mutate `self.entry` itself here, or a rejected
+        save leaves invalid data sitting in the document even though
+        nothing was ever written to disk (a real bug: user-reported that
+        setting an invalid value, having Save fail, then pressing Back
+        still showed the invalid value — because the old code mutated
+        the SAME dict object `document` already held). Call
+        `_rollback_trial_entry()` if `save()` rejects it."""
+        raise NotImplementedError
+
+    def _rollback_trial_entry(self) -> None:
+        """Undo `_install_trial_entry()` — restore the ORIGINAL `self.entry`
+        (untouched) into `document`. Called when `save()` rejects the trial."""
         raise NotImplementedError
 
     def _referencing_watcher_labels(self) -> list[str]:

--- a/gateway/configtool/screens/overview.py
+++ b/gateway/configtool/screens/overview.py
@@ -22,7 +22,7 @@ from ..formatting import status_badge
 from ..modals import TypePickerModal
 from ..model import StatusIndex
 from .agent_detail import AgentDetailScreen
-from .connector_detail import ConnectorDetailScreen
+from .connector_detail import CONNECTOR_TYPES, ConnectorDetailScreen
 from .defaults import DefaultsScreen
 from .tool_presets import ToolPresetsScreen
 from .watcher_detail import WatcherDetailScreen
@@ -87,29 +87,36 @@ class OverviewScreen(Screen):
 
     @work
     async def action_new_entity(self) -> None:
-        """'n' — scoped to whichever tab is active. Only Agents supports
-        creation so far (docs/design/config-tool.md's Phase 2 order does
-        connector/agent CRUD together; agent landed first — see the design
-        doc's Phase 2 status). Other tabs just notify, rather than doing
-        nothing silently or crashing."""
+        """'n' — scoped to whichever tab is active. Agents and Connectors
+        support creation; Watchers/Defaults/Tool Presets don't yet (Phase 3).
+        Unsupported tabs just notify, rather than doing nothing silently or
+        crashing."""
         app: "ConfigToolApp" = self.app  # type: ignore[assignment]
         if app.editable_config is None:
             self.notify("Config does not currently load — nothing to add to.", severity="error")
             return
 
         active_tab = self.query_one(TabbedContent).active
-        if active_tab != "tab-agents":
+        if active_tab == "tab-agents":
+            agent_type = await self.app.push_screen_wait(
+                TypePickerModal("New agent — pick a type", list(_AGENT_TYPES))
+            )
+            if agent_type is None:
+                return
+            self.app.push_screen(
+                AgentDetailScreen(app.editable_config, "", {"type": agent_type}, mode="create")
+            )
+        elif active_tab == "tab-connectors":
+            connector_type = await self.app.push_screen_wait(
+                TypePickerModal("New connector — pick a type", list(CONNECTOR_TYPES))
+            )
+            if connector_type is None:
+                return
+            self.app.push_screen(
+                ConnectorDetailScreen(app.editable_config, {"type": connector_type}, mode="create")
+            )
+        else:
             self.notify("Creating a new entry isn't supported on this tab yet.", severity="warning")
-            return
-
-        agent_type = await self.app.push_screen_wait(
-            TypePickerModal("New agent — pick a type", list(_AGENT_TYPES))
-        )
-        if agent_type is None:
-            return
-        self.app.push_screen(
-            AgentDetailScreen(app.editable_config, "", {"type": agent_type}, mode="create")
-        )
 
     def action_refresh(self) -> None:
         # Must go through app.reload_config() (re-reads EditableConfig.document

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -850,3 +850,136 @@ class TestDeleteAgent:
 
             keys = {k.key for k in app.screen.query_one(Footer).query(FooterKey)}
             assert "d" not in keys
+
+
+class TestResetFieldToInherited:
+    """ctrl+r (action_reset_field()) — user-reported gap: str/int/list
+    fields can revert to inherited by clearing the box to blank, but a
+    Checkbox/Select has no "blank" state, so a bool/enum field stayed
+    explicit forever once touched, even set back to a value matching the
+    default. This is the fix: reset the FOCUSED field regardless of kind."""
+
+    async def test_resetting_an_explicit_boolean_reverts_it_to_inherited_on_save(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(
+            tmp_path,
+            _config_with_one_agent(work_dir, "lazy_instruction_loading: false\n"),
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            checkbox = app.screen.query_one("#field-lazy_instruction_loading", Checkbox)
+            assert checkbox.value is False  # explicit, matches the entry above
+            checkbox.focus()
+            await pilot.pause()
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            # Reset shows the pure-default value (AgentConfig's own default,
+            # True — agent_defaults in this fixture doesn't set it either).
+            assert checkbox.value is True
+
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert "lazy_instruction_loading" not in entry  # reverted to inherited
+
+    async def test_resetting_a_string_field_also_reverts_it_to_inherited(
+        self, tmp_path, work_dir
+    ):
+        """Confirms ctrl+r works uniformly across field kinds, not just
+        booleans — even though str fields already had clear-to-blank."""
+        config_path = _write_config(
+            tmp_path, _config_with_one_agent(work_dir, "session_prefix: custom\n")
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            field = app.screen.query_one("#field-session_prefix", Input)
+            assert field.value == "custom"
+            field.focus()
+            await pilot.pause()
+
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            assert field.value == "agent-chat"  # AgentConfig's own default
+
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert "session_prefix" not in entry
+
+    async def test_changing_the_field_again_after_reset_overrides_the_reset(
+        self, tmp_path, work_dir
+    ):
+        """Reset then a further real edit must NOT be silently swallowed —
+        normal diff-based semantics take back over once the widget's value
+        no longer matches what reset set it to."""
+        config_path = _write_config(
+            tmp_path,
+            _config_with_one_agent(work_dir, "lazy_instruction_loading: false\n"),
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            checkbox = app.screen.query_one("#field-lazy_instruction_loading", Checkbox)
+            checkbox.focus()
+            await pilot.pause()
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+            assert checkbox.value is True
+
+            checkbox.value = False  # change it again, away from the reset value
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert entry["lazy_instruction_loading"] is False  # explicit, not reverted
+
+    async def test_ctrl_r_on_a_non_field_widget_is_a_safe_no_op(self, tmp_path, work_dir):
+        """Name/Description inputs aren't tagged with field_key (no
+        *_defaults concept) — pressing ctrl+r while focused there must do
+        nothing, not crash."""
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            desc = app.screen.query_one("#field-description", Input)
+            desc.value = "some description"
+            desc.focus()
+            await pilot.pause()
+
+            await pilot.press("ctrl+r")  # must not raise
+            await pilot.pause()
+            assert desc.value == "some description"  # untouched
+
+    async def test_ctrl_r_hint_only_shown_while_editing(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            table = app.screen.query_one("#agents-table", DataTable)
+            table.focus()
+            table.move_cursor(row=0)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            keys = {k.key for k in app.screen.query_one(Footer).query(FooterKey)}
+            assert "ctrl+r" not in keys  # view mode — nothing to reset
+
+            await pilot.press("e")
+            await pilot.pause()
+            keys = {k.key for k in app.screen.query_one(Footer).query(FooterKey)}
+            assert "ctrl+r" in keys

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -80,16 +80,17 @@ class TestNewAgentEntryPoint:
             await pilot.pause()
             assert isinstance(app.screen, TypePickerModal)
 
-    async def test_n_key_on_connectors_tab_notifies_instead_of_crashing(
+    async def test_n_key_on_watchers_tab_notifies_instead_of_crashing(
         self, tmp_path, work_dir
     ):
-        """Connector creation isn't built yet (separate task) — pressing 'n'
-        on that tab must be a friendly no-op, not a crash or silent no-op."""
+        """Watcher creation is Phase 3, not built yet — pressing 'n' on that
+        tab must be a friendly no-op, not a crash or silent no-op. (Connector
+        creation, tested elsewhere, now IS supported on tab-connectors.)"""
         config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
             await pilot.pause()
-            app.screen.query_one("TabbedContent").active = "tab-connectors"
+            app.screen.query_one("TabbedContent").active = "tab-watchers"
             await pilot.pause()
 
             await pilot.press("n")

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -609,3 +609,42 @@ class TestFooterHintsMatchAvailableActions:
             assert "ctrl+s" in keys
             assert "e" not in keys
             assert "tab" in keys
+
+
+class TestFirstFieldFocus:
+    """Regression: the form's VerticalScroll container was itself the first
+    stop in the Tab cycle (it's focusable by default, for keyboard
+    scrolling) — user-reported needing to press Tab TWICE after entering
+    edit mode to reach the first real field. Fixed with can_focus=False on
+    the container; scrolling still works via mouse wheel/PageUp/PageDown."""
+
+    async def test_create_mode_auto_focuses_the_name_field_with_zero_tabs(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-agents"
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert app.screen.focused is not None
+            assert app.screen.focused.id == "field-name"
+
+    async def test_edit_mode_reaches_the_first_field_with_a_single_tab(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            await pilot.press("tab")
+            await pilot.pause()
+            assert app.screen.focused is not None
+            assert app.screen.focused.id == "field-description"

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -19,7 +19,7 @@ from textual.widgets import Checkbox, DataTable, Footer, Input, Select, Static
 from textual.widgets._footer import FooterKey
 
 from gateway.configtool.app import ConfigToolApp
-from gateway.configtool.modals import ConfirmModal, TypePickerModal
+from gateway.configtool.modals import ConfirmModal, MessageModal, TypePickerModal
 from gateway.configtool.screens.agent_detail import AgentDetailScreen
 from gateway.configtool.screens.overview import OverviewScreen
 
@@ -164,6 +164,10 @@ class TestCreateAgent:
             await pilot.press("ctrl+s")
             await pilot.pause()
 
+            assert isinstance(app.screen, MessageModal)
+            await pilot.press("enter")  # dismiss
+            await pilot.pause()
+
             assert isinstance(app.screen, AgentDetailScreen)
             assert app.screen.mode == "create"
             # The original agent must be untouched.
@@ -185,6 +189,9 @@ class TestCreateAgent:
             await pilot.pause()
 
             await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert isinstance(app.screen, MessageModal)
+            await pilot.press("enter")  # dismiss
             await pilot.pause()
             assert isinstance(app.screen, AgentDetailScreen)
             assert app.screen.mode == "create"
@@ -213,6 +220,10 @@ class TestCreateAgent:
             )
             await pilot.pause()
             await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, MessageModal)
+            await pilot.press("enter")  # dismiss
             await pilot.pause()
 
             assert isinstance(app.screen, AgentDetailScreen)
@@ -367,6 +378,10 @@ class TestEditAgent:
             app.screen.query_one("#field-timeout", Input).value = "not-a-number"
             await pilot.pause()
             await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, MessageModal)
+            await pilot.press("enter")  # dismiss
             await pilot.pause()
 
             assert isinstance(app.screen, AgentDetailScreen)
@@ -679,12 +694,14 @@ async def _open_agent_in_view_mode(pilot, app, row: int = 0) -> None:
 
 
 class TestDeleteAgent:
-    async def test_d_key_shows_confirm_modal(self, tmp_path, work_dir):
+    async def test_d_key_on_an_unreferenced_agent_shows_confirm_modal(
+        self, tmp_path, work_dir
+    ):
         config_path = _write_config(tmp_path, _config_with_two_agents(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
             await pilot.pause()
-            await _open_agent_in_view_mode(pilot, app)
+            await _open_agent_in_view_mode(pilot, app, row=1)  # unused-agent
 
             await pilot.press("d")
             await pilot.pause()
@@ -695,7 +712,7 @@ class TestDeleteAgent:
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
             await pilot.pause()
-            await _open_agent_in_view_mode(pilot, app)
+            await _open_agent_in_view_mode(pilot, app, row=1)  # unused-agent
 
             await pilot.press("d")
             await pilot.pause()
@@ -727,13 +744,13 @@ class TestDeleteAgent:
             assert "existing-agent" in raw["agents"]
             assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
 
-    async def test_deleting_a_referenced_agent_fails_and_rolls_back(
+    async def test_deleting_a_referenced_agent_is_blocked_before_the_confirm(
         self, tmp_path, work_dir
     ):
-        """A watcher still references 'existing-agent' — save()'s
-        validate_config() must reject the deletion (GatewayConfig.from_file
-        raises "references unknown agent"), and the agent must be restored,
-        not left removed-from-memory-but-not-saved."""
+        """A watcher still references 'existing-agent' — the pre-delete
+        check catches this BEFORE even offering the destructive confirm,
+        naming the referencing watcher in a MessageModal rather than
+        relying on save()'s generic validator error."""
         config_path = _write_config(tmp_path, _config_with_two_agents(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
@@ -743,10 +760,15 @@ class TestDeleteAgent:
 
             await pilot.press("d")
             await pilot.pause()
-            await pilot.press("tab", "enter")  # Delete
+
+            assert isinstance(app.screen, MessageModal)
+            body = str(app.screen.query_one("#message-body").render())
+            assert "existing-agent" in body
+            await pilot.press("enter")  # dismiss
             await pilot.pause()
 
-            # Stays on the (still-view-mode) detail screen — delete failed.
+            # Stays on the (still-view-mode) detail screen — nothing was
+            # ever removed from `document` in the first place.
             assert isinstance(app.screen, AgentDetailScreen)
             assert app.screen.mode == "view"
             assert "existing-agent" in app.editable_config.agents_raw

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -648,3 +648,122 @@ class TestFirstFieldFocus:
             await pilot.pause()
             assert app.screen.focused is not None
             assert app.screen.focused.id == "field-description"
+
+
+def _config_with_two_agents(work_dir: Path) -> str:
+    """'existing-agent' is referenced by the watcher; 'unused-agent' is not
+    — used to test both the delete-succeeds and delete-blocked paths."""
+    return f"""\
+        agents:
+          existing-agent:
+            working_directory: {work_dir}
+          unused-agent:
+            working_directory: {work_dir}
+        connectors:
+          - name: rc
+            type: rocketchat
+            server: {{url: "http://localhost:3000", username: bot, password: pw}}
+        watchers:
+          - connector: rc
+            agent: existing-agent
+            room: general
+    """
+
+
+async def _open_agent_in_view_mode(pilot, app, row: int = 0) -> None:
+    table = app.screen.query_one("#agents-table", DataTable)
+    table.focus()
+    table.move_cursor(row=row)
+    await pilot.press("enter")
+    await pilot.pause()
+
+
+class TestDeleteAgent:
+    async def test_d_key_shows_confirm_modal(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_two_agents(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_view_mode(pilot, app)
+
+            await pilot.press("d")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+    async def test_cancelling_the_delete_keeps_the_agent(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_two_agents(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_view_mode(pilot, app)
+
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("enter")  # Cancel is focused by default
+            await pilot.pause()
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "view"
+            assert "unused-agent" in app.editable_config.agents_raw
+
+    async def test_confirming_delete_of_an_unreferenced_agent_succeeds(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_two_agents(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            # row 1 is "unused-agent" (dict order: existing-agent, unused-agent)
+            await _open_agent_in_view_mode(pilot, app, row=1)
+            assert app.screen.agent_name == "unused-agent"
+
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("tab", "enter")  # Delete
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert "unused-agent" not in raw["agents"]
+            assert "existing-agent" in raw["agents"]
+            assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
+
+    async def test_deleting_a_referenced_agent_fails_and_rolls_back(
+        self, tmp_path, work_dir
+    ):
+        """A watcher still references 'existing-agent' — save()'s
+        validate_config() must reject the deletion (GatewayConfig.from_file
+        raises "references unknown agent"), and the agent must be restored,
+        not left removed-from-memory-but-not-saved."""
+        config_path = _write_config(tmp_path, _config_with_two_agents(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_view_mode(pilot, app, row=0)
+            assert app.screen.agent_name == "existing-agent"
+
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("tab", "enter")  # Delete
+            await pilot.pause()
+
+            # Stays on the (still-view-mode) detail screen — delete failed.
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "view"
+            assert "existing-agent" in app.editable_config.agents_raw
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert "existing-agent" in raw["agents"]  # untouched on disk too
+
+    async def test_delete_is_hidden_from_the_footer_while_editing(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_two_agents(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            from textual.widgets import Footer
+            from textual.widgets._footer import FooterKey
+
+            keys = {k.key for k in app.screen.query_one(Footer).query(FooterKey)}
+            assert "d" not in keys

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -390,6 +390,67 @@ class TestEditAgent:
             entry = app.editable_config.agents_raw["existing-agent"]
             assert "timeout" not in entry
 
+    async def test_a_save_that_fails_validate_config_does_not_mutate_the_live_entry(
+        self, tmp_path, work_dir
+    ):
+        """User-reported: setting timeout to a value that parses fine as an
+        integer but fails validate_config() (timeout <= permissions.timeout,
+        with permissions enabled), having Save fail, then pressing Back
+        still showed the invalid value — i.e. the failed save had already
+        mutated the SAME dict object already living in cfg.document, since
+        edit mode used to pass self.entry itself (not a copy) as the
+        in-progress target_entry. Fixed by always applying updates to a
+        COPY and only swapping it into `document` (installed BEFORE save(),
+        rolled back on failure) — this pins the original entry stays
+        completely untouched, in memory AND on disk, after a rejected save."""
+        config_path = _write_config(
+            tmp_path,
+            _config_with_one_agent(
+                work_dir, "timeout: 500\npermissions: {enabled: true, timeout: 300}\n"
+            ),
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-timeout", Input).value = "-1"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, MessageModal)
+            body = str(app.screen.query_one("#message-body").render())
+            assert "timeout" in body
+            await pilot.press("enter")  # dismiss
+            await pilot.pause()
+
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "edit"
+
+            # The ORIGINAL entry must be completely untouched — not just
+            # "no timeout key", but the exact original value preserved.
+            entry = app.editable_config.agents_raw["existing-agent"]
+            assert entry["timeout"] == 500
+
+            # Escape (discarding this still-open edit) and confirm the
+            # view-mode screen (and the file on disk) show the ORIGINAL
+            # value too, not the rejected -1.
+            await pilot.press("escape")
+            await pilot.pause()
+            if isinstance(app.screen, ConfirmModal):
+                await pilot.press("tab", "enter")  # Discard
+                await pilot.pause()
+
+            assert isinstance(app.screen, AgentDetailScreen)
+            assert app.screen.mode == "view"
+            body = app.screen._body_text()
+            assert "timeout: 500" in body
+            assert "-1" not in body
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["agents"]["existing-agent"]["timeout"] == 500
+
     async def test_working_directory_warning_appears_for_a_missing_directory(
         self, tmp_path, work_dir
     ):

--- a/tests/unit/test_configtool_connector_crud.py
+++ b/tests/unit/test_configtool_connector_crud.py
@@ -1,0 +1,393 @@
+"""Pilot-based tests for ConnectorDetailScreen's create/edit flow.
+
+The security-critical property here (advisor-flagged: treat with the same
+weight as EditableConfig.save()'s $VAR round-trip test) is
+`test_editing_an_unrelated_field_leaves_an_existing_secret_placeholder_untouched`
+below — a connector's `server.password` set to `"${RC_PASSWORD}"` must
+survive an edit to a DIFFERENT field completely unresolved, never masked
+data, never the actual env var's real value.
+"""
+
+from __future__ import annotations
+
+import os
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+from textual.widgets import DataTable, Input
+
+from gateway.configtool.app import ConfigToolApp
+from gateway.configtool.modals import ConfirmModal, TypePickerModal
+from gateway.configtool.screens.connector_detail import ConnectorDetailScreen
+from gateway.configtool.screens.overview import OverviewScreen
+
+
+def _write_config(tmp_path: Path, yaml_text: str) -> str:
+    path = tmp_path / "config.yaml"
+    path.write_text(textwrap.dedent(yaml_text))
+    return str(path)
+
+
+@pytest.fixture
+def work_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "work"
+    d.mkdir()
+    return d
+
+
+def _config_with_one_rocketchat_connector(work_dir: Path, password: str = "pw") -> str:
+    return f"""\
+        agents:
+          default:
+            type: claude
+            working_directory: {work_dir}
+        connectors:
+          - name: rc-existing
+            type: rocketchat
+            server: {{url: "http://localhost:3000", username: bot, password: "{password}"}}
+        watchers:
+          - connector: rc-existing
+            agent: default
+            room: general
+    """
+
+
+async def _open_connector_in_edit_mode(pilot, app) -> None:
+    table = app.screen.query_one("#connectors-table", DataTable)
+    table.focus()
+    table.move_cursor(row=0)
+    await pilot.press("enter")
+    await pilot.pause()
+    await pilot.press("e")
+    await pilot.pause()
+
+
+async def _open_type_picker_for_connectors(pilot, app) -> None:
+    app.screen.query_one("TabbedContent").active = "tab-connectors"
+    await pilot.pause()
+    await pilot.press("n")
+    await pilot.pause()
+
+
+class TestNewConnectorEntryPoint:
+    async def test_n_key_on_connectors_tab_opens_type_picker_with_all_4_types(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_type_picker_for_connectors(pilot, app)
+            assert isinstance(app.screen, TypePickerModal)
+            assert app.screen.options == ["rocketchat", "mattermost", "voice", "script"]
+
+
+class TestCreateConnector:
+    async def test_creating_a_rocketchat_connector_persists_it(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_type_picker_for_connectors(pilot, app)
+            await pilot.press("enter")  # first option: rocketchat
+            await pilot.pause()
+            assert isinstance(app.screen, ConnectorDetailScreen)
+            assert app.screen.mode == "create"
+
+            app.screen.query_one("#field-name", Input).value = "rc-second"
+            app.screen.query_one("#field-server-url", Input).value = "http://rc2.local"
+            app.screen.query_one("#field-server-username", Input).value = "bot2"
+            app.screen.query_one("#field-server-password", Input).value = "pw2"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            names = {c["name"]: c for c in raw["connectors"]}
+            assert names["rc-second"]["server"]["url"] == "http://rc2.local"
+            assert names["rc-second"]["server"]["password"] == "pw2"
+            assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
+
+    async def test_creating_a_voice_connector_uses_the_flat_field_list(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_type_picker_for_connectors(pilot, app)
+            await pilot.press("down", "down", "enter")  # voice (3rd option)
+            await pilot.pause()
+            assert isinstance(app.screen, ConnectorDetailScreen)
+
+            app.screen.query_one("#field-name", Input).value = "voice-1"
+            app.screen.query_one("#field-port", Input).value = "9999"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            names = {c["name"]: c for c in raw["connectors"]}
+            assert names["voice-1"]["port"] == 9999
+
+    async def test_creating_a_script_connector_has_no_type_specific_fields(
+        self, tmp_path, work_dir
+    ):
+        """ScriptConnector never reads raw — the form should just show name/
+        description and an explanatory note, not crash on an empty field list."""
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_type_picker_for_connectors(pilot, app)
+            await pilot.press("down", "down", "down", "enter")  # script (4th option)
+            await pilot.pause()
+            assert isinstance(app.screen, ConnectorDetailScreen)
+
+            app.screen.query_one("#field-name", Input).value = "script-1"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            names = {c["name"]: c for c in raw["connectors"]}
+            assert names["script-1"]["type"] == "script"
+
+    async def test_creating_with_a_duplicate_name_shows_an_error_and_rolls_back(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_type_picker_for_connectors(pilot, app)
+            await pilot.press("enter")  # rocketchat
+            await pilot.pause()
+
+            app.screen.query_one("#field-name", Input).value = "rc-existing"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, ConnectorDetailScreen)
+            assert app.screen.mode == "create"
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert len(raw["connectors"]) == 1  # nothing was appended
+
+    async def test_creating_with_a_blank_name_shows_an_error(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_type_picker_for_connectors(pilot, app)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert isinstance(app.screen, ConnectorDetailScreen)
+            assert app.screen.mode == "create"
+
+    async def test_mattermost_auth_xor_violation_fails_save_and_rolls_back(
+        self, tmp_path, work_dir
+    ):
+        """Configuring BOTH token and username/password violates
+        MattermostConfig.__post_init__ — validate_config() (run by save())
+        is the real enforcement; the form doesn't reimplement it."""
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_type_picker_for_connectors(pilot, app)
+            await pilot.press("down", "enter")  # mattermost
+            await pilot.pause()
+
+            app.screen.query_one("#field-name", Input).value = "mm-bad"
+            app.screen.query_one("#field-server-url", Input).value = "http://mm.local"
+            app.screen.query_one("#field-server-team", Input).value = "team"
+            app.screen.query_one("#field-server-token", Input).value = "tok"
+            app.screen.query_one("#field-server-username", Input).value = "u"
+            app.screen.query_one("#field-server-password", Input).value = "p"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, ConnectorDetailScreen)
+            assert app.screen.mode == "create"
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert len(raw["connectors"]) == 1  # rolled back, nothing appended
+
+
+class TestEditConnector:
+    async def test_editing_an_unrelated_field_leaves_an_existing_secret_placeholder_untouched(
+        self, tmp_path, work_dir
+    ):
+        """THE keystone test for this screen (see module docstring)."""
+        os.environ["RC_PASSWORD_CONNECTOR_TEST"] = "the-real-secret-value"
+        try:
+            config_path = _write_config(
+                tmp_path,
+                _config_with_one_rocketchat_connector(
+                    work_dir, password="${RC_PASSWORD_CONNECTOR_TEST}"
+                ),
+            )
+            app = ConfigToolApp(config_path)
+            async with app.run_test() as pilot:
+                await pilot.pause()
+                await _open_connector_in_edit_mode(pilot, app)
+
+                pw_input = app.screen.query_one("#field-server-password", Input)
+                # The widget must show the literal placeholder, never the
+                # resolved secret and never a masked "****" at the data level
+                # (masking is display-only via Input(password=True); .value
+                # is always the real underlying string).
+                assert pw_input.value == "${RC_PASSWORD_CONNECTOR_TEST}"
+
+                app.screen.query_one("#field-server-username", Input).value = "renamed-bot"
+                await pilot.pause()
+                await pilot.press("ctrl+s")
+                await pilot.pause()
+
+                assert isinstance(app.screen, OverviewScreen)
+                raw = yaml.safe_load(Path(config_path).read_text())
+                connector = raw["connectors"][0]
+                assert connector["server"]["username"] == "renamed-bot"
+                assert connector["server"]["password"] == "${RC_PASSWORD_CONNECTOR_TEST}"
+        finally:
+            os.environ.pop("RC_PASSWORD_CONNECTOR_TEST", None)
+
+    async def test_editing_and_changing_the_secret_writes_the_new_plaintext_value(
+        self, tmp_path, work_dir
+    ):
+        """Documented v1 scope: there is no '.env toggle' yet (deferred — see
+        docs/design/config-tool.md) — typing a new secret directly writes it
+        to config.yaml in plaintext, exactly like the existing $EDITOR escape
+        hatch already allows. Not a regression, just not-yet-automated."""
+        config_path = _write_config(
+            tmp_path, _config_with_one_rocketchat_connector(work_dir, password="oldpw")
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-server-password", Input).value = "brand-new-secret"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "brand-new-secret"
+
+    async def test_name_and_type_are_not_editable_fields(self, tmp_path, work_dir):
+        """Renaming would silently orphan referencing watchers; changing type
+        would require reshaping the whole field list. Both immutable post-
+        creation in this UI (see module docstring) — $EDITOR remains for it."""
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            assert not app.screen.query("#field-name")
+            assert not app.screen.query("#field-type")
+
+    async def test_list_field_round_trips_owners(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-allowed_users-owners", Input).value = "alice, bob"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["allowed_users"]["owners"] == ["alice", "bob"]
+
+    async def test_untouched_fields_are_not_written_as_explicit(self, tmp_path, work_dir):
+        """Regression for decision 2: connector_defaults-inherited fields
+        must stay inherited if the form is opened and something ELSE is
+        changed — displaying a merged/effective value must not itself count
+        as "explicit"."""
+        config_path = _write_config(
+            tmp_path,
+            f"""\
+                connector_defaults:
+                  require_mention: false
+                agents:
+                  default:
+                    type: claude
+                    working_directory: {work_dir}
+                connectors:
+                  - name: rc-existing
+                    type: rocketchat
+                    server: {{url: "http://localhost:3000", username: bot, password: pw}}
+                watchers:
+                  - connector: rc-existing
+                    agent: default
+                    room: general
+            """,
+        )
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            require_mention = app.screen.query_one("#field-require_mention")
+            assert require_mention.value is False  # inherited from connector_defaults
+
+            app.screen.query_one("#field-timezone", Input).value = "America/Los_Angeles"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            connector = raw["connectors"][0]
+            assert connector["timezone"] == "America/Los_Angeles"
+            assert "require_mention" not in connector  # still inherited, not explicit
+
+
+class TestConnectorEscapeConfirmation:
+    async def test_escape_with_unsaved_changes_shows_confirm_modal(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-server-url", Input).value = "http://changed"
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+    async def test_create_mode_escape_with_unsaved_changes_discards_cleanly(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_type_picker_for_connectors(pilot, app)
+            await pilot.press("enter")
+            await pilot.pause()
+
+            app.screen.query_one("#field-name", Input).value = "abandoned"
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+            await pilot.press("tab", "enter")  # Discard
+            await pilot.pause()
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert len(raw["connectors"]) == 1  # nothing added

--- a/tests/unit/test_configtool_connector_crud.py
+++ b/tests/unit/test_configtool_connector_crud.py
@@ -391,3 +391,107 @@ class TestConnectorEscapeConfirmation:
             assert isinstance(app.screen, OverviewScreen)
             raw = yaml.safe_load(Path(config_path).read_text())
             assert len(raw["connectors"]) == 1  # nothing added
+
+
+def _config_with_two_connectors(work_dir: Path) -> str:
+    """'rc-referenced' is used by the watcher; 'rc-orphan' is not — used to
+    test both the delete-succeeds and delete-blocked paths."""
+    return f"""\
+        agents:
+          default:
+            type: claude
+            working_directory: {work_dir}
+        connectors:
+          - name: rc-referenced
+            type: rocketchat
+            server: {{url: "http://localhost:3000", username: bot, password: pw}}
+          - name: rc-orphan
+            type: rocketchat
+            server: {{url: "http://localhost:3001", username: bot2, password: pw2}}
+        watchers:
+          - connector: rc-referenced
+            agent: default
+            room: general
+    """
+
+
+async def _open_connector_in_view_mode(pilot, app, row: int = 0) -> None:
+    table = app.screen.query_one("#connectors-table", DataTable)
+    table.focus()
+    table.move_cursor(row=row)
+    await pilot.press("enter")
+    await pilot.pause()
+
+
+class TestDeleteConnector:
+    async def test_d_key_shows_confirm_modal(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_two_connectors(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_view_mode(pilot, app)
+
+            await pilot.press("d")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+    async def test_cancelling_the_delete_keeps_the_connector(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_two_connectors(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_view_mode(pilot, app, row=1)  # rc-orphan
+
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("enter")  # Cancel is focused by default
+            await pilot.pause()
+            assert isinstance(app.screen, ConnectorDetailScreen)
+            assert app.screen.mode == "view"
+            names = {c.get("name") for c in app.editable_config.connectors_raw}
+            assert "rc-orphan" in names
+
+    async def test_confirming_delete_of_an_unreferenced_connector_succeeds(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_two_connectors(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_view_mode(pilot, app, row=1)  # rc-orphan
+
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("tab", "enter")  # Delete
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            names = {c["name"] for c in raw["connectors"]}
+            assert "rc-orphan" not in names
+            assert "rc-referenced" in names
+            assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
+
+    async def test_deleting_a_referenced_connector_fails_and_rolls_back(
+        self, tmp_path, work_dir
+    ):
+        """A watcher still references 'rc-referenced' — save()'s
+        validate_config() must reject the deletion, and the connector must
+        be restored, not left removed-from-memory-but-not-saved."""
+        config_path = _write_config(tmp_path, _config_with_two_connectors(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_view_mode(pilot, app, row=0)  # rc-referenced
+
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("tab", "enter")  # Delete
+            await pilot.pause()
+
+            assert isinstance(app.screen, ConnectorDetailScreen)
+            assert app.screen.mode == "view"
+            names = {c.get("name") for c in app.editable_config.connectors_raw}
+            assert "rc-referenced" in names
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert any(c["name"] == "rc-referenced" for c in raw["connectors"])

--- a/tests/unit/test_configtool_connector_crud.py
+++ b/tests/unit/test_configtool_connector_crud.py
@@ -19,7 +19,7 @@ import yaml
 from textual.widgets import DataTable, Input
 
 from gateway.configtool.app import ConfigToolApp
-from gateway.configtool.modals import ConfirmModal, TypePickerModal
+from gateway.configtool.modals import ConfirmModal, MessageModal, TypePickerModal
 from gateway.configtool.screens.connector_detail import ConnectorDetailScreen
 from gateway.configtool.screens.overview import OverviewScreen
 
@@ -174,6 +174,10 @@ class TestCreateConnector:
             await pilot.press("ctrl+s")
             await pilot.pause()
 
+            assert isinstance(app.screen, MessageModal)
+            await pilot.press("enter")  # dismiss
+            await pilot.pause()
+
             assert isinstance(app.screen, ConnectorDetailScreen)
             assert app.screen.mode == "create"
             raw = yaml.safe_load(Path(config_path).read_text())
@@ -189,6 +193,9 @@ class TestCreateConnector:
             await pilot.pause()
 
             await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert isinstance(app.screen, MessageModal)
+            await pilot.press("enter")  # dismiss
             await pilot.pause()
             assert isinstance(app.screen, ConnectorDetailScreen)
             assert app.screen.mode == "create"
@@ -215,6 +222,10 @@ class TestCreateConnector:
             app.screen.query_one("#field-server-password", Input).value = "p"
             await pilot.pause()
             await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, MessageModal)
+            await pilot.press("enter")  # dismiss
             await pilot.pause()
 
             assert isinstance(app.screen, ConnectorDetailScreen)
@@ -424,12 +435,14 @@ async def _open_connector_in_view_mode(pilot, app, row: int = 0) -> None:
 
 
 class TestDeleteConnector:
-    async def test_d_key_shows_confirm_modal(self, tmp_path, work_dir):
+    async def test_d_key_on_an_unreferenced_connector_shows_confirm_modal(
+        self, tmp_path, work_dir
+    ):
         config_path = _write_config(tmp_path, _config_with_two_connectors(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
             await pilot.pause()
-            await _open_connector_in_view_mode(pilot, app)
+            await _open_connector_in_view_mode(pilot, app, row=1)  # rc-orphan
 
             await pilot.press("d")
             await pilot.pause()
@@ -472,12 +485,13 @@ class TestDeleteConnector:
             assert "rc-referenced" in names
             assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
 
-    async def test_deleting_a_referenced_connector_fails_and_rolls_back(
+    async def test_deleting_a_referenced_connector_is_blocked_before_the_confirm(
         self, tmp_path, work_dir
     ):
-        """A watcher still references 'rc-referenced' — save()'s
-        validate_config() must reject the deletion, and the connector must
-        be restored, not left removed-from-memory-but-not-saved."""
+        """A watcher still references 'rc-referenced' — the pre-delete check
+        catches this BEFORE even offering the destructive confirm, naming
+        the referencing watcher in a MessageModal rather than relying on
+        save()'s generic validator error."""
         config_path = _write_config(tmp_path, _config_with_two_connectors(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
@@ -486,7 +500,11 @@ class TestDeleteConnector:
 
             await pilot.press("d")
             await pilot.pause()
-            await pilot.press("tab", "enter")  # Delete
+
+            assert isinstance(app.screen, MessageModal)
+            body = str(app.screen.query_one("#message-body").render())
+            assert "rc-referenced" in body
+            await pilot.press("enter")  # dismiss
             await pilot.pause()
 
             assert isinstance(app.screen, ConnectorDetailScreen)

--- a/tests/unit/test_configtool_connector_crud.py
+++ b/tests/unit/test_configtool_connector_crud.py
@@ -365,6 +365,48 @@ class TestEditConnector:
             assert connector["timezone"] == "America/Los_Angeles"
             assert "require_mention" not in connector  # still inherited, not explicit
 
+    async def test_a_save_that_fails_validate_config_does_not_mutate_the_live_entry(
+        self, tmp_path, work_dir
+    ):
+        """Same bug class as AgentDetailScreen's equivalent test: edit mode
+        used to apply Save's updates directly to self.entry (the SAME dict
+        object already living in cfg.document), so a rejected save still
+        left the invalid data sitting in memory (and, if Back was pressed
+        without a further successful save, visibly shown). Clearing the
+        password field reverts it to inherited (empty, since no
+        connector_defaults sets it) — _check_connectors then rejects the
+        empty password, and BOTH the password clear AND the unrelated
+        username change made in the same edit session must roll back
+        together, atomically."""
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-server-password", Input).value = ""
+            app.screen.query_one("#field-server-username", Input).value = "changed-username"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, MessageModal)
+            body = str(app.screen.query_one("#message-body").render())
+            assert "password" in body
+            await pilot.press("enter")  # dismiss
+            await pilot.pause()
+
+            assert isinstance(app.screen, ConnectorDetailScreen)
+            assert app.screen.mode == "edit"
+
+            entry = app.editable_config.connectors_raw[0]
+            assert entry["server"]["password"] == "pw"  # original, untouched
+            assert entry["server"]["username"] == "bot"  # unrelated change also rolled back
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "pw"
+            assert raw["connectors"][0]["server"]["username"] == "bot"
+
 
 class TestConnectorEscapeConfirmation:
     async def test_escape_with_unsaved_changes_shows_confirm_modal(self, tmp_path, work_dir):

--- a/tests/unit/test_configtool_form_common.py
+++ b/tests/unit/test_configtool_form_common.py
@@ -1,0 +1,198 @@
+"""Unit tests for gateway/configtool/screens/form_common.py's standalone
+helpers — find_referencing_watcher_labels() specifically, since it's the
+basis for the pre-delete "still used by watcher(s): ..." check on both
+AgentDetailScreen and ConnectorDetailScreen.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+from gateway.configtool.model import EditableConfig
+from gateway.configtool.screens.form_common import find_referencing_watcher_labels
+
+
+class TestFindReferencingWatcherLabels(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.agent_dir = self.tmp / "work"
+        self.agent_dir.mkdir()
+
+    def _cfg(self, yaml_text: str) -> EditableConfig:
+        path = self.tmp / "config.yaml"
+        path.write_text(textwrap.dedent(yaml_text))
+        return EditableConfig.load(path)
+
+    def test_finds_a_watcher_by_explicit_connector(self):
+        cfg = self._cfg(f"""\
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            watchers:
+              - name: my-watcher
+                connector: rc
+                agent: default
+                room: general
+        """)
+        labels = find_referencing_watcher_labels(cfg, connector_name="rc")
+        self.assertEqual(labels, ["my-watcher"])
+
+    def test_finds_a_watcher_by_explicit_agent(self):
+        cfg = self._cfg(f"""\
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            watchers:
+              - name: my-watcher
+                connector: rc
+                agent: default
+                room: general
+        """)
+        labels = find_referencing_watcher_labels(cfg, agent_name="default")
+        self.assertEqual(labels, ["my-watcher"])
+
+    def test_returns_empty_when_nothing_references_the_name(self):
+        cfg = self._cfg(f"""\
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            watchers:
+              - name: my-watcher
+                connector: rc
+                agent: default
+                room: general
+        """)
+        self.assertEqual(find_referencing_watcher_labels(cfg, connector_name="unrelated"), [])
+        self.assertEqual(find_referencing_watcher_labels(cfg, agent_name="unrelated"), [])
+
+    def test_finds_a_watcher_that_only_inherits_its_connector_from_watcher_defaults(self):
+        """watcher_defaults may set connector/agent (unlike name/room/rooms/
+        session_id) — a watcher entry with no explicit 'connector:' still
+        counts as referencing it."""
+        cfg = self._cfg(f"""\
+            watcher_defaults:
+              connector: rc
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            watchers:
+              - name: my-watcher
+                agent: default
+                room: general
+        """)
+        labels = find_referencing_watcher_labels(cfg, connector_name="rc")
+        self.assertEqual(labels, ["my-watcher"])
+
+    def test_label_falls_back_to_room_when_the_watcher_has_no_name(self):
+        cfg = self._cfg(f"""\
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            watchers:
+              - connector: rc
+                agent: default
+                room: general
+        """)
+        labels = find_referencing_watcher_labels(cfg, connector_name="rc")
+        self.assertEqual(labels, ["general"])
+
+    def test_label_falls_back_to_joined_rooms_when_the_watcher_has_no_name(self):
+        cfg = self._cfg(f"""\
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            watchers:
+              - connector: rc
+                agent: default
+                rooms: [general, dev]
+        """)
+        labels = find_referencing_watcher_labels(cfg, connector_name="rc")
+        self.assertEqual(labels, ["general, dev"])
+
+    def test_multiple_referencing_watchers_are_all_returned(self):
+        cfg = self._cfg(f"""\
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            watchers:
+              - name: watcher-a
+                connector: rc
+                agent: default
+                room: general
+              - name: watcher-b
+                connector: rc
+                agent: default
+                room: dev
+        """)
+        labels = find_referencing_watcher_labels(cfg, connector_name="rc")
+        self.assertEqual(labels, ["watcher-a", "watcher-b"])
+
+    def test_both_connector_and_agent_filters_must_match(self):
+        cfg = self._cfg(f"""\
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+              other:
+                type: claude
+                working_directory: {self.agent_dir}
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            watchers:
+              - name: watcher-a
+                connector: rc
+                agent: other
+                room: general
+        """)
+        # connector matches but agent doesn't -> no match
+        self.assertEqual(
+            find_referencing_watcher_labels(cfg, connector_name="rc", agent_name="default"), []
+        )
+        self.assertEqual(
+            find_referencing_watcher_labels(cfg, connector_name="rc", agent_name="other"),
+            ["watcher-a"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/test_configtool_form_common.py
+++ b/tests/unit/test_configtool_form_common.py
@@ -106,7 +106,11 @@ class TestFindReferencingWatcherLabels(unittest.TestCase):
         labels = find_referencing_watcher_labels(cfg, connector_name="rc")
         self.assertEqual(labels, ["my-watcher"])
 
-    def test_label_falls_back_to_room_when_the_watcher_has_no_name(self):
+    def test_label_uses_the_real_auto_generated_name_when_the_watcher_has_no_name(self):
+        """The real name an unnamed watcher gets everywhere else in the TUI
+        (e.g. the Overview's Watchers tab) is `_auto_watcher_name()`'s
+        "<connector>-<room>" (gateway/config.py) — NOT the bare room string.
+        A user-reported mismatch here was the actual bug this test pins."""
         cfg = self._cfg(f"""\
             agents:
               default:
@@ -122,9 +126,11 @@ class TestFindReferencingWatcherLabels(unittest.TestCase):
                 room: general
         """)
         labels = find_referencing_watcher_labels(cfg, connector_name="rc")
-        self.assertEqual(labels, ["general"])
+        self.assertEqual(labels, ["rc-general"])
 
-    def test_label_falls_back_to_joined_rooms_when_the_watcher_has_no_name(self):
+    def test_a_rooms_group_produces_one_label_per_real_expanded_watcher(self):
+        """A `rooms: [a, b]` entry is 2 SEPARATE real watchers (rc-general,
+        rc-dev), not one joined "general, dev" string."""
         cfg = self._cfg(f"""\
             agents:
               default:
@@ -140,7 +146,27 @@ class TestFindReferencingWatcherLabels(unittest.TestCase):
                 rooms: [general, dev]
         """)
         labels = find_referencing_watcher_labels(cfg, connector_name="rc")
-        self.assertEqual(labels, ["general, dev"])
+        self.assertEqual(labels, ["rc-general", "rc-dev"])
+
+    def test_returns_empty_when_the_config_does_not_currently_load(self):
+        """A delete pre-check has nothing useful to say if the config is
+        already broken for some unrelated reason — save()'s own validation
+        remains the backstop for that; this must not raise."""
+        cfg = self._cfg(f"""\
+            agents:
+              default:
+                type: claude
+                working_directory: {self.agent_dir}
+            connectors:
+              - name: rc
+                type: rocketchat
+                server: {{url: http://localhost:3000, username: bot, password: pw}}
+            watchers:
+              - connector: rc
+                agent: nonexistent-agent
+                room: general
+        """)
+        self.assertEqual(find_referencing_watcher_labels(cfg, connector_name="rc"), [])
 
     def test_multiple_referencing_watchers_are_all_returned(self):
         cfg = self._cfg(f"""\


### PR DESCRIPTION
## Summary
`ConnectorDetailScreen` gains edit/create modes, reachable via `n` on the Connectors tab, through the connector-type variant of `TypePickerModal` (rocketchat/mattermost/voice/script — same generic class the agent picker already uses).

**Refactor:** extracted `gateway/configtool/screens/form_common.py` (`FormScreen` + field-diff helpers) out of `AgentDetailScreen` now that Connector is a second concrete user of the same edit/create machinery. `AgentDetailScreen` moved onto it with **no behavior change** — its full 25-test suite passes unmodified.

**Deliberate scope cut, decided before writing form code:** per-type FIXED field lists instead of the generic nested tree editor the design doc originally called for. Verified first that every real connector type's raw shape is exactly one level deep — exactly what the dotted-key machinery already proven correct for agent's `permissions.*` handles. The tree editor would only earn its complexity for arbitrary/unknown keys, and `$EDITOR` already covers that case — deferred pending evidence it's actually needed, not abandoned.

`type`/`name` are immutable in edit mode (chosen only at creation): letting `type` change in place would mean the form reshaping itself around one of its own fields (rocketchat/mattermost have materially different shapes), and renaming would silently orphan any watcher referencing the old name. Mattermost's token-XOR-username/password constraint gets a plain informational line, not an interactive RadioSet — `save()`'s `validate_config()` is the actual enforcement regardless.

**Deferred, tracked as its own follow-up (task created):** the `.env` "store in .env" toggle itself. Typing a plaintext secret and saving writes it in plaintext today, same as the existing `$EDITOR` escape hatch already allows — not a regression.

**The keystone test** (same weight as `EditableConfig.save()`'s `$VAR` round-trip): opening a connector whose `server.password` is `"${SOME_VAR}"`, editing a different field, and saving leaves the password field's raw value exactly `"${SOME_VAR}"` — never resolved, never masked at the data level.

**Fixed from real-terminal testing:** entity forms needed Tab pressed twice to reach the first field (the form's `VerticalScroll` container was itself focusable and first in the Tab cycle) — fixed with `can_focus=False` on the container. Also fixed create mode's auto-focus landing on the container instead of the Name field.

**Added after review — a real gap, not a deferred plan:** Delete for both agents and connectors (`d` from view mode). I'd been calling create+edit "CRUD" loosely; checked the design doc and confirmed Delete was never actually specified for either entity. `ConfirmModal` → remove from `document` → `save()`. Same "let save() be the backstop" philosophy as the rest of this screen: deleting an entity still referenced by a watcher fails `save()`'s validation with a clear error and the entry is reinserted — no reference-counting reimplemented.

## Test plan
- [x] `uv run ruff check gateway/ tests/` — all checks passed
- [x] `uv run pytest tests/unit tests/integration -q` — 1941 passed
- [x] Real-terminal QA done by the user during review — found the double-Tab issue and the "is delete part of CRUD?" gap, both now fixed/added in this PR