### PR TITLE
Config TUI: wire the .env secret-storage toggle into connector fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ htmlcov/
 *.log
 .env
 config.yaml
+.config-backups/
 .DS_Store
 example-agents/**/node_modules/
 .claude

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -148,9 +148,14 @@ per-row status lookups.
    `context_inject_files` resolve relative to `config_dir`), runs the
    unchanged `validate_config(tmp)`, blocks save on errors (raises
    `ValueError`, temp file deleted, real file untouched); on success:
-   timestamped backup (`config.yaml.bak.<unix-ts>`, `shutil.copy2`, matching
-   `onboard.py`'s convention) then `os.replace()` (atomic on POSIX) — the
-   daemon never observes a partially-written config.yaml. `dirty`/
+   timestamped backup under `<config_dir>/.config-backups/`
+   (`config.yaml.bak.<unix-ts>`, `shutil.copy2`, matching `onboard.py`'s own
+   backup step, which writes to the same directory) then `os.replace()`
+   (atomic on POSIX) — the daemon never observes a partially-written
+   config.yaml. Both `config.yaml` and every backup are `chmod`'d `0600`
+   (the backup directory `0700`) on every save — see decision 6's
+   discussion below for why this matters as much for `config.yaml` as for
+   `.env`. `dirty`/
    `mark_dirty()` also shipped alongside it; `ConfigToolApp.action_quit()`
    gates on `dirty` via a new `ConfirmModal` (Textual `@work`-decorated,
    since `push_screen_wait()` requires a worker context) — no edit screen
@@ -386,6 +391,99 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
   initial snapshot and its unedited value-at-save are both the same literal
   placeholder string) — no special-casing needed, confirmed by a dedicated
   test rather than assumed.
+- **User pushed back on the whole feature: is `.env` worth it, versus just
+  relying on `config.yaml`'s own file permissions?** Investigated rather
+  than assumed. Findings that settled it: `.env` was the ONLY thing in this
+  codebase getting deliberate secret hardening (`onboard.py` `chmod 0600`)
+  — `config.yaml` itself was never chmod'd anywhere, and worse,
+  `EditableConfig.save()` writes `config.yaml.tmp` via plain `open(...,
+  "w")` (process umask, not whatever the real file's permissions were) and
+  atomically replaces the real file with it — so even a MANUAL `chmod 600
+  config.yaml` would silently revert to the umask default (typically 644)
+  on the very next TUI save. Separately, every save's `config.yaml.bak.
+  <unix-ts>` backup (and `onboard.py`'s own backup step) sat right next to
+  the real files, matched by neither `.gitignore` entry (`config.yaml`/
+  `.env` are exact-filename matches, not globs) nor any chmod — meaning a
+  password that was EVER in plaintext, even briefly before being migrated
+  into `.env`, lived on forever in an unprotected, git-visible-if-not-for-
+  luck snapshot. Conclusion: "just use config.yaml permissions instead"
+  wasn't actually a real alternative as things stood — nothing enforced
+  config.yaml's permissions at all, and doing so properly (chmod every
+  save, chmod every backup, fix `.gitignore`) is comparable effort to
+  fixing `.env`'s rough edges, with the downside of losing the "config.yaml
+  is structurally safe to share/back up, `.env` is the only sensitive file"
+  separation. **Decision: keep `.env`, harden both.** Shipped as part of
+  the same round:
+  - `EditableConfig.save()` now writes every backup under
+    `<config_dir>/.config-backups/` (created `chmod 0700`; each backup file
+    `chmod 0600`) instead of scattered flat `.bak.<ts>` files beside
+    `config.yaml`, and `chmod`s `config.yaml` itself to `0600` after every
+    successful save — closing the "manual chmod gets silently undone" gap.
+    `onboard.py`'s own backup step (the "start fresh" wizard path) and its
+    initial `config.yaml` write were aligned to the same directory/chmod
+    convention, so there's one backup location and one permission
+    convention, not two. `.gitignore` gained `.config-backups/`.
+  - **Two more toggle bugs, both from the same root cause — the checkbox
+    was hardcoded `value=True` unconditionally, never reflecting the
+    field's actual current state:**
+    1. *Reopening after an explicit uncheck-and-save-as-plaintext showed
+       the checkbox checked again.* Fixed: the checkbox's initial value
+       now reflects reality — checked iff the field's own raw value
+       already looks like a `$VAR`/`${VAR}` reference, unchecked otherwise
+       (create mode still defaults checked — there's no current state to
+       reflect yet, and it nudges new secrets toward `.env`). Direct
+       consequence: leaving the toggle at ITS default no longer silently
+       migrates an untouched plaintext secret just because some unrelated
+       field changed (the "migrate without retyping" fix from the previous
+       round) — migrating now requires explicitly CHECKING a box that
+       accurately started unchecked, which is a deliberate action instead
+       of an implicit side effect of saving anything else. Still zero
+       retyping required either way.
+    2. *A field already pointing at `.env` only ever showed the literal
+       `"${VAR}"` placeholder — no way to see or sanely change the actual
+       password.* `FormScreen._resolve_secret_display()` resolves a
+       `$VAR`/`${VAR}` field's value against `.env` FOR DISPLAY ONLY (reads
+       `env_writer.read_env_vars()` directly — never `GatewayConfig.
+       from_file`/`load_dotenv`/`os.environ` — so the keystone above still
+       holds: `self.entry`/`document` never see a resolved value). Both
+       `_compute_initial_values()` (the diff baseline) and the widget's
+       starting value go through this, so an untouched field still diffs
+       as "unchanged" — nothing gets written anywhere — and typing a new
+       value over the resolved display diffs as a genuine change, exactly
+       like any other field; this is the actual fix for "how do you expect
+       the user to change the password." Falls back to the literal
+       placeholder (with a `(not found in .env — type a new value to set
+       one)` hint) when the var isn't resolvable — e.g. sourced from the
+       shell environment rather than a `.env` file — never silently
+       blanking a field that has a real value. `action_reset_field()`
+       (ctrl+r) goes through the same resolver for consistency.
+       **Bug caught while writing this fix's own test:** rotating an
+       already-`.env`-backed secret (typing a new value over the resolved
+       display, toggle left at its now-correctly-checked default) was
+       recomputing a FRESH deterministic var name
+       (`env_var_name_for()`) instead of reusing whatever var name the
+       field was ALREADY pointing at — harmless for a field the tool
+       itself had migrated (deterministic name matches by construction),
+       but for a field hand-set to a non-conventional name via the
+       `$EDITOR` escape hatch, rotation would have silently spawned a
+       SECOND, differently-named `.env` entry and orphaned the original
+       with the stale old password still in it. Fixed:
+       `ConnectorDetailScreen.action_save()` now reuses the var name
+       extracted from the field's own current raw value when it's already
+       a reference, and only falls back to generating a fresh deterministic
+       name for a genuine plaintext-to-`.env` migration — the collision
+       guard is unaffected (it's only ever load-bearing on that
+       fresh-generation path; reusing an owned name can never collide with
+       itself by construction).
+  - **Known, accepted, out-of-scope-for-now gap:** unchecking the toggle on
+    an already-`.env`-backed field WITHOUT changing the value does nothing
+    — the diff sees "unchanged" (the resolved display looks the same
+    either way) and nothing gets written, so the field stays `.env`-backed.
+    "Un-migrate this secret back to plaintext without rotating it" is a
+    real but different feature from anything the user actually asked for
+    this round (which was: see/change the value, and stop the checkbox
+    lying about the field's actual state) — not built, to avoid scope
+    creep past what was requested.
 
 - **Shipped (added after initial Phase 2 review — user caught that "CRUD"
   was being used loosely and Delete had never actually been designed for

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -321,8 +321,8 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
 - **Shipped: the `.env` "store in .env" toggle.** A "Store in .env"
   `Checkbox` (default ON) next to every `secret=True` field
   (`FieldSpec.secret` already existed for masking; now also drives this).
-  On Save, for each secret field that ACTUALLY changed to a genuine new
-  plaintext value (a value already matching `$VAR`/`${VAR}` — checked via
+  On Save, for each secret field whose CURRENT value is a genuine plaintext
+  value (a value already matching `$VAR`/`${VAR}` — checked via
   `looks_like_env_var_reference()` — is left alone, since the user is
   explicitly referencing an externally-managed var, not typing a new
   secret) with the toggle checked: `env_var_name_for()` generates a
@@ -338,10 +338,45 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
   still fails for some OTHER, unrelated reason afterward, the value already
   written to `.env` is left there, unreferenced by anything — harmless,
   equivalent to a user having pre-populated `.env` with a value not wired
-  up yet; not worth building a transactional rollback for. Also accepted,
-  documented, not handled: the generated var name could collide with an
-  unrelated existing `.env` key — rare, not worth a collision-detection UI
-  for v1.
+  up yet; not worth building a transactional rollback for.
+- **Three user-reported follow-ups on the toggle, all fixed:**
+  1. *Not gated on "did this session's edit change the field."* The
+     original implementation only converted a secret to `.env` if
+     `spec.key in updates` — meaning a plaintext secret saved earlier with
+     the toggle unchecked could never be migrated later without literally
+     retyping the same password (which the user correctly flagged as a
+     dead end). Now every secret field's CURRENT value is checked
+     regardless of whether it changed THIS session — leaving the toggle at
+     its default (checked) and saving, even while editing a totally
+     unrelated field, migrates an already-plaintext secret into `.env`.
+     Already-a-`${VAR}` values are still skipped either way, so this
+     doesn't cause repeated/redundant `.env` writes on every subsequent save.
+  2. *Deleting a connector left its `.env` secret orphaned.* Fixed via a
+     new `FormScreen._on_deleted_successfully()` hook, fired after the
+     document save succeeds — `ConnectorDetailScreen`'s override removes
+     any `.env` key matching the deleted connector's exact deterministic
+     name, but ONLY where the raw entry's value was EXACTLY that
+     placeholder (never a heuristic "looks like it belongs to this
+     connector" guess).
+  3. *Var name collisions were an accepted, silent risk — user pushed
+     back, correctly.* What shipped instead: `read_env_vars()` checks
+     whether the generated name already exists in `.env` before writing;
+     if it does AND this connector doesn't already own it (its pre-save
+     value for that field wasn't already this exact placeholder — a plain
+     re-save isn't a collision), the save is BLOCKED with a clear message
+     naming the conflicting key, rather than silently overwriting an
+     unrelated secret. `env_writer.py` gained `read_env_vars()` (parse
+     `.env` into a dict) and `remove_env_vars()` (drop specific keys,
+     same merge-preserving-everything-else behavior as `upsert_env_vars()`)
+     to support both fixes.
+- **Shipped (nice-to-have, user-requested): `ctrl+t` reveals/re-masks the
+  FOCUSED secret field** (`Input.password` is a reactive — display-only,
+  never affects `.value`, so this has zero interaction with the diff/save
+  logic). **Gotcha:** the natural first choice, `ctrl+p`, is Textual's own
+  `App.COMMAND_PALETTE_BINDING` — a priority binding that silently
+  intercepts the keypress before it ever reaches a screen-level binding
+  for the same key. Caught by a failing test, not shipped wrong; moved to
+  `ctrl+t`.
 - **Verified (the actual keystone test for this screen, same weight as
   `EditableConfig.save()`'s $VAR round-trip):** opening an existing
   connector whose `server.password` is `"${SOME_VAR}"`, editing an

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -512,6 +512,27 @@ split-out insertion position).
   container — it isn't meant to be independently focused; scrolling still
   works via the mouse wheel/PageUp/PageDown. Worth checking for on any
   future container that wraps a form's fields.
+- **`Input`'s own `DEFAULT_CSS` is `width: 100%` — inside a `Horizontal`
+  field-row, that claims the ENTIRE row, pushing every sibling that comes
+  after it off past the terminal's right edge.** User-reported: the new
+  "Store in .env" `Checkbox` (task #27) was completely invisible. Confirmed
+  via `widget.region` (NOT just `query_one()` succeeding — Pilot's query
+  finds a widget regardless of where it's actually rendered, which is
+  exactly why this shipped unnoticed): the checkbox's region started at
+  `x=146` in a 120-column terminal, fully off-screen. The SAME root cause
+  had already been silently hiding every field's provenance marker (the
+  "(explicit)"/"(inherited from defaults)" label) on both `AgentDetailScreen`
+  and `ConnectorDetailScreen` since Phase 2's agent form first shipped — a
+  dim decorative label going unnoticed off-screen is a lot less obvious
+  than a missing interactive control, which is probably why it took the
+  checkbox to surface it. `Select`'s own `DEFAULT_CSS` already uses `width:
+  1fr` and never had this problem — fixed by adding
+  `FormScreen .field-row Input { width: 1fr; }`, so the Input shares the
+  row's remaining space with its fixed/auto-width siblings instead of
+  claiming all of it. **Any future field-row widget added after an Input
+  needs a `.region`-based test, not just a `query_one()` existence check —
+  that's the only way this class of bug gets caught before a user reports
+  it.**
 - **`push_screen_wait()` needs a `@work`-decorated caller**, same gotcha as
   `ConfigToolApp.action_quit()` — `AgentDetailScreen.action_back()` awaits a
   `ConfirmModal` result for its own discard-vs-keep-editing decision, so it's

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -5,9 +5,9 @@ escape hatch). **Phase 2 in progress:** items 7–10 from the Phase 1 code
 review cleared; `EditableConfig.save()`/dirty-tracking/`ConfirmModal`
 foundation shipped; agent create/edit shipped; connector create/edit shipped
 (per-type field lists — the generic tree editor originally planned is
-deferred, see Part 3); the `.env` writer is shipped but not yet wired to a
-UI toggle. The tool-list/preset editor is not yet built. Phase 3 is
-designed below but not yet started. The
+deferred, see Part 3); delete shipped for both agents and connectors; the
+`.env` "store in .env" toggle shipped. The tool-list/preset editor is not
+yet built. Phase 3 is designed below but not yet started. The
 v0.2 format simplification (`connector_defaults`/`agent_defaults`/
 `watcher_defaults`, `tool_presets`, watcher `rooms:`) plus `acg config
 validate` and the JSON Schema (see `docs/migration-0.2.md`) are prerequisites
@@ -318,15 +318,30 @@ Phase 2 first cleared the Phase 1 code review's deferred items 7–10
   `MattermostConfig.__post_init__`) is the actual enforcement either way,
   so the simpler static hint was chosen over building a stateful widget for
   guidance alone.
-- **Deferred, not built:** the `.env` "store in .env" toggle itself. Typing
-  a plaintext secret directly into a masked field (`Input(password=True)` —
-  display-only masking; `.value` is always the real string, same as every
-  other field) and saving writes it to config.yaml in plaintext today,
-  exactly like the existing `$EDITOR` escape hatch already allows — not a
-  regression, just not yet automated. The writer (`upsert_env_vars`) and the
-  masked-secret Input widgets are both in place; wiring a toggle to
-  auto-generate an env var name, call the writer, and rewrite the entry's
-  field to a `${VAR}` placeholder is a self-contained follow-up.
+- **Shipped: the `.env` "store in .env" toggle.** A "Store in .env"
+  `Checkbox` (default ON) next to every `secret=True` field
+  (`FieldSpec.secret` already existed for masking; now also drives this).
+  On Save, for each secret field that ACTUALLY changed to a genuine new
+  plaintext value (a value already matching `$VAR`/`${VAR}` — checked via
+  `looks_like_env_var_reference()` — is left alone, since the user is
+  explicitly referencing an externally-managed var, not typing a new
+  secret) with the toggle checked: `env_var_name_for()` generates a
+  deterministic name (`"<ENTITY>_<FIELD>"`, e.g. `RC_HOME_PASSWORD`),
+  `upsert_env_vars()` writes it to `.env`, and the entry's field becomes
+  `"${VAR}"`. **Ordering subtlety that cost a wrong-first-attempt:** the
+  `.env` write must happen BEFORE `cfg.save()`, not after — `save()`'s own
+  `validate_config()` calls `GatewayConfig.from_file`, which resolves every
+  `${VAR}` placeholder immediately (`load_dotenv(path.parent / ".env")` +
+  `os.path.expandvars`); if the var isn't in `.env` yet, `save()` itself
+  fails with "unresolved environment variable" before config.yaml is ever
+  written. Accepted trade-off from writing `.env` first: if `cfg.save()`
+  still fails for some OTHER, unrelated reason afterward, the value already
+  written to `.env` is left there, unreferenced by anything — harmless,
+  equivalent to a user having pre-populated `.env` with a value not wired
+  up yet; not worth building a transactional rollback for. Also accepted,
+  documented, not handled: the generated var name could collide with an
+  unrelated existing `.env` key — rare, not worth a collision-detection UI
+  for v1.
 - **Verified (the actual keystone test for this screen, same weight as
   `EditableConfig.save()`'s $VAR round-trip):** opening an existing
   connector whose `server.password` is `"${SOME_VAR}"`, editing an

--- a/gateway/configtool/env_writer.py
+++ b/gateway/configtool/env_writer.py
@@ -52,3 +52,50 @@ def upsert_env_vars(env_path: Path, updates: dict[str, str]) -> None:
     env_path.parent.mkdir(parents=True, exist_ok=True)
     env_path.write_text(("\n".join(lines) + "\n") if lines else "")
     env_path.chmod(0o600)
+
+
+def _unquote(value: str) -> str:
+    if len(value) >= 2 and value[0] == value[-1] == '"':
+        return value[1:-1]
+    return value
+
+
+def read_env_vars(env_path: Path) -> dict[str, str]:
+    """Read the current `KEY=value` pairs from `.env` at `env_path` (empty
+    dict if it doesn't exist). Used to check whether a key already exists —
+    and with what value — before `upsert_env_vars()` would silently
+    overwrite it (see `ConnectorDetailScreen.action_save()`'s pre-write
+    collision check)."""
+    if not env_path.exists():
+        return {}
+    result: dict[str, str] = {}
+    for raw_line in env_path.read_text().splitlines():
+        stripped = raw_line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        result[key.strip()] = _unquote(value.strip())
+    return result
+
+
+def remove_env_vars(env_path: Path, keys: set[str]) -> None:
+    """Remove any `KEY=...` line whose key is in `keys` from `.env` at
+    `env_path`. A no-op if the file doesn't exist or none of `keys` are
+    present. Every other line — comments, blank lines, unrelated keys — is
+    preserved exactly as-is, in its original position. Restricts the file
+    to 0600 after writing, same as `upsert_env_vars()`."""
+    if not env_path.exists():
+        return
+    lines: list[str] = []
+    changed = False
+    for raw_line in env_path.read_text().splitlines():
+        stripped = raw_line.strip()
+        key = stripped.split("=", 1)[0].strip() if "=" in stripped else ""
+        if key and not stripped.startswith("#") and key in keys:
+            changed = True
+            continue
+        lines.append(raw_line)
+    if not changed:
+        return
+    env_path.write_text(("\n".join(lines) + "\n") if lines else "")
+    env_path.chmod(0o600)

--- a/gateway/configtool/model.py
+++ b/gateway/configtool/model.py
@@ -146,11 +146,30 @@ class EditableConfig:
         2. Run the real `validate_config()` against that temp file. If it
            doesn't validate, delete the temp file and raise ValueError with
            the errors — the real config on disk is never touched.
-        3. Only on success: copy the real file to a timestamped backup
-           (`config.yaml.bak.<unix-ts>`, matching gateway/onboard.py's
-           existing convention) and atomically replace it with the temp
-           file (`os.replace` — atomic on POSIX, so a reader/the daemon
-           never observes a partially-written config.yaml).
+        3. Only on success: copy the real file to a timestamped backup under
+           `<config_dir>/.config-backups/` (`config.yaml.bak.<unix-ts>`,
+           matching gateway/onboard.py's own backup step, which writes to
+           the same directory) and atomically replace it with the temp file
+           (`os.replace` — atomic on POSIX, so a reader/the daemon never
+           observes a partially-written config.yaml).
+
+        `config.yaml` and every backup snapshot can hold a plaintext secret
+        — either a field saved with "Store in .env" unchecked, or a secret
+        that was migrated into `.env` LATER but still appears in plaintext
+        in a backup taken before that migration. Both `config.yaml` itself
+        and each backup file are chmod'd 0600 here (matching the treatment
+        `.env`/`env_writer.py` already give the `.env` file) — `config.yaml`
+        specifically needs this on EVERY save because writing `tmp_path` via
+        plain `open(..., "w")` takes the process umask, not whatever
+        permissions the real file had before; without this line, a manual
+        `chmod 600 config.yaml` would silently revert to the umask default
+        the very next time this method runs. The backup directory itself is
+        chmod'd 0700 for the same reason a bare `.gitignore` entry on
+        `config.yaml.bak.*` isn't enough by itself: it also keeps the whole
+        deployment's history of past secrets out of a directory readers
+        might casually `ls`/glob/back up without expecting a pile of
+        `config.yaml.bak.*` files that will keep growing on every future
+        save either.
 
         Raises FileNotFoundError if `path` doesn't exist yet (nothing to
         back up) — Phase 2/3 forms only ever call save() on an already-loaded
@@ -174,9 +193,14 @@ class EditableConfig:
                     "valid config:\n" + "\n".join(result.errors)
                 )
 
-            backup_path = self.path.with_name(f"{self.path.name}.bak.{int(time.time())}")
+            backup_dir = self.path.parent / ".config-backups"
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            backup_dir.chmod(0o700)
+            backup_path = backup_dir / f"{self.path.name}.bak.{int(time.time())}"
             shutil.copy2(self.path, backup_path)
+            backup_path.chmod(0o600)
             os.replace(tmp_path, self.path)
+            self.path.chmod(0o600)
         finally:
             # Only ever removes OUR OWN temp file, not the real config: if
             # os.replace() above succeeded, tmp_path no longer exists at this

--- a/gateway/configtool/screens/connector_detail.py
+++ b/gateway/configtool/screens/connector_detail.py
@@ -31,12 +31,21 @@ from typing import Literal
 from textual import work
 from textual.app import ComposeResult
 from textual.containers import Horizontal, VerticalScroll
-from textual.widgets import Input, Static
+from textual.widgets import Checkbox, Input, Static
 
+from ..env_writer import upsert_env_vars
 from ..formatting import mask_if_secret, provenance_label
 from ..modals import MessageModal
 from ..model import EditableConfig
-from .form_common import FieldSpec, FormScreen, apply_update, find_referencing_watcher_labels
+from .form_common import (
+    FieldSpec,
+    FormScreen,
+    apply_update,
+    env_toggle_widget_id,
+    env_var_name_for,
+    find_referencing_watcher_labels,
+    looks_like_env_var_reference,
+)
 
 CONNECTOR_TYPES = ("rocketchat", "mattermost", "voice", "script")
 
@@ -281,6 +290,46 @@ class ConnectorDetailScreen(FormScreen):
                     MessageModal(
                         f"A connector named '{name}' already exists.", title="Could not save"
                     )
+                )
+                return
+
+        # Secret fields with "Store in .env" checked: if the field's value
+        # actually changed to a genuine new plaintext secret (not already a
+        # $VAR/${VAR} reference the user typed directly), swap it for a
+        # ${VAR} placeholder in `updates`.
+        env_writes: dict[str, str] = {}
+        entity_name_for_env = name if self.mode == "create" else self.entry.get("name", "?")
+        for spec in self._field_specs():
+            if not spec.secret or spec.key not in updates:
+                continue
+            new_value = updates[spec.key]
+            if not new_value or looks_like_env_var_reference(new_value):
+                continue
+            toggle = self.query_one(f"#{env_toggle_widget_id(spec.key)}", Checkbox)
+            if not toggle.value:
+                continue
+            var_name = env_var_name_for(entity_name_for_env, spec.key)
+            env_writes[var_name] = new_value
+            updates[spec.key] = f"${{{var_name}}}"
+
+        if env_writes:
+            # MUST happen BEFORE cfg.save(), not after: save()'s own
+            # validate_config() calls GatewayConfig.from_file, which
+            # resolves every ${VAR} placeholder immediately via
+            # load_dotenv(path.parent / ".env") + os.path.expandvars — if
+            # the var isn't in .env yet, save() itself fails with
+            # "unresolved environment variable" before config.yaml is ever
+            # written. Accepted trade-off: if cfg.save() still fails for
+            # some OTHER, unrelated reason after this, the value written
+            # here is left in .env, unreferenced by anything — harmless,
+            # equivalent to a user having pre-populated .env with a value
+            # not wired up yet. Nothing else has been touched yet at this
+            # point, so a failure here is a clean, early return.
+            try:
+                upsert_env_vars(self.cfg.path.parent / ".env", env_writes)
+            except OSError as exc:
+                await self.app.push_screen_wait(
+                    MessageModal(f"Could not write to .env: {exc}", title="Could not save")
                 )
                 return
 

--- a/gateway/configtool/screens/connector_detail.py
+++ b/gateway/configtool/screens/connector_detail.py
@@ -341,14 +341,33 @@ class ConnectorDetailScreen(FormScreen):
             toggle = self.query_one(f"#{env_toggle_widget_id(spec.key)}", Checkbox)
             if not toggle.value:
                 continue
-            var_name = env_var_name_for(entity_name_for_env, spec.key)
+
+            # Reuse the var name this field is ALREADY referencing (e.g. a
+            # rotation: the widget shows the resolved secret — see
+            # FormScreen._resolve_secret_display() — and the user typed a
+            # NEW value over it) rather than always generating the
+            # deterministic name. Otherwise a field whose current var name
+            # doesn't happen to match the deterministic convention (most
+            # commonly: hand-edited via the $EDITOR escape hatch before
+            # ever touching this toggle) would get a SECOND, differently-
+            # named .env entry on rotation, orphaning the original with the
+            # stale old value still sitting in it. Only a genuine
+            # plaintext-to-.env migration (original_value isn't a
+            # reference at all) generates a fresh deterministic name.
+            original_value = get_nested(self.entry, spec.key)
+            if isinstance(original_value, str) and looks_like_env_var_reference(original_value):
+                var_name = original_value.strip("${}")
+            else:
+                var_name = env_var_name_for(entity_name_for_env, spec.key)
 
             # Collision guard: refuse rather than silently overwrite an
             # unrelated existing .env entry that happens to share the
             # generated name. Not a collision if this connector already
             # owns the name (its pre-save value for this field was already
-            # this exact placeholder — a re-save, not a conflict).
-            original_value = get_nested(self.entry, spec.key)
+            # this exact placeholder — a re-save/rotation, not a conflict) —
+            # always true when var_name was just reused from original_value
+            # above, so this guard is only ever load-bearing for the fresh-
+            # generation branch.
             existing_env = read_env_vars(env_path)
             if var_name in existing_env and original_value != f"${{{var_name}}}":
                 await self.app.push_screen_wait(

--- a/gateway/configtool/screens/connector_detail.py
+++ b/gateway/configtool/screens/connector_detail.py
@@ -33,7 +33,7 @@ from textual.app import ComposeResult
 from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Checkbox, Input, Static
 
-from ..env_writer import upsert_env_vars
+from ..env_writer import read_env_vars, remove_env_vars, upsert_env_vars
 from ..formatting import mask_if_secret, provenance_label
 from ..modals import MessageModal
 from ..model import EditableConfig
@@ -44,7 +44,10 @@ from .form_common import (
     env_toggle_widget_id,
     env_var_name_for,
     find_referencing_watcher_labels,
+    get_nested,
     looks_like_env_var_reference,
+    read_widget_value,
+    widget_id,
 )
 
 CONNECTOR_TYPES = ("rocketchat", "mattermost", "voice", "script")
@@ -161,6 +164,29 @@ class ConnectorDetailScreen(FormScreen):
 
     def _referencing_watcher_labels(self) -> list[str]:
         return find_referencing_watcher_labels(self.cfg, connector_name=self._entity_label())
+
+    def _on_deleted_successfully(self) -> None:
+        """User-reported: deleting a connector left its .env secret(s)
+        behind, orphaned. Removes any .env key this connector owned — ONLY
+        keys matching the exact deterministic naming convention
+        (env_var_name_for), and only where the raw entry's field value was
+        EXACTLY that placeholder (never a heuristic guess at what "belongs"
+        to this connector) — self.entry still holds its last content here;
+        _remove_entry_from_document() only detached it from
+        cfg.document's list, it didn't clear the dict itself."""
+        entity_name = self.entry.get("name", "?")
+        keys_to_remove = set()
+        for spec in self._field_specs():
+            if not spec.secret:
+                continue
+            value = get_nested(self.entry, spec.key)
+            if not isinstance(value, str):
+                continue
+            var_name = env_var_name_for(entity_name, spec.key)
+            if value == f"${{{var_name}}}":
+                keys_to_remove.add(var_name)
+        if keys_to_remove:
+            remove_env_vars(self.cfg.path.parent / ".env", keys_to_remove)
 
     def _on_enter_edit_mode(self) -> None:
         self._compute_initial_values(self.entry)
@@ -293,23 +319,51 @@ class ConnectorDetailScreen(FormScreen):
                 )
                 return
 
-        # Secret fields with "Store in .env" checked: if the field's value
-        # actually changed to a genuine new plaintext secret (not already a
-        # $VAR/${VAR} reference the user typed directly), swap it for a
-        # ${VAR} placeholder in `updates`.
+        # Secret fields with "Store in .env" checked: convert the field's
+        # CURRENT value — not just a value that changed THIS session — to a
+        # ${VAR} placeholder, as long as it's a genuine plaintext secret
+        # (not already a $VAR/${VAR} reference, left alone either way).
+        # Deliberately not gated on `spec.key in updates`: leaving the
+        # toggle checked (its default) and saving is how an ALREADY-
+        # plaintext field (e.g. one saved earlier with the toggle
+        # unchecked) gets migrated into .env — user-reported that there was
+        # otherwise no way to do this short of retyping the same password.
         env_writes: dict[str, str] = {}
         entity_name_for_env = name if self.mode == "create" else self.entry.get("name", "?")
+        env_path = self.cfg.path.parent / ".env"
         for spec in self._field_specs():
-            if not spec.secret or spec.key not in updates:
+            if not spec.secret:
                 continue
-            new_value = updates[spec.key]
-            if not new_value or looks_like_env_var_reference(new_value):
+            widget = self.query_one("#" + widget_id(spec.key))
+            current_value = read_widget_value(spec, widget)
+            if not current_value or looks_like_env_var_reference(current_value):
                 continue
             toggle = self.query_one(f"#{env_toggle_widget_id(spec.key)}", Checkbox)
             if not toggle.value:
                 continue
             var_name = env_var_name_for(entity_name_for_env, spec.key)
-            env_writes[var_name] = new_value
+
+            # Collision guard: refuse rather than silently overwrite an
+            # unrelated existing .env entry that happens to share the
+            # generated name. Not a collision if this connector already
+            # owns the name (its pre-save value for this field was already
+            # this exact placeholder — a re-save, not a conflict).
+            original_value = get_nested(self.entry, spec.key)
+            existing_env = read_env_vars(env_path)
+            if var_name in existing_env and original_value != f"${{{var_name}}}":
+                await self.app.push_screen_wait(
+                    MessageModal(
+                        f"'{var_name}' already exists in .env and isn't "
+                        f"currently used by this connector's {spec.label} — "
+                        "refusing to overwrite it. Rename this connector, "
+                        "or resolve the conflict in .env manually, then "
+                        "try again.",
+                        title="Could not save",
+                    )
+                )
+                return
+
+            env_writes[var_name] = current_value
             updates[spec.key] = f"${{{var_name}}}"
 
         if env_writes:
@@ -326,7 +380,7 @@ class ConnectorDetailScreen(FormScreen):
             # not wired up yet. Nothing else has been touched yet at this
             # point, so a failure here is a clean, early return.
             try:
-                upsert_env_vars(self.cfg.path.parent / ".env", env_writes)
+                upsert_env_vars(env_path, env_writes)
             except OSError as exc:
                 await self.app.push_screen_wait(
                     MessageModal(f"Could not write to .env: {exc}", title="Could not save")

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -243,6 +243,16 @@ class FormScreen(DetailScreen):
         # navigation didn't work) resets the FOCUSED field specifically,
         # regardless of kind.
         Binding("ctrl+r", "reset_field", "Reset field", show=True),
+        # User-requested (nice-to-have, not a bug): a way to check what's
+        # actually in a masked secret field before saving. ctrl+t (NOT
+        # ctrl+p — that's Textual's own App.COMMAND_PALETTE_BINDING, which
+        # takes priority over any screen-level binding for the same key and
+        # silently ate every keypress until this was caught by a failing
+        # test) toggles the FOCUSED field's Input.password reactive —
+        # masking is display-only (Input(password=True) never affects
+        # .value), so this is purely cosmetic and doesn't touch anything
+        # read_widget_value() or the diff logic sees.
+        Binding("ctrl+t", "toggle_password_visibility", "Show/hide password", show=True),
     ]
 
     DEFAULT_CSS = """
@@ -321,7 +331,7 @@ class FormScreen(DetailScreen):
         mode (nothing to save yet)."""
         if action in ("edit", "delete"):
             return self.mode == "view"
-        if action in ("save", "reset_field"):
+        if action in ("save", "reset_field", "toggle_password_visibility"):
             return self.mode != "view"
         return True
 
@@ -503,6 +513,21 @@ class FormScreen(DetailScreen):
         self._form_dirty = True
         self.notify(f"{spec.label}: will revert to inherited on Save.", severity="information")
 
+    def action_toggle_password_visibility(self) -> None:
+        """ctrl+t: reveal/re-mask the FOCUSED secret field. A no-op if focus
+        isn't on a masked Input (Input.password is always False for a
+        non-secret field, so toggling it there would be a silent, confusing
+        no-visible-effect action — checked explicitly via the field's own
+        FieldSpec.secret, not just "is this an Input")."""
+        widget = self.focused
+        field_key = getattr(widget, "field_key", None)
+        if field_key is None or not isinstance(widget, Input):
+            return
+        spec = next((s for s in self._field_specs() if s.key == field_key), None)
+        if spec is None or not spec.secret:
+            return
+        widget.password = not widget.password
+
     # ── navigation ───────────────────────────────────────────────────────────
 
     async def action_edit(self) -> None:
@@ -609,10 +634,17 @@ class FormScreen(DetailScreen):
             await self.app.push_screen_wait(MessageModal(str(exc), title="Could not delete"))
             return
 
+        self._on_deleted_successfully()
         self.app.pop_screen()
         app = self.app
         app.notify(f"Deleted {self._entity_noun()} '{self._entity_label()}'.", severity="information")
         app.reload_config()  # type: ignore[attr-defined]
+
+    def _on_deleted_successfully(self) -> None:
+        """Hook for subclass-specific cleanup once the deletion is confirmed
+        durable (document saved to disk). No-op by default;
+        ConnectorDetailScreen uses this to remove any `.env` entries this
+        connector owned (see its own override)."""
 
     # ── generic diff collection (Save calls this, then applies the result
     # however this entity needs to — see module docstring) ──────────────────

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -260,9 +260,25 @@ class FormScreen(DetailScreen):
     FormScreen .field-provenance {
         padding-top: 1;
         margin-left: 2;
+        width: auto;
     }
     FormScreen Checkbox {
         width: auto;
+    }
+    /* Input's own DEFAULT_CSS is `width: 100%` — inside a Horizontal
+    field-row, that claims the ENTIRE row's width, pushing every sibling
+    that comes after it (the "Store in .env" Checkbox, the provenance
+    marker) off past the terminal's right edge. Confirmed as the actual,
+    user-reported cause of a "missing" checkbox — it was rendering, just
+    off-screen; the SAME bug had already been silently hiding every
+    provenance marker on every field row since Phase 2's agent form
+    shipped (a dim decorative label going unnoticed off-screen is a lot
+    less obvious than an interactive control). `1fr` matches Select's own
+    DEFAULT_CSS (which never had this problem) — share the row's
+    remaining space with fixed/auto-width siblings instead of claiming
+    all of it. */
+    FormScreen .field-row Input {
+        width: 1fr;
     }
     """
 

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -47,6 +47,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, VerticalScroll
 from textual.widgets import Checkbox, Footer, Header, Input, Select, Static
 
+from ..env_writer import read_env_vars
 from ..formatting import provenance_label
 from ..modals import ConfirmModal, MessageModal
 from ..model import EditableConfig, Provenance
@@ -417,8 +418,41 @@ class FormScreen(DetailScreen):
             value = get_nested(merged, spec.key)
             if value is None:
                 value = dataclass_defaults.get(spec.key)
+            if spec.secret:
+                value = self._resolve_secret_display(value)
             self._initial_values[spec.key] = value
         self._initial_values["description"] = entry.get("description")
+
+    def _resolve_secret_display(self, raw_value: object) -> object:
+        """For a secret field whose effective value is a `$VAR`/`${VAR}`
+        reference, resolve it against `.env` FOR DISPLAY ONLY, so the user
+        can actually see and edit the real password instead of the literal
+        placeholder text (user-reported: "how do you expect user to change
+        the password" if all they can see is `${SOME_VAR}`).
+
+        This does NOT weaken the security keystone documented at the top of
+        this module (`EditableConfig` never resolves `$VAR` on load/save):
+        `self.entry`/`cfg.document` still hold the raw placeholder string
+        the whole time — this reads `.env` directly via `env_writer.
+        read_env_vars()`, the same file `ConnectorDetailScreen.action_save()`
+        already reads/writes, never `GatewayConfig.from_file`/`load_dotenv`/
+        `os.environ`. Only `_initial_values` (the widget's starting display
+        value AND the diff baseline `_collect_field_updates()` compares
+        against) uses the resolved form, so leaving the field untouched
+        diffs as "unchanged" — nothing gets written to `document` or `.env`
+        — and typing a new value diffs as a genuine change exactly like any
+        other field.
+
+        Falls back to `raw_value` unchanged if it isn't an env reference, or
+        if the referenced var isn't in `.env` (e.g. sourced from the shell
+        environment instead) — never silently blanks a field that has a
+        real value; `_compose_field_row()` adds a hint for this fallback
+        case so it doesn't look identical to "value not found at all"."""
+        if not isinstance(raw_value, str) or not looks_like_env_var_reference(raw_value):
+            return raw_value
+        var_name = raw_value.strip("${}")
+        resolved = read_env_vars(self.cfg.path.parent / ".env").get(var_name)
+        return raw_value if resolved is None else resolved
 
     def _field_provenance(self, spec: FieldSpec, entry: dict) -> Provenance | None:
         top_key = spec.key.split(".", 1)[0]
@@ -431,6 +465,22 @@ class FormScreen(DetailScreen):
         provenance = self._field_provenance(spec, entry)
         prov_text = f"[dim]({provenance_label(provenance)})[/dim]" if provenance else ""
         initial = self._initial_values.get(spec.key)
+        # own_raw is this entry's OWN explicit value (pre-merge, unresolved)
+        # for a secret field — used to decide the "Store in .env" checkbox's
+        # default (below) and to detect the fallback case where
+        # _resolve_secret_display() couldn't resolve the var (the widget is
+        # then showing the raw placeholder, same as `own_raw`, rather than
+        # an actual secret) so a hint can be added instead of looking
+        # identical to a field that simply has no provenance marker.
+        own_raw = get_nested(entry, spec.key) if spec.secret else None
+        if (
+            spec.secret
+            and isinstance(own_raw, str)
+            and looks_like_env_var_reference(own_raw)
+            and initial == own_raw
+        ):
+            hint = "[dim](not found in .env — type a new value to set one)[/dim]"
+            prov_text = f"{prov_text} {hint}" if prov_text else hint
         with Horizontal(classes="field-row"):
             yield Static(spec.label, classes="field-label")
             if spec.kind == "bool":
@@ -458,11 +508,20 @@ class FormScreen(DetailScreen):
             widget.field_key = spec.key
             yield widget
             if spec.secret:
-                # Default ON (docs/design/config-tool.md decision 6) — acted
-                # on only if this field's value actually changes on Save;
-                # see ConnectorDetailScreen.action_save().
+                # Reflects whether THIS entry's own field is already stored
+                # in .env (own_raw looks like a $VAR/${VAR} reference) —
+                # NOT hardcoded True. User-reported bug: unchecking this,
+                # saving as plaintext, then reopening the form showed the
+                # checkbox checked again regardless of what was actually on
+                # disk, because this used to default to True unconditionally.
+                # create mode has no own_raw yet, so it keeps the original
+                # default-ON nudge (docs/design/config-tool.md decision 6)
+                # to encourage using .env for a brand new secret.
+                toggle_default = self.mode == "create" or (
+                    isinstance(own_raw, str) and looks_like_env_var_reference(own_raw)
+                )
                 yield Checkbox(
-                    "Store in .env", value=True, id=env_toggle_widget_id(spec.key)
+                    "Store in .env", value=toggle_default, id=env_toggle_widget_id(spec.key)
                 )
             yield Static(prov_text, classes="field-provenance")
 
@@ -507,6 +566,8 @@ class FormScreen(DetailScreen):
         value = get_nested(defaults_only, spec.key)
         if value is None:
             value = self._dataclass_defaults().get(spec.key)
+        if spec.secret:
+            value = self._resolve_secret_display(value)
 
         set_widget_value(spec, widget, value)
         self._reset_keys[spec.key] = read_widget_value(spec, widget)

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -37,6 +37,7 @@ A subclass provides:
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Literal
 
@@ -58,11 +59,47 @@ class FieldSpec:
     kind: Literal["str", "int", "bool", "list", "enum"]
     label: str
     options: tuple[str, ...] | None = None
-    secret: bool = False  # mask the widget's display (Input(password=True))
+    # Masks the widget's display (Input(password=True)) AND renders a
+    # "Store in .env" Checkbox next to it (docs/design/config-tool.md
+    # decision 6) — default ON. See looks_like_env_var_reference()/
+    # env_var_name_for() below and ConnectorDetailScreen.action_save() for
+    # how the toggle actually gets acted on.
+    secret: bool = False
+
+
+_ENV_VAR_REF_RE = re.compile(r"^\$\{?[A-Za-z_][A-Za-z0-9_]*\}?$")
+
+
+def looks_like_env_var_reference(value: str) -> bool:
+    """True if `value` is ENTIRELY a `$VAR` or `${VAR}` reference (matching
+    both forms `gateway/config.py`'s `_expand_env_vars` resolves, via
+    `os.path.expandvars`). Used to avoid double-writing `.env` when a secret
+    field's new value is already a placeholder the user typed directly
+    (referencing an externally-managed var) rather than a genuine new
+    plaintext secret."""
+    return bool(_ENV_VAR_REF_RE.match(value))
+
+
+def env_var_name_for(entity_name: str, field_key: str) -> str:
+    """Deterministic `.env` var name for a secret field: `"<ENTITY>_<FIELD>"`,
+    uppercased, any non-alphanumeric character replaced with `_`. E.g.
+    connector `"rc-home"` + field `"server.password"` -> `"RC_HOME_PASSWORD"`.
+    Accepted, documented risk (not handled): this could collide with an
+    unrelated existing `.env` key sharing the same generated name — rare in
+    practice, not worth a collision-detection UI for v1.
+    """
+    suffix = field_key.rsplit(".", 1)[-1]
+    sanitized_entity = re.sub(r"[^A-Za-z0-9]", "_", entity_name).upper()
+    sanitized_field = re.sub(r"[^A-Za-z0-9]", "_", suffix).upper()
+    return f"{sanitized_entity}_{sanitized_field}"
 
 
 def widget_id(key: str) -> str:
     return "field-" + key.replace(".", "-")
+
+
+def env_toggle_widget_id(key: str) -> str:
+    return widget_id(key) + "-env-toggle"
 
 
 def get_nested(d: dict, dotted_key: str) -> object:
@@ -394,6 +431,13 @@ class FormScreen(DetailScreen):
             # future field key containing a literal dash.
             widget.field_key = spec.key
             yield widget
+            if spec.secret:
+                # Default ON (docs/design/config-tool.md decision 6) — acted
+                # on only if this field's value actually changes on Save;
+                # see ConnectorDetailScreen.action_save().
+                yield Checkbox(
+                    "Store in .env", value=True, id=env_toggle_widget_id(spec.key)
+                )
             yield Static(prov_text, classes="field-provenance")
 
     # ── dirty tracking (per-screen, not EditableConfig.dirty — nothing is

--- a/gateway/onboard.py
+++ b/gateway/onboard.py
@@ -411,13 +411,23 @@ def _handle_existing_config() -> bool:
     if choice == "2":
         import time
         ts = int(time.time())
+        # Same `.config-backups/` directory the config TUI's own save()
+        # (gateway/configtool/model.py) uses — one place, not two competing
+        # conventions, and chmod'd 0700 since a backup can hold a plaintext
+        # secret (an unmigrated password/token) same as the live files do.
+        backup_dir = CONFIG_FILE.parent / ".config-backups"
+        if CONFIG_FILE.exists() or ENV_FILE.exists():
+            backup_dir.mkdir(parents=True, exist_ok=True)
+            backup_dir.chmod(0o700)
         if CONFIG_FILE.exists():
-            bak = CONFIG_FILE.parent / f"config.yaml.bak.{ts}"
+            bak = backup_dir / f"config.yaml.bak.{ts}"
             shutil.copy2(CONFIG_FILE, bak)
+            bak.chmod(0o600)
             console.print(f"  Backed up config to [dim]{bak}[/dim]")
         if ENV_FILE.exists():
-            bak_env = ENV_FILE.parent / f".env.bak.{ts}"
+            bak_env = backup_dir / f".env.bak.{ts}"
             shutil.copy2(ENV_FILE, bak_env)
+            bak_env.chmod(0o600)
             console.print(f"  Backed up .env to [dim]{bak_env}[/dim]")
 
     return True  # continue with wizard
@@ -501,6 +511,10 @@ def run_onboard(repo_path: Path | None = None) -> None:
         working_directory=str(working_dir),
     )
     CONFIG_FILE.write_text(config_yaml)
+    # Matches ENV_FILE's own chmod below — config.yaml can hold a plaintext
+    # secret just as easily as .env can (a field saved with "Store in .env"
+    # off), so it gets the same treatment from the moment it's created.
+    CONFIG_FILE.chmod(0o600)
     console.print(f"\n  [green]✓[/green] Wrote {CONFIG_FILE}")
 
     _write_env(

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -234,6 +234,27 @@ class TestCreateAgent:
 
 
 class TestEditAgent:
+    async def test_provenance_markers_are_within_the_visible_terminal_width(
+        self, tmp_path, work_dir
+    ):
+        """Real layout bug, caught via the connector screen's "Store in
+        .env" checkbox being reported invisible: Input's own DEFAULT_CSS is
+        width:100%, which — inside the Horizontal field-row — claimed the
+        ENTIRE row, pushing every field's provenance marker (the "(explicit)"
+        / "(inherited from defaults)" label) off past the terminal's right
+        edge since this form first shipped. Fixed with width:1fr on Input
+        within .field-row (matching Select's own DEFAULT_CSS, which never
+        had this problem)."""
+        config_path = _write_config(tmp_path, _config_with_one_agent(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await _open_agent_in_edit_mode(pilot, app)
+            markers = list(app.screen.query(".field-provenance"))
+            assert markers  # sanity: there are provenance markers to check
+            for marker in markers:
+                assert marker.region.x + marker.region.width <= app.size.width
+
     async def test_edit_mode_prefills_the_effective_merged_value(self, tmp_path, work_dir):
         config_path = _write_config(
             tmp_path, _config_with_one_agent(work_dir, "session_prefix: custom-prefix\n")

--- a/tests/unit/test_configtool_agent_crud.py
+++ b/tests/unit/test_configtool_agent_crud.py
@@ -142,7 +142,7 @@ class TestCreateAgent:
             assert raw["agents"]["brand-new"]["type"] == "claude"
             assert raw["agents"]["brand-new"]["working_directory"] == str(work_dir)
             # A backup of the pre-save file must exist (EditableConfig.save()).
-            assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
+            assert list((Path(config_path).parent / ".config-backups").glob("config.yaml.bak.*"))
 
     async def test_creating_with_a_duplicate_name_shows_an_error_and_stays_in_the_form(
         self, tmp_path, work_dir
@@ -824,7 +824,7 @@ class TestDeleteAgent:
             raw = yaml.safe_load(Path(config_path).read_text())
             assert "unused-agent" not in raw["agents"]
             assert "existing-agent" in raw["agents"]
-            assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
+            assert list((Path(config_path).parent / ".config-backups").glob("config.yaml.bak.*"))
 
     async def test_deleting_a_referenced_agent_is_blocked_before_the_confirm(
         self, tmp_path, work_dir

--- a/tests/unit/test_configtool_connector_crud.py
+++ b/tests/unit/test_configtool_connector_crud.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from textual.widgets import DataTable, Input
+from textual.widgets import Checkbox, DataTable, Input
 
 from gateway.configtool.app import ConfigToolApp
 from gateway.configtool.modals import ConfirmModal, MessageModal, TypePickerModal
@@ -100,6 +100,10 @@ class TestCreateConnector:
             app.screen.query_one("#field-server-url", Input).value = "http://rc2.local"
             app.screen.query_one("#field-server-username", Input).value = "bot2"
             app.screen.query_one("#field-server-password", Input).value = "pw2"
+            # "Store in .env" defaults ON (tested separately below) — off
+            # here since this test is about basic field persistence, not
+            # the secret-handling behavior.
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = False
             await pilot.pause()
             await pilot.press("ctrl+s")
             await pilot.pause()
@@ -272,13 +276,13 @@ class TestEditConnector:
         finally:
             os.environ.pop("RC_PASSWORD_CONNECTOR_TEST", None)
 
-    async def test_editing_and_changing_the_secret_writes_the_new_plaintext_value(
+    async def test_editing_and_changing_the_secret_with_the_env_toggle_off_writes_plaintext(
         self, tmp_path, work_dir
     ):
-        """Documented v1 scope: there is no '.env toggle' yet (deferred — see
-        docs/design/config-tool.md) — typing a new secret directly writes it
-        to config.yaml in plaintext, exactly like the existing $EDITOR escape
-        hatch already allows. Not a regression, just not-yet-automated."""
+        """"Store in .env" defaults ON (tested separately below) — with it
+        explicitly turned off, typing a new secret directly writes it to
+        config.yaml in plaintext, exactly like the existing $EDITOR escape
+        hatch already allows."""
         config_path = _write_config(
             tmp_path, _config_with_one_rocketchat_connector(work_dir, password="oldpw")
         )
@@ -288,6 +292,7 @@ class TestEditConnector:
             await _open_connector_in_edit_mode(pilot, app)
 
             app.screen.query_one("#field-server-password", Input).value = "brand-new-secret"
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = False
             await pilot.pause()
             await pilot.press("ctrl+s")
             await pilot.pause()
@@ -406,6 +411,146 @@ class TestEditConnector:
             raw = yaml.safe_load(Path(config_path).read_text())
             assert raw["connectors"][0]["server"]["password"] == "pw"
             assert raw["connectors"][0]["server"]["username"] == "bot"
+
+
+class TestEnvSecretToggle:
+    """"Store in .env" (docs/design/config-tool.md decision 6) — a per-
+    secret-field Checkbox, default ON, next to every masked field. Acted on
+    only when that field's value actually changes to a genuine new
+    plaintext secret; a value already looking like a $VAR/${VAR} reference
+    is left alone (the user is explicitly pointing at an externally-managed
+    var, not typing a new secret)."""
+
+    async def test_toggle_is_checked_by_default(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+            toggle = app.screen.query_one("#field-server-password-env-toggle", Checkbox)
+            assert toggle.value is True
+
+    async def test_changing_a_secret_with_the_toggle_on_writes_a_placeholder_and_the_env_file(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-server-password", Input).value = "super-secret-value"
+            # toggle already defaults True — leave it
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "${RC_EXISTING_PASSWORD}"
+
+            env_path = Path(tmp_path) / ".env"
+            env_text = env_path.read_text()
+            assert "RC_EXISTING_PASSWORD=super-secret-value" in env_text
+
+    async def test_env_var_name_combines_connector_name_and_field(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-server-username", Input).value = "newbot"
+            app.screen.query_one("#field-server-password", Input).value = "hunter2"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            # username isn't a secret field -- untouched by env logic.
+            assert raw["connectors"][0]["server"]["username"] == "newbot"
+            assert raw["connectors"][0]["server"]["password"] == "${RC_EXISTING_PASSWORD}"
+
+    async def test_a_value_already_looking_like_a_var_reference_is_left_alone(
+        self, tmp_path, work_dir, monkeypatch
+    ):
+        # Set so save()'s own validate_config() can actually resolve it —
+        # this test is about the TUI not re-wrapping/rewriting an
+        # already-a-reference value, not about whether the var resolves.
+        monkeypatch.setenv("SOME_OTHER_VAR", "resolved-value")
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-server-password", Input).value = "${SOME_OTHER_VAR}"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            # Left exactly as typed -- not re-wrapped, and nothing written
+            # to .env for a var the user is explicitly already referencing.
+            assert raw["connectors"][0]["server"]["password"] == "${SOME_OTHER_VAR}"
+            assert not (Path(tmp_path) / ".env").exists()
+
+    async def test_untouched_secret_field_never_triggers_env_writes(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-timezone", Input).value = "America/New_York"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "pw"  # untouched
+            assert not (Path(tmp_path) / ".env").exists()
+
+    async def test_env_write_failure_leaves_config_yaml_completely_untouched(
+        self, tmp_path, work_dir, monkeypatch
+    ):
+        """.env MUST be written before cfg.save(), not after: save()'s own
+        validate_config() resolves every ${VAR} placeholder immediately
+        (GatewayConfig.from_file -> load_dotenv + expandvars) — if the var
+        isn't in .env yet, save() itself fails with "unresolved environment
+        variable" before config.yaml is ever touched. So a failure writing
+        to .env is a clean, early return: nothing else has happened yet."""
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+
+        def _boom(env_path, updates):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(
+            "gateway.configtool.screens.connector_detail.upsert_env_vars", _boom
+        )
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-server-password", Input).value = "super-secret-value"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, MessageModal)
+            body = str(app.screen.query_one("#message-body").render())
+            assert "disk full" in body
+
+            assert isinstance(app.screen, MessageModal)
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(app.screen, ConnectorDetailScreen)
+            assert app.screen.mode == "edit"
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "pw"  # untouched
 
 
 class TestConnectorEscapeConfirmation:

--- a/tests/unit/test_configtool_connector_crud.py
+++ b/tests/unit/test_configtool_connector_crud.py
@@ -421,6 +421,23 @@ class TestEnvSecretToggle:
     is left alone (the user is explicitly pointing at an externally-managed
     var, not typing a new secret)."""
 
+    async def test_toggle_is_within_the_visible_terminal_width(self, tmp_path, work_dir):
+        """User-reported: the checkbox wasn't visible at all. Root cause:
+        Input's own DEFAULT_CSS is width:100%, which — inside the
+        Horizontal field-row — claimed the ENTIRE row, pushing the
+        Checkbox (and every field's provenance marker, actually, since
+        Phase 2's agent form first shipped) off past the terminal's right
+        edge. It was rendering, just off-screen; Pilot's query_one() found
+        it regardless of position, which is exactly why this had to be
+        caught by checking .region, not just presence in the DOM."""
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+            toggle = app.screen.query_one("#field-server-password-env-toggle", Checkbox)
+            assert toggle.region.x + toggle.region.width <= app.size.width
+
     async def test_toggle_is_checked_by_default(self, tmp_path, work_dir):
         config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
         app = ConfigToolApp(config_path)

--- a/tests/unit/test_configtool_connector_crud.py
+++ b/tests/unit/test_configtool_connector_crud.py
@@ -512,13 +512,44 @@ class TestEnvSecretToggle:
             assert raw["connectors"][0]["server"]["password"] == "${SOME_OTHER_VAR}"
             assert not (Path(tmp_path) / ".env").exists()
 
-    async def test_untouched_secret_field_never_triggers_env_writes(self, tmp_path, work_dir):
+    async def test_untouched_plaintext_secret_still_migrates_to_env_when_toggle_left_on(
+        self, tmp_path, work_dir
+    ):
+        """User-reported fix: leaving the toggle at its default (checked)
+        and saving — even without retyping the password, even editing a
+        completely unrelated field — is how an EXISTING plaintext secret
+        (e.g. saved earlier with the toggle unchecked) gets migrated into
+        .env. There was previously no other way to do this short of
+        retyping the same password, which the user correctly flagged as
+        broken/confusing."""
         config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
             await pilot.pause()
             await _open_connector_in_edit_mode(pilot, app)
 
+            app.screen.query_one("#field-timezone", Input).value = "America/New_York"
+            # password field and its "Store in .env" toggle: untouched,
+            # toggle at its default (checked).
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "${RC_EXISTING_PASSWORD}"
+            env_text = (Path(tmp_path) / ".env").read_text()
+            assert "RC_EXISTING_PASSWORD=pw" in env_text
+
+    async def test_untouched_secret_field_is_left_alone_when_toggle_is_off(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = False
             app.screen.query_one("#field-timezone", Input).value = "America/New_York"
             await pilot.pause()
             await pilot.press("ctrl+s")
@@ -527,6 +558,34 @@ class TestEnvSecretToggle:
             raw = yaml.safe_load(Path(config_path).read_text())
             assert raw["connectors"][0]["server"]["password"] == "pw"  # untouched
             assert not (Path(tmp_path) / ".env").exists()
+
+    async def test_reopening_after_migration_shows_the_toggle_checked_and_is_a_no_op(
+        self, tmp_path, work_dir
+    ):
+        """Once a field is already "${VAR}", it looks_like_env_var_reference()
+        and is left alone on every subsequent save — no infinite
+        reconversion, no redundant .env writes."""
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+            await pilot.press("ctrl+s")  # migrate on the first save (default toggle)
+            await pilot.pause()
+
+            await _open_connector_in_edit_mode(pilot, app)
+            pw_input = app.screen.query_one("#field-server-password", Input)
+            assert pw_input.value == "${RC_EXISTING_PASSWORD}"
+            toggle = app.screen.query_one("#field-server-password-env-toggle", Checkbox)
+            assert toggle.value is True
+
+            app.screen.query_one("#field-timezone", Input).value = "America/Chicago"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "${RC_EXISTING_PASSWORD}"
 
     async def test_env_write_failure_leaves_config_yaml_completely_untouched(
         self, tmp_path, work_dir, monkeypatch
@@ -568,6 +627,63 @@ class TestEnvSecretToggle:
 
             raw = yaml.safe_load(Path(config_path).read_text())
             assert raw["connectors"][0]["server"]["password"] == "pw"  # untouched
+
+    async def test_generated_var_name_colliding_with_an_unrelated_existing_env_key_is_blocked(
+        self, tmp_path, work_dir
+    ):
+        """User-asked: if there's already an unrelated RC_EXISTING_PASSWORD
+        in .env, does the tool know to use a different name, or could it
+        silently overwrite something? Answer: neither — it refuses to save
+        rather than guess. A real collision (a name this connector doesn't
+        already own) blocks the save with a clear message; the existing
+        .env value is left completely untouched."""
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        env_path = tmp_path / ".env"
+        env_path.write_text("RC_EXISTING_PASSWORD=someone-elses-unrelated-secret\n")
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            app.screen.query_one("#field-server-password", Input).value = "my-new-secret"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, MessageModal)
+            body = str(app.screen.query_one("#message-body").render())
+            assert "RC_EXISTING_PASSWORD" in body
+            assert "already exists" in body
+
+            # Neither config.yaml nor .env was touched.
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "pw"
+            assert env_path.read_text() == "RC_EXISTING_PASSWORD=someone-elses-unrelated-secret\n"
+
+    async def test_re_saving_a_connector_that_already_owns_the_var_is_not_a_collision(
+        self, tmp_path, work_dir
+    ):
+        """The var already existing is only a problem if this connector
+        DOESN'T already own it — a plain re-save (e.g. after migration)
+        must not falsely trip the collision guard."""
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+            await pilot.press("ctrl+s")  # migrates password -> ${RC_EXISTING_PASSWORD}
+            await pilot.pause()
+
+            await _open_connector_in_edit_mode(pilot, app)
+            app.screen.query_one("#field-timezone", Input).value = "America/Denver"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)  # no collision MessageModal
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["timezone"] == "America/Denver"
+            assert raw["connectors"][0]["server"]["password"] == "${RC_EXISTING_PASSWORD}"
 
 
 class TestConnectorEscapeConfirmation:
@@ -717,3 +833,97 @@ class TestDeleteConnector:
             assert "rc-referenced" in names
             raw = yaml.safe_load(Path(config_path).read_text())
             assert any(c["name"] == "rc-referenced" for c in raw["connectors"])
+
+    async def test_deleting_a_connector_removes_its_own_env_secret_but_not_others(
+        self, tmp_path, work_dir
+    ):
+        """User-reported: deleting a connector left its .env secret behind,
+        orphaned. Only removes the key matching THIS connector's exact
+        deterministic var name where the raw entry's value is exactly that
+        placeholder — an unrelated key (even one that happens to look like
+        it could belong to some other connector) must survive. A second,
+        unreferenced connector ("rc-orphan") is the one being deleted here
+        — "rc-referenced" and its watcher stay untouched so the config
+        still has >=1 connector afterward and the delete isn't blocked by
+        the referencing-watcher check."""
+        config_path = _write_config(
+            tmp_path,
+            f"""\
+                agents:
+                  default:
+                    type: claude
+                    working_directory: {work_dir}
+                connectors:
+                  - name: rc-referenced
+                    type: rocketchat
+                    server: {{url: "http://localhost:3000", username: bot, password: pw}}
+                  - name: rc-orphan
+                    type: rocketchat
+                    server: {{url: "http://localhost:3001", username: bot2, password: "${{RC_ORPHAN_PASSWORD}}"}}
+                watchers:
+                  - connector: rc-referenced
+                    agent: default
+                    room: general
+            """,
+        )
+        env_path = tmp_path / ".env"
+        env_path.write_text("RC_ORPHAN_PASSWORD=secret123\nUNRELATED_KEY=keep-me\n")
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+
+            await _open_connector_in_view_mode(pilot, app, row=1)  # rc-orphan
+            assert app.screen.entry.get("name") == "rc-orphan"
+            await pilot.press("d")
+            await pilot.pause()
+            await pilot.press("tab", "enter")  # Delete
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            env_text = env_path.read_text()
+            assert "RC_ORPHAN_PASSWORD" not in env_text
+            assert "UNRELATED_KEY=keep-me" in env_text
+
+
+class TestPasswordVisibilityToggle:
+    """ctrl+t (nice-to-have, user-requested) — reveal/re-mask the FOCUSED
+    secret field. Purely cosmetic: Input.password only affects display,
+    never .value, so it has zero interaction with the diff/save logic."""
+
+    async def test_ctrl_t_reveals_and_re_masks_the_focused_password_field(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            pw_input = app.screen.query_one("#field-server-password", Input)
+            assert pw_input.password is True  # masked by default
+            pw_input.focus()
+            await pilot.pause()
+
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            assert pw_input.password is False
+            assert pw_input.value == "pw"  # .value was never masked to begin with
+
+            await pilot.press("ctrl+t")
+            await pilot.pause()
+            assert pw_input.password is True
+
+    async def test_ctrl_t_on_a_non_secret_field_is_a_safe_no_op(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+
+            url_input = app.screen.query_one("#field-server-url", Input)
+            url_input.focus()
+            await pilot.pause()
+
+            await pilot.press("ctrl+t")  # must not raise
+            await pilot.pause()
+            assert url_input.password is False

--- a/tests/unit/test_configtool_connector_crud.py
+++ b/tests/unit/test_configtool_connector_crud.py
@@ -113,7 +113,7 @@ class TestCreateConnector:
             names = {c["name"]: c for c in raw["connectors"]}
             assert names["rc-second"]["server"]["url"] == "http://rc2.local"
             assert names["rc-second"]["server"]["password"] == "pw2"
-            assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
+            assert list((Path(config_path).parent / ".config-backups").glob("config.yaml.bak.*"))
 
     async def test_creating_a_voice_connector_uses_the_flat_field_list(
         self, tmp_path, work_dir
@@ -242,7 +242,16 @@ class TestEditConnector:
     async def test_editing_an_unrelated_field_leaves_an_existing_secret_placeholder_untouched(
         self, tmp_path, work_dir
     ):
-        """THE keystone test for this screen (see module docstring)."""
+        """THE keystone test for this screen (see module docstring): the
+        raw document (`self.entry`/`cfg.document`) never gets a resolved
+        secret written into it, regardless of what the widget shows for
+        editing. This specific fixture sets the var via `os.environ`
+        directly, WITHOUT an actual `.env` FILE on disk — `_resolve_secret_
+        display()` only ever reads the `.env` file (never `os.environ`/
+        `GatewayConfig`), so this is also the regression test for that
+        fallback path: an unresolvable reference still shows the literal
+        placeholder (with a hint, not a blank field) rather than blanking
+        or crashing."""
         os.environ["RC_PASSWORD_CONNECTOR_TEST"] = "the-real-secret-value"
         try:
             config_path = _write_config(
@@ -257,11 +266,15 @@ class TestEditConnector:
                 await _open_connector_in_edit_mode(pilot, app)
 
                 pw_input = app.screen.query_one("#field-server-password", Input)
-                # The widget must show the literal placeholder, never the
-                # resolved secret and never a masked "****" at the data level
-                # (masking is display-only via Input(password=True); .value
-                # is always the real underlying string).
+                # No .env file exists, so the var can't be resolved for
+                # display — the widget must show the literal placeholder,
+                # never the resolved secret and never a masked "****" at the
+                # data level (masking is display-only via
+                # Input(password=True); .value is always the real
+                # underlying string).
                 assert pw_input.value == "${RC_PASSWORD_CONNECTOR_TEST}"
+                prov = app.screen.query(".field-provenance")
+                assert any("not found in .env" in str(s.render()) for s in prov)
 
                 app.screen.query_one("#field-server-username", Input).value = "renamed-bot"
                 await pilot.pause()
@@ -415,11 +428,17 @@ class TestEditConnector:
 
 class TestEnvSecretToggle:
     """"Store in .env" (docs/design/config-tool.md decision 6) — a per-
-    secret-field Checkbox, default ON, next to every masked field. Acted on
-    only when that field's value actually changes to a genuine new
-    plaintext secret; a value already looking like a $VAR/${VAR} reference
-    is left alone (the user is explicitly pointing at an externally-managed
-    var, not typing a new secret)."""
+    secret-field Checkbox next to every masked field. Its default reflects
+    the field's ACTUAL current state (checked iff the raw value already
+    looks like a $VAR/${VAR} reference) rather than always being True —
+    user-reported: unchecking it, saving as plaintext, then reopening the
+    form showed it checked again regardless of what was really on disk,
+    because it used to be hardcoded True unconditionally. create mode still
+    defaults ON (nothing to reflect yet — encourages using .env for a brand
+    new secret). Acted on only when the checkbox ends up checked at Save
+    time; a value already looking like a $VAR/${VAR} reference is left
+    alone either way (the user is explicitly pointing at an externally-
+    managed var, not typing a new secret)."""
 
     async def test_toggle_is_within_the_visible_terminal_width(self, tmp_path, work_dir):
         """User-reported: the checkbox wasn't visible at all. Root cause:
@@ -438,8 +457,24 @@ class TestEnvSecretToggle:
             toggle = app.screen.query_one("#field-server-password-env-toggle", Checkbox)
             assert toggle.region.x + toggle.region.width <= app.size.width
 
-    async def test_toggle_is_checked_by_default(self, tmp_path, work_dir):
+    async def test_toggle_defaults_unchecked_when_the_field_is_currently_plaintext(
+        self, tmp_path, work_dir
+    ):
         config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+            toggle = app.screen.query_one("#field-server-password-env-toggle", Checkbox)
+            assert toggle.value is False
+
+    async def test_toggle_defaults_checked_when_the_field_is_already_in_env(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(
+            tmp_path, _config_with_one_rocketchat_connector(work_dir, password="${RC_PW}")
+        )
+        (tmp_path / ".env").write_text("RC_PW=already-migrated\n")
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
             await pilot.pause()
@@ -447,7 +482,90 @@ class TestEnvSecretToggle:
             toggle = app.screen.query_one("#field-server-password-env-toggle", Checkbox)
             assert toggle.value is True
 
-    async def test_changing_a_secret_with_the_toggle_on_writes_a_placeholder_and_the_env_file(
+    async def test_edit_mode_shows_the_real_resolved_secret_not_the_placeholder(
+        self, tmp_path, work_dir
+    ):
+        """User-reported: seeing only "${RC_PW}" gave no way to tell what
+        the current password even was, or how to change it short of
+        blindly overwriting an unknown value. The widget must show the
+        actual secret (read directly from the .env file, never via
+        GatewayConfig/os.environ — see FormScreen._resolve_secret_display())
+        so the user can see it and, if they want, type a new one over it."""
+        config_path = _write_config(
+            tmp_path, _config_with_one_rocketchat_connector(work_dir, password="${RC_PW}")
+        )
+        (tmp_path / ".env").write_text("RC_PW=the-real-password\n")
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+            pw_input = app.screen.query_one("#field-server-password", Input)
+            assert pw_input.value == "the-real-password"
+            assert pw_input.password is True  # still masked by default (ctrl+t reveals)
+
+    async def test_leaving_a_resolved_secret_untouched_is_a_no_op_on_save(
+        self, tmp_path, work_dir
+    ):
+        """The resolved display value is also the diff baseline
+        (_initial_values) — an untouched field must not look "changed"
+        just because it's now showing a real secret instead of a
+        placeholder, or every save would needlessly rewrite .env and
+        re-diff a field the user never touched."""
+        config_path = _write_config(
+            tmp_path, _config_with_one_rocketchat_connector(work_dir, password="${RC_PW}")
+        )
+        (tmp_path / ".env").write_text("RC_PW=the-real-password\n")
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+            app.screen.query_one("#field-timezone", Input).value = "America/Denver"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "${RC_PW}"
+            assert (tmp_path / ".env").read_text() == "RC_PW=the-real-password\n"
+
+    async def test_typing_a_new_password_over_the_resolved_value_rotates_the_env_secret(
+        self, tmp_path, work_dir
+    ):
+        """The user-reported "how do I change the password" flow: select
+        all / type over the resolved value, leave the toggle at its
+        default (checked — the field is already env-backed), save. Same
+        var name, new value — a rotation, not a rename."""
+        config_path = _write_config(
+            tmp_path, _config_with_one_rocketchat_connector(work_dir, password="${RC_PW}")
+        )
+        (tmp_path / ".env").write_text("RC_PW=old-password\n")
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_connector_in_edit_mode(pilot, app)
+            pw_input = app.screen.query_one("#field-server-password", Input)
+            assert pw_input.value == "old-password"
+            pw_input.value = "new-rotated-password"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["connectors"][0]["server"]["password"] == "${RC_PW}"
+            assert (tmp_path / ".env").read_text() == "RC_PW=new-rotated-password\n"
+
+    async def test_toggle_defaults_checked_in_create_mode(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_type_picker_for_connectors(pilot, app)
+            await pilot.press("enter")  # rocketchat
+            await pilot.pause()
+            toggle = app.screen.query_one("#field-server-password-env-toggle", Checkbox)
+            assert toggle.value is True
+
+    async def test_changing_a_secret_with_the_toggle_checked_writes_a_placeholder_and_the_env_file(
         self, tmp_path, work_dir
     ):
         config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
@@ -457,7 +575,9 @@ class TestEnvSecretToggle:
             await _open_connector_in_edit_mode(pilot, app)
 
             app.screen.query_one("#field-server-password", Input).value = "super-secret-value"
-            # toggle already defaults True — leave it
+            # Toggle defaults unchecked (field is currently plaintext) — the
+            # user must explicitly opt in to storing the NEW value in .env.
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = True
             await pilot.pause()
             await pilot.press("ctrl+s")
             await pilot.pause()
@@ -479,6 +599,7 @@ class TestEnvSecretToggle:
 
             app.screen.query_one("#field-server-username", Input).value = "newbot"
             app.screen.query_one("#field-server-password", Input).value = "hunter2"
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = True
             await pilot.pause()
             await pilot.press("ctrl+s")
             await pilot.pause()
@@ -512,16 +633,19 @@ class TestEnvSecretToggle:
             assert raw["connectors"][0]["server"]["password"] == "${SOME_OTHER_VAR}"
             assert not (Path(tmp_path) / ".env").exists()
 
-    async def test_untouched_plaintext_secret_still_migrates_to_env_when_toggle_left_on(
+    async def test_checking_the_toggle_without_retyping_the_secret_still_migrates_it_to_env(
         self, tmp_path, work_dir
     ):
-        """User-reported fix: leaving the toggle at its default (checked)
-        and saving — even without retyping the password, even editing a
-        completely unrelated field — is how an EXISTING plaintext secret
-        (e.g. saved earlier with the toggle unchecked) gets migrated into
-        .env. There was previously no other way to do this short of
-        retyping the same password, which the user correctly flagged as
-        broken/confusing."""
+        """User-reported fix: checking the toggle and saving — even without
+        retyping the password, even editing a completely unrelated field at
+        the same time — is how an EXISTING plaintext secret (e.g. saved
+        earlier with the toggle unchecked) gets migrated into .env. There
+        was previously no other way to do this short of retyping the same
+        password, which the user correctly flagged as broken/confusing.
+        (The toggle itself defaults unchecked for an already-plaintext
+        field — see TestEnvSecretToggle's defaulting tests — so migrating
+        it is now a deliberate, explicit action rather than something that
+        happens implicitly just by saving any other field.)"""
         config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
@@ -529,8 +653,8 @@ class TestEnvSecretToggle:
             await _open_connector_in_edit_mode(pilot, app)
 
             app.screen.query_one("#field-timezone", Input).value = "America/New_York"
-            # password field and its "Store in .env" toggle: untouched,
-            # toggle at its default (checked).
+            # password field itself: untouched. Toggle: explicitly checked.
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = True
             await pilot.pause()
             await pilot.press("ctrl+s")
             await pilot.pause()
@@ -564,18 +688,27 @@ class TestEnvSecretToggle:
     ):
         """Once a field is already "${VAR}", it looks_like_env_var_reference()
         and is left alone on every subsequent save — no infinite
-        reconversion, no redundant .env writes."""
+        reconversion, no redundant .env writes. Also: reopening resolves
+        the placeholder back to the real secret for display/editing
+        (user-reported: seeing only "${VAR}" gave no way to tell what the
+        current password even was) — masked by default via ctrl+t, same as
+        any other secret field, never shown in the clear unmasked."""
         config_path = _write_config(tmp_path, _config_with_one_rocketchat_connector(work_dir))
         app = ConfigToolApp(config_path)
         async with app.run_test() as pilot:
             await pilot.pause()
             await _open_connector_in_edit_mode(pilot, app)
-            await pilot.press("ctrl+s")  # migrate on the first save (default toggle)
+            # Toggle defaults unchecked (field is currently plaintext) — check
+            # it explicitly to migrate on this first save.
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = True
+            await pilot.pause()
+            await pilot.press("ctrl+s")
             await pilot.pause()
 
             await _open_connector_in_edit_mode(pilot, app)
             pw_input = app.screen.query_one("#field-server-password", Input)
-            assert pw_input.value == "${RC_EXISTING_PASSWORD}"
+            assert pw_input.value == "pw"  # resolved from .env, not the placeholder
+            assert pw_input.password is True
             toggle = app.screen.query_one("#field-server-password-env-toggle", Checkbox)
             assert toggle.value is True
 
@@ -611,6 +744,7 @@ class TestEnvSecretToggle:
             await _open_connector_in_edit_mode(pilot, app)
 
             app.screen.query_one("#field-server-password", Input).value = "super-secret-value"
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = True
             await pilot.pause()
             await pilot.press("ctrl+s")
             await pilot.pause()
@@ -646,6 +780,7 @@ class TestEnvSecretToggle:
             await _open_connector_in_edit_mode(pilot, app)
 
             app.screen.query_one("#field-server-password", Input).value = "my-new-secret"
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = True
             await pilot.pause()
             await pilot.press("ctrl+s")
             await pilot.pause()
@@ -671,6 +806,7 @@ class TestEnvSecretToggle:
         async with app.run_test() as pilot:
             await pilot.pause()
             await _open_connector_in_edit_mode(pilot, app)
+            app.screen.query_one("#field-server-password-env-toggle", Checkbox).value = True
             await pilot.press("ctrl+s")  # migrates password -> ${RC_EXISTING_PASSWORD}
             await pilot.pause()
 
@@ -803,7 +939,7 @@ class TestDeleteConnector:
             names = {c["name"] for c in raw["connectors"]}
             assert "rc-orphan" not in names
             assert "rc-referenced" in names
-            assert list(Path(config_path).parent.glob("config.yaml.bak.*"))
+            assert list((Path(config_path).parent / ".config-backups").glob("config.yaml.bak.*"))
 
     async def test_deleting_a_referenced_connector_is_blocked_before_the_confirm(
         self, tmp_path, work_dir

--- a/tests/unit/test_configtool_env_writer.py
+++ b/tests/unit/test_configtool_env_writer.py
@@ -12,7 +12,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from gateway.configtool.env_writer import upsert_env_vars
+from gateway.configtool.env_writer import read_env_vars, remove_env_vars, upsert_env_vars
 
 
 class TestUpsertEnvVars(unittest.TestCase):
@@ -94,6 +94,78 @@ class TestUpsertEnvVars(unittest.TestCase):
         self.env_path.chmod(0o644)
         upsert_env_vars(self.env_path, {"RC_URL": "http://new"})
         self.assertEqual(self._permissions(self.env_path), "0o600")
+
+
+class TestReadEnvVars(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.env_path = self.tmp / ".env"
+
+    def test_returns_empty_dict_when_file_does_not_exist(self):
+        self.assertEqual(read_env_vars(self.env_path), {})
+
+    def test_reads_simple_key_value_pairs(self):
+        self.env_path.write_text("RC_URL=http://old\nRC_PASSWORD=hunter2\n")
+        self.assertEqual(
+            read_env_vars(self.env_path),
+            {"RC_URL": "http://old", "RC_PASSWORD": "hunter2"},
+        )
+
+    def test_unquotes_a_quoted_value(self):
+        self.env_path.write_text('NAME="hello world"\n')
+        self.assertEqual(read_env_vars(self.env_path), {"NAME": "hello world"})
+
+    def test_ignores_comments_and_blank_lines(self):
+        self.env_path.write_text("# a comment\n\nRC_URL=http://old\n")
+        self.assertEqual(read_env_vars(self.env_path), {"RC_URL": "http://old"})
+
+    def test_a_commented_out_key_is_not_read(self):
+        self.env_path.write_text("# RC_PASSWORD=disabled\n")
+        self.assertEqual(read_env_vars(self.env_path), {})
+
+
+class TestRemoveEnvVars(unittest.TestCase):
+    def setUp(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.env_path = self.tmp / ".env"
+
+    def test_no_op_when_file_does_not_exist(self):
+        remove_env_vars(self.env_path, {"RC_PASSWORD"})  # must not raise
+        self.assertFalse(self.env_path.exists())
+
+    def test_removes_the_matching_key_and_leaves_everything_else(self):
+        self.env_path.write_text(
+            "# top comment\nRC_URL=http://old\nRC_PASSWORD=hunter2\n\nMM_TOKEN=abc\n"
+        )
+        remove_env_vars(self.env_path, {"RC_PASSWORD"})
+        self.assertEqual(
+            self.env_path.read_text(),
+            "# top comment\nRC_URL=http://old\n\nMM_TOKEN=abc\n",
+        )
+
+    def test_removes_multiple_keys_at_once(self):
+        self.env_path.write_text("A=1\nB=2\nC=3\n")
+        remove_env_vars(self.env_path, {"A", "C"})
+        self.assertEqual(self.env_path.read_text(), "B=2\n")
+
+    def test_a_commented_out_key_is_not_removed(self):
+        self.env_path.write_text("# RC_PASSWORD=disabled\nRC_URL=http://old\n")
+        remove_env_vars(self.env_path, {"RC_PASSWORD"})
+        self.assertEqual(
+            self.env_path.read_text(), "# RC_PASSWORD=disabled\nRC_URL=http://old\n"
+        )
+
+    def test_no_op_when_key_is_not_present(self):
+        self.env_path.write_text("RC_URL=http://old\n")
+        original = self.env_path.read_text()
+        remove_env_vars(self.env_path, {"NOT_PRESENT"})
+        self.assertEqual(self.env_path.read_text(), original)
+
+    def test_restricts_permissions_to_0600_after_removal(self):
+        self.env_path.write_text("RC_PASSWORD=hunter2\n")
+        self.env_path.chmod(0o644)
+        remove_env_vars(self.env_path, {"RC_PASSWORD"})
+        self.assertEqual(oct(self.env_path.stat().st_mode & 0o777), "0o600")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_configtool_model.py
+++ b/tests/unit/test_configtool_model.py
@@ -470,9 +470,19 @@ class TestEditableConfigSave(_EditableConfigTestBase):
         original_text = path.read_text()
         cfg = EditableConfig.load(path)
         cfg.save()
-        backups = list(path.parent.glob("config.yaml.bak.*"))
+        backup_dir = path.parent / ".config-backups"
+        backups = list(backup_dir.glob("config.yaml.bak.*"))
         self.assertEqual(len(backups), 1)
         self.assertEqual(backups[0].read_text(), original_text)
+        # secrets-adjacent files: backup dir owner-only, backup file owner-only
+        self.assertEqual(oct(backup_dir.stat().st_mode)[-3:], "700")
+        self.assertEqual(oct(backups[0].stat().st_mode)[-3:], "600")
+
+    def test_save_chmods_config_yaml_to_owner_only(self):
+        path = self._write(self._valid_cfg_text())
+        cfg = EditableConfig.load(path)
+        cfg.save()
+        self.assertEqual(oct(path.stat().st_mode)[-3:], "600")
 
     def test_save_clears_the_dirty_flag(self):
         path = self._write(self._valid_cfg_text())
@@ -502,7 +512,7 @@ class TestEditableConfigSave(_EditableConfigTestBase):
         # no partial/temp/backup artifacts left behind either.
         self.assertEqual(path.read_text(), original_text)
         self.assertFalse((path.parent / "config.yaml.tmp").exists())
-        self.assertEqual(list(path.parent.glob("config.yaml.bak.*")), [])
+        self.assertFalse((path.parent / ".config-backups").exists())
         # dirty must stay set: the in-memory edit was never actually saved.
         self.assertTrue(cfg.dirty)
 

--- a/tests/unit/test_onboard.py
+++ b/tests/unit/test_onboard.py
@@ -735,8 +735,10 @@ class TestRunOnboard:
         ):
             run_onboard(repo_path=tmp_path)
 
-        # At least one .bak file should exist for config
-        bak_files = list(tmp_path.glob("config.yaml.bak.*"))
+        # At least one .bak file should exist for config, under the shared
+        # .config-backups/ directory (same convention as the config TUI's
+        # own EditableConfig.save()).
+        bak_files = list((tmp_path / ".config-backups").glob("config.yaml.bak.*"))
         assert len(bak_files) >= 1
         # New config was written
         new_config = yaml.safe_load(config_file.read_text())


### PR DESCRIPTION
## Summary
Completes decision 6 from the design doc — both pieces it needed (the merge-by-key `.env` writer, and the masked-secret `Input` widgets on `ConnectorDetailScreen`) already shipped in earlier PRs; this wires them together.

A "Store in .env" checkbox (default ON) now renders next to every secret field (`server.password`, `server.token`, `voice.secret`). On Save, if that field's value actually changed to a genuine new plaintext secret and the toggle is checked: a deterministic env var name is generated (`RC_HOME_PASSWORD` style), the value is written to `.env`, and the config field becomes `"${VAR}"`. A value that's already a `$VAR`/`${VAR}` reference is left completely alone — the user is pointing at an externally-managed var, not typing a new secret.

**Ordering subtlety caught by tests before it shipped wrong:** `.env` has to be written *before* `cfg.save()`, not after — `save()`'s own validator resolves every `${VAR}` placeholder immediately, so if the var isn't in `.env` yet, save() fails with "unresolved environment variable" before config.yaml is ever touched. Accepted trade-off from writing `.env` first: if `save()` still fails for an unrelated reason afterward, the value already written to `.env` is left there, unreferenced — harmless.

## Test plan
- [x] `uv run ruff check gateway/ tests/` — all checks passed
- [x] `uv run pytest tests/unit tests/integration -q` — 1963 passed (7 new tests covering the toggle default, the write-both-config-and-.env path, the var-name convention, the already-a-reference skip, the untouched-field no-op, and the write-failure ordering)