### PR TITLE
feat: make agent_defaults/watcher_defaults editable in the config TUI

### DIFF
--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -1065,11 +1065,12 @@ split-out insertion position).
 **Owner decision, splitting Phase 3 in two:** watcher CRUD (the `rooms:`
 group auto-split rule especially) is a lot of surface for one branch —
 scoped down to just `DefaultsScreen` editing for this pass, watcher CRUD
-deferred to its own future branch. A follow-up question about the
-new-watcher flow's connector→agent pre-suggestion (scan existing
-`watchers:` entries for the picked connector, pre-fill the agent Select
-with whichever agent they already use) was answered but not yet
-implemented, since it belongs to that deferred work.
+deferred to its own future branch. The new-watcher flow's connector→agent
+picker was also decided ahead of time, for whenever that branch happens:
+**plain Select dropdowns, no pre-suggestion** — the owner didn't see enough
+value in scanning existing `watchers:` entries to guess which agent a
+newly-picked connector "usually" pairs with, versus just two independent
+dropdowns with no cross-referencing logic to build, maintain, or test.
 
 ### `DefaultsScreen` made editable (shipped, `agent_defaults`/`watcher_defaults` only)
 

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -191,7 +191,7 @@ per-row status lookups.
 | `AgentDetailScreen` | pushed | **Shipped, all 3 modes.** view/edit/create. Form fields are a manually-maintained mirror of `$defs/agent` (not a runtime schema interpreter — safe since the schema is closed). Nothing is written to `document` until Save; Save diffs every field against its value-at-open and writes only what changed (docs/design/config-tool.md decision 2). Tool-list fields (`owner_allowed_tools`/`guest_allowed_tools`) are **shipped, editable** — two `ListView`s ('a' add via `PresetOrInlineModal`, 'x' remove), diffed the same way (against the MERGED value at open) but OUTSIDE the `FieldSpec` pipeline, since a list of preset-refs/inline-rule-dicts doesn't fit it. Escape with unsaved changes routes through `ConfirmModal` |
 | `ConnectorDetailScreen` | pushed | **Shipped, all 3 modes.** Per-type fixed field lists (tree editor deferred — see Part 3). `type`/`name` immutable in edit mode |
 | `WatcherDetailScreen` | pushed | **Shipped**, `mode="view"` only still — Phase 3. Already takes a `mode: Literal["view","edit","create"]` param — no screen-class rework needed when its turn comes |
-| `DefaultsScreen` | pushed | **Shipped** (view-only): shows blast radius per key |
+| `DefaultsScreen` | pushed | **Shipped, editable** for `agent_defaults`/`watcher_defaults` (reusing `AgentDetailScreen`'s own field list for the former; a small dedicated field list for the latter). `connector_defaults` stays view-only — deferred, see its own entry further down. Shows blast radius per key in both view and edit mode; Save blocks behind a `ConfirmModal` naming every entry that would see its effective value change, whenever that list is non-empty |
 | `ToolPresetsScreen` | pushed | **Shipped, editable.** Rule list + "used by" (checked against the MERGED per-agent tool list, not the raw entry — see gotchas below). 'a' adds a rule (`InlineToolRuleModal`) / 'd' removes the selected one — both save immediately (no separate edit mode; a bare list of rules has no provenance/blast-radius concept to protect). Deleting the WHOLE preset happens from `OverviewScreen`'s Tool Presets tab instead (`d` on the row), not from inside this screen |
 | `ConfirmModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — yes/no dialog, Cancel focused by default. Gates `ConfigToolApp.action_quit()` on `EditableConfig.dirty`, and `AgentDetailScreen`'s own per-screen form-dirty flag on Escape |
 | `MessageModal` | modal | **Shipped** (`gateway/configtool/modals.py`) — dismiss-only error/info dialog; replaces `notify(severity="error")` for anything worth blocking on (validation/save/delete failures) — user-reported that toasts vanish before a multi-line error can be read |
@@ -1061,6 +1061,111 @@ in-app since phase 2); `RoomListEditorScreen`; the `rooms:` split rule +
 group `ConfirmModal`; `DefaultsScreen` made editable (lowest churn, last).
 Golden-file YAML round-trip tests (key order, description retention,
 split-out insertion position).
+
+**Owner decision, splitting Phase 3 in two:** watcher CRUD (the `rooms:`
+group auto-split rule especially) is a lot of surface for one branch —
+scoped down to just `DefaultsScreen` editing for this pass, watcher CRUD
+deferred to its own future branch. A follow-up question about the
+new-watcher flow's connector→agent pre-suggestion (scan existing
+`watchers:` entries for the picked connector, pre-fill the agent Select
+with whichever agent they already use) was answered but not yet
+implemented, since it belongs to that deferred work.
+
+### `DefaultsScreen` made editable (shipped, `agent_defaults`/`watcher_defaults` only)
+
+- **`connector_defaults` stays view-only, on purpose.** Which fields are
+  actually safe to share across every connector TYPE is a real, separate
+  design question — `reply_in_thread`/`permission_reply_in_thread`/
+  `require_mention`/`filter_sender`/`timezone` are plausibly fine (generic,
+  type-agnostic), but `server:` almost certainly isn't (a rocketchat and a
+  mattermost connector sharing one server URL makes no sense), and
+  `gateway/config.py`'s forbidden-keys set for `connector_defaults` doesn't
+  block it structurally. Rather than bury that judgment call in this
+  change, `_field_specs()` returns `()` for `connector_defaults` and
+  `check_action()` hides 'e' entirely when there's nothing editable —
+  deferred to its own pass.
+- **`agent_defaults` reuses `AgentDetailScreen`'s own field list verbatim**
+  (`AGENT_FORM_FIELDS`/`AGENT_DATACLASS_DEFAULTS`, renamed from
+  `_ALL_FORM_FIELDS`/`_AGENT_DATACLASS_DEFAULTS` to drop the leading
+  underscore now that they're a genuine cross-module contract) — zero
+  drift risk, since every key is legal in `agent_defaults` too
+  (`gateway/config.py`'s forbidden-keys set for it is empty).
+  `watcher_defaults` gets its own small field list
+  (`WATCHER_DEFAULTS_FIELDS`): `online_notification`, `offline_notification`,
+  `context_inject_files`, `history_handoff.*` — everything EXCEPT
+  `name`/`room`/`rooms`/`session_id`, which the loader already forbids
+  there (each pins one specific watcher's identity).
+- **Does NOT extend `FormScreen`.** A `*_defaults:` block has no "entity" to
+  create or delete, and its own fields have no provenance concept (a
+  defaults block doesn't itself inherit from anywhere — decision 2's
+  explicit/inherited/explicit-suppressing distinction is about an ENTRY
+  relative to its defaults block). Stretching `FormScreen`'s vocabulary over
+  that shape would cost more than it saves. Reuses the free helper
+  functions in `form_common.py` directly (`FieldSpec`,
+  `read_widget_value`/`set_widget_value`/`apply_update`/`widget_id`/
+  `get_nested`/`list_to_text`) — only the field-row rendering (blast-radius
+  counts instead of `FormScreen`'s explicit/inherited provenance marker) is
+  new.
+- **Refactor enabling the above:** the shared `.entity-form`/`.field-row`/
+  `.field-label`/`.field-provenance`/`Input` CSS block moved from
+  `FormScreen.DEFAULT_CSS` to `DetailScreen.DEFAULT_CSS` (`base.py`, the
+  nearest common ancestor both reach) — Textual's CSS type selectors match
+  by ancestry, not literal class name, so `DetailScreen .field-row` covers
+  both `FormScreen` subclasses and `DefaultsScreen` without duplicating the
+  block. Purely a relocation — full configtool suite re-run green
+  immediately after, before anything else was built on top.
+- **Blast-radius confirm (decision 2, now actually gated on).**
+  `action_save()` computes, per changed/removed key, which entries do NOT
+  already override it — those are exactly the entries whose EFFECTIVE
+  value is about to change. If that list is non-empty for ANY changed key,
+  a `ConfirmModal` names every affected entry per key before the write
+  proceeds; a key that turns out to affect nobody (every entry already
+  overrides it, or nobody exists yet) needs no confirmation. `description`
+  is excluded from this check entirely — it's informational only, never
+  merged into any entry (`_extract_defaults_block` strips it before merge,
+  same as the real loader).
+- **Real bug found and fixed while building this, in code written THIS
+  session (not a legacy one):** the first draft's diffing compared each
+  field's stored "initial value" (which uses the dataclass-default
+  fallback — e.g. `[]` for an absent `context_inject_files`, `""` for an
+  absent `working_directory`-shaped default) directly against
+  `read_widget_value()`'s untouched readback, which normalizes any EMPTY
+  "str"/"list"-kind box to `None` regardless of whether the underlying
+  value was `None`, `""`, or `[]`. The mismatch (`None != []`, or
+  `None != ""`) made an UNTOUCHED field register as "changed" on every
+  single Save whenever its current effective value happened to be
+  empty — caught immediately by
+  `test_untouched_fields_are_not_rewritten` and 3 other tests that failed
+  with a spurious extra key contaminating the blast-radius confirm's
+  entry list. Fixed in `_compute_initial_values()`: normalize a "str"/
+  "list"-kind stored initial value to `None` whenever it's present but
+  falsy, matching what the widget would read back if left untouched.
+  Deliberately excludes "int": an explicit `0` renders as the text `"0"`
+  (non-empty) and reads back as `0` again — no mismatch there, and
+  normalizing it away would introduce the exact same false positive in
+  reverse. **This same latent pattern likely exists in `FormScreen`'s own
+  `_collect_field_updates()`/`_compute_initial_values()`** (`AgentDetailScreen`/
+  `ConnectorDetailScreen`) for any "str"-kind field whose dataclass default
+  is `""` (e.g. `working_directory`) — traced through and found HARMLESS
+  there in every case checked (the resulting spurious "update" always
+  collapses to `apply_update()` popping an already-absent key, a no-op),
+  but not exhaustively audited across every field/connector type. Flagged
+  to the user as a discovered-but-out-of-scope follow-up, not fixed here —
+  fixing it touches shipped, already-tested entity-CRUD code unrelated to
+  this change, and deserves its own regression test rather than a
+  drive-by edit.
+- Test coverage: `tests/unit/test_configtool_defaults_editable.py` — edit-
+  mode visibility (agent_defaults editable, connector_defaults's 'e' a
+  no-op), untouched-fields-write-nothing (the regression test for the bug
+  above), blast-radius confirm shown only for keys with affected entries
+  and naming them correctly, confirm-cancelled leaves the file untouched,
+  zero-affected-entries saves straight through with no confirm at all,
+  `ctrl+r` clears a field back to "no shared default" (pops the key),
+  invalid-int shows a `MessageModal`, watcher_defaults' own field list
+  works the same way, and Escape's dirty-discard-confirm (and the no-op
+  case when nothing changed).
+- `uv run pytest tests/unit tests/integration -q` — 2037 passed.
+  `uv run ruff check gateway/ tests/` — clean.
 
 ## Implementation notes from Phase 1 (for whoever builds phase 2/3)
 

--- a/docs/design/config-tool.md
+++ b/docs/design/config-tool.md
@@ -1168,6 +1168,59 @@ dropdowns with no cross-referencing logic to build, maintain, or test.
 - `uv run pytest tests/unit tests/integration -q` — 2037 passed.
   `uv run ruff check gateway/ tests/` — clean.
 
+### Direct edit-from-list on the Defaults tab (shipped, follow-up)
+
+User-reported: after the above shipped, "I don't see a way to edit the
+defaults." Turned into a lengthy cross-machine investigation (headless
+`Pilot`-driven diagnostics against the user's real config, a live
+pty-driven real-terminal repro using Python's stdlib `pty` module to
+sidestep an ancient, unreliable `screen` build on the remote host,
+checking for a stale Python interpreter/dependency mismatch) that all
+independently confirmed the feature worked correctly — the actual cause
+turned out to be screen/terminology confusion during testing: the
+screenshots shared were `connector_defaults` (correctly non-editable),
+`WatcherDetailScreen` (a different, still-view-only screen — Phase 3),
+and `AgentDetailScreen` (editing one specific agent *entity*, an
+unrelated, already-shipped feature) — never actually the
+`agent_defaults`/`watcher_defaults` row this feature is about. Once
+pointed at the right row, editing worked exactly as built.
+
+What *was* a real, reasonable gap the report surfaced: unlike
+Connectors/Agents/Tool Presets, the Defaults tab had no direct
+edit-from-list shortcut — every other list-page action already lets you
+press 'e'/'d' on the row under the cursor without an Enter-first detour
+into a read-only view (`OverviewScreen.action_edit_row()`/
+`action_delete_row()`), but Defaults still required Enter → view → 'e'.
+Added for consistency:
+
+- `DefaultsScreen.__init__` now supports being constructed directly in
+  `mode="edit"` (calling `_compute_initial_values()` immediately, the same
+  way `AgentDetailScreen.__init__` already does) rather than only via the
+  `action_edit()` view→edit transition.
+- A new `_started_in_edit_mode` flag (mirroring `FormScreen`'s own field
+  of the same name) makes `action_back()` — and the "nothing changed"
+  branch of `action_save()` — pop straight back to the list instead of
+  falling back to a view-mode rendering the user never asked to see, for
+  a screen that skipped view mode entirely.
+- `OverviewScreen.check_action()`'s `edit_row` now includes `tab-defaults`
+  unconditionally (not gated per-row — check_action isn't re-evaluated on
+  every cursor movement within a table, only on binding-chain-changing
+  events like a screen push/pop, so a per-row-accurate footer hint isn't
+  cheaply achievable here); `action_edit_row()`'s new `tab-defaults` branch
+  checks the specific row via a new `is_editable_kind()` helper
+  (`defaults.py`) and notifies "'connector_defaults' has nothing editable
+  yet" rather than opening a broken/empty edit form — the same
+  notify-instead-of-hiding precedent `action_new_entity()` already uses
+  for tabs it doesn't support.
+- Test coverage: `TestDirectEditFromList` in
+  `tests/unit/test_configtool_defaults_editable.py` — 'e' on
+  agent_defaults opens edit mode directly with fields prefilled; 'e' on
+  connector_defaults notifies instead of navigating; Escape/an unchanged
+  Save both pop straight to the list (not a view-mode fallback); a real
+  change still shows the blast-radius confirm and persists correctly.
+- `uv run pytest tests/unit tests/integration -q` — 2042 passed.
+  `uv run ruff check gateway/ tests/` — clean.
+
 ## Implementation notes from Phase 1 (for whoever builds phase 2/3)
 
 - **Never name a Screen/Widget method `_render`** — it collides with

--- a/gateway/configtool/screens/agent_detail.py
+++ b/gateway/configtool/screens/agent_detail.py
@@ -82,8 +82,10 @@ _KNOWN_FIELDS = [
 # config.py) — used ONLY to prefill the form with the true effective value
 # when a field is set by neither the entry nor agent_defaults. Unlike view
 # mode (which simply omits a line for an absent field), a form editing that
-# field needs to show what it would actually evaluate to right now.
-_AGENT_DATACLASS_DEFAULTS: dict[str, object] = {
+# field needs to show what it would actually evaluate to right now. Public
+# (no leading underscore): DefaultsScreen reuses this dict too, as the
+# "no shared default set" fallback value for editing agent_defaults itself.
+AGENT_DATACLASS_DEFAULTS: dict[str, object] = {
     "type": "claude",
     "command": "claude",
     "working_directory": "",
@@ -112,7 +114,12 @@ _PERMISSIONS_FORM_FIELDS: list[FieldSpec] = [
     FieldSpec("permissions.timeout", "int", "Permissions timeout (seconds)"),
     FieldSpec("permissions.skip_owner_approval", "bool", "Skip owner approval"),
 ]
-_ALL_FORM_FIELDS = (*_FORM_FIELDS, *_PERMISSIONS_FORM_FIELDS)
+# Public (no leading underscore): also reused by DefaultsScreen to edit
+# agent_defaults with the exact same field set, schema-derived-so-zero-
+# drift-risk reasoning applies just as much there — every one of these keys
+# is legal in agent_defaults too (gateway/config.py's forbidden-keys set for
+# agent_defaults is empty).
+AGENT_FORM_FIELDS = (*_FORM_FIELDS, *_PERMISSIONS_FORM_FIELDS)
 
 
 def _resolve_working_directory(config_path: Path, raw_value: str) -> Path:
@@ -208,13 +215,13 @@ class AgentDetailScreen(FormScreen):
         self._tool_list_state()
 
     def _field_specs(self) -> tuple[FieldSpec, ...]:
-        return _ALL_FORM_FIELDS
+        return AGENT_FORM_FIELDS
 
     def _defaults_kind(self) -> str:
         return "agent_defaults"
 
     def _dataclass_defaults(self) -> dict[str, object]:
-        return _AGENT_DATACLASS_DEFAULTS
+        return AGENT_DATACLASS_DEFAULTS
 
     # ── tool-list editor (owner_allowed_tools / guest_allowed_tools) ────────
 

--- a/gateway/configtool/screens/base.py
+++ b/gateway/configtool/screens/base.py
@@ -28,6 +28,46 @@ class DetailScreen(Screen):
 
     BODY_ID: str = "detail-body"
 
+    # Field-row layout shared by every screen with an actual edit FORM
+    # (FormScreen — AgentDetailScreen/ConnectorDetailScreen — and
+    # DefaultsScreen, which intentionally does NOT extend FormScreen — see
+    # its own module docstring for why). Lives here, on the common ancestor
+    # both reach, rather than duplicated in each: Textual's CSS type
+    # selectors below match by ancestry, not literal class name, so
+    # `DetailScreen .field-row` applies equally inside a FormScreen
+    # subclass's composed tree and a DefaultsScreen's.
+    DEFAULT_CSS = """
+    DetailScreen .entity-form {
+        padding: 1 2;
+    }
+    DetailScreen .field-row {
+        height: auto;
+        margin-bottom: 1;
+    }
+    DetailScreen .field-label {
+        width: 30;
+        padding-top: 1;
+    }
+    DetailScreen .field-provenance {
+        padding-top: 1;
+        margin-left: 2;
+        width: auto;
+    }
+    DetailScreen Checkbox {
+        width: auto;
+    }
+    /* Input's own DEFAULT_CSS is `width: 100%` — inside a Horizontal
+    field-row, that claims the ENTIRE row's width, pushing every sibling
+    that comes after it (a "Store in .env" Checkbox, a provenance/blast-
+    radius marker) off past the terminal's right edge. `1fr` matches
+    Select's own DEFAULT_CSS (which never had this problem) — share the
+    row's remaining space with fixed/auto-width siblings instead of
+    claiming all of it. */
+    DetailScreen .field-row Input {
+        width: 1fr;
+    }
+    """
+
     def compose(self) -> ComposeResult:
         yield Header()
         yield VerticalScroll(Static(self._body_text(), id=self.BODY_ID))

--- a/gateway/configtool/screens/defaults.py
+++ b/gateway/configtool/screens/defaults.py
@@ -1,19 +1,75 @@
-"""DefaultsScreen — view (and, in a later phase, edit) one `*_defaults:`
-block.
+"""DefaultsScreen — view and edit one `*_defaults:` block.
 
-Phase 1 shows the block's own contents plus how many connector/agent/watcher
+Shows the block's own contents plus how many connector/agent/watcher
 entries currently inherit vs. override each of its keys ("blast radius") —
-per docs/design/config-tool.md, editing a shared default must show this
-before commit; Phase 1 displays it, a later phase gates the edit on it.
+per docs/design/config-tool.md decision 2, editing a shared default must
+show this BEFORE commit: action_save() below computes, for every key that's
+about to change, which entries would see their EFFECTIVE value actually
+change as a result, and blocks the write behind a ConfirmModal listing them
+if that list is non-empty. A changed key that happens to affect nobody
+(every entry already overrides it, or it's brand new and nothing existed
+before) needs no confirmation at all.
+
+Editable for agent_defaults and watcher_defaults only. connector_defaults
+stays view-only: which fields are actually safe to share across every
+connector TYPE (reply_in_thread/permission_reply_in_thread and friends,
+almost certainly NOT `server:` — a rocketchat and a mattermost connector
+have no business sharing one server URL) is a real, separate design
+question that deserves its own pass, not a subset rushed into this one.
+check_action() hides 'e' entirely when there is nothing editable for the
+active kind (_field_specs() returns empty).
+
+agent_defaults reuses AgentDetailScreen's own AGENT_FORM_FIELDS /
+AGENT_DATACLASS_DEFAULTS verbatim — zero drift risk, the same reasoning
+that module documents for editing a single agent entry applies identically
+to editing the shared block every agent entry merges against (every key in
+that list is legal in agent_defaults too — gateway/config.py's forbidden-
+keys set for agent_defaults is empty). watcher_defaults gets its own small
+field list below: gateway/config.py forbids {name, room, rooms,
+session_id} there, since each of those pins one SPECIFIC watcher's
+identity and has no business in a block every watcher merges against.
+
+This does NOT extend FormScreen: a `*_defaults:` block has no "entity" to
+create or delete (an absent block is just an empty block —
+`_extract_defaults_block` returns `{}` rather than raising), and its own
+fields have no provenance concept (a defaults block does not itself
+inherit from anywhere — decision 2's "explicit / inherited /
+explicit-suppressing" only applies to an ENTRY relative to its defaults
+block). FormScreen's machinery is built around exactly those two things;
+reusing it here would mean stretching its vocabulary over a shape that
+doesn't fit. The free helper functions in form_common.py (`FieldSpec`,
+`read_widget_value`/`set_widget_value`/`apply_update`/`widget_id`/
+`get_nested`/`list_to_text`) are reused directly — only the field-row
+rendering (which needs blast-radius counts, not FormScreen's explicit/
+inherited provenance marker) is new. The shared `.entity-form`/`.field-row`
+CSS layout lives on `DetailScreen` (base.py), the nearest common ancestor,
+so this screen gets the identical layout without duplicating it.
 """
 
 from __future__ import annotations
 
 from typing import Literal
 
+from textual import work
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, VerticalScroll
+from textual.widgets import Checkbox, Footer, Header, Input, Select, Static
+
 from ..formatting import format_value
+from ..modals import ConfirmModal, MessageModal
 from ..model import EditableConfig
+from .agent_detail import AGENT_DATACLASS_DEFAULTS, AGENT_FORM_FIELDS
 from .base import DetailScreen
+from .form_common import (
+    FieldSpec,
+    apply_update,
+    get_nested,
+    list_to_text,
+    read_widget_value,
+    set_widget_value,
+    widget_id,
+)
 
 _ENTRY_ACCESSOR = {
     "connector_defaults": lambda cfg: cfg.connectors_raw,
@@ -21,15 +77,111 @@ _ENTRY_ACCESSOR = {
     "watcher_defaults": lambda cfg: cfg.watchers_raw,
 }
 
+# watcher_defaults' own field list — see module docstring for why these
+# specific keys (gateway/config.py's forbidden set for this block is
+# {name, room, rooms, session_id}).
+WATCHER_DEFAULTS_FIELDS: tuple[FieldSpec, ...] = (
+    FieldSpec("online_notification", "str", "Online notification"),
+    FieldSpec("offline_notification", "str", "Offline notification"),
+    FieldSpec("context_inject_files", "list", "Context inject files (comma-separated)"),
+    FieldSpec("history_handoff.enabled", "bool", "History handoff enabled"),
+    FieldSpec("history_handoff.fetch_count", "int", "History handoff fetch count"),
+    FieldSpec("history_handoff.verbatim_tail", "int", "History handoff verbatim tail"),
+)
+# Mirrors gateway/config.py's OWN `.get(key, X)` calls at the watcher-
+# parsing site (NOT HistoryHandoffConfig's dataclass field defaults, which
+# have already drifted from them once — the dataclass itself defaults
+# history_handoff.enabled to True, but the loader's own
+# `hh_raw.get("enabled", False)` actually applies False whenever the key is
+# absent). Matching the LOADER, not the dataclass, is what makes this form
+# an honest "what would this evaluate to right now" preview.
+WATCHER_DEFAULTS_DATACLASS_DEFAULTS: dict[str, object] = {
+    "online_notification": None,
+    "offline_notification": None,
+    "context_inject_files": [],
+    "history_handoff.enabled": False,
+    "history_handoff.fetch_count": 50,
+    "history_handoff.verbatim_tail": 15,
+}
+
+# kind -> (field specs, "no shared default set" fallback values). Absent
+# from this dict (connector_defaults) means _field_specs() returns ()  —
+# nothing to edit, check_action() hides 'e'.
+_EDITABLE_KINDS: dict[str, tuple[tuple[FieldSpec, ...], dict[str, object]]] = {
+    "agent_defaults": (AGENT_FORM_FIELDS, AGENT_DATACLASS_DEFAULTS),
+    "watcher_defaults": (WATCHER_DEFAULTS_FIELDS, WATCHER_DEFAULTS_DATACLASS_DEFAULTS),
+}
+
+
+def _labeled_entries(cfg: EditableConfig, kind: str) -> list[tuple[str, dict]]:
+    """Like _ENTRY_ACCESSOR, but (label, raw_entry) pairs — used only by the
+    edit flow's blast-radius CONFIRM dialog, which needs to NAME affected
+    entries, not just count them. Labels are best-effort, human-readable
+    identifiers (not the real resolved watcher name — `_auto_watcher_name()`
+    needs connector resolution this has no reason to duplicate here); good
+    enough for "here's roughly what this affects," never used for lookup."""
+    if kind == "connector_defaults":
+        return [(e.get("name") or "?", e) for e in cfg.connectors_raw]
+    if kind == "agent_defaults":
+        return list(cfg.agents_raw.items())
+    if kind == "watcher_defaults":
+        return [
+            (w.get("name") or f"{w.get('connector', '?')}/{w.get('room') or w.get('rooms')}", w)
+            for w in cfg.watchers_raw
+        ]
+    return []
+
 
 class DefaultsScreen(DetailScreen):
     BODY_ID = "defaults-detail-body"
+
+    BINDINGS = [
+        Binding("e", "edit", "Edit", show=True),
+        Binding("ctrl+s", "save", "Save", show=True),
+        Binding("ctrl+r", "reset_field", "Clear field", show=True),
+        Binding("tab", "app.focus_next", "Next field", show=True),
+    ]
 
     def __init__(self, cfg: EditableConfig, kind: str, mode: Literal["view", "edit"] = "view"):
         super().__init__()
         self.cfg = cfg
         self.kind = kind
         self.mode = mode
+        self._initial_values: dict[str, object] = {}
+        self._reset_keys: dict[str, object] = {}
+        self._form_dirty = False
+        self._last_field_error: str | None = None
+        self._populating = False
+
+    def _field_specs(self) -> tuple[FieldSpec, ...]:
+        return _EDITABLE_KINDS.get(self.kind, ((), {}))[0]
+
+    def _dataclass_defaults(self) -> dict[str, object]:
+        return _EDITABLE_KINDS.get(self.kind, ((), {}))[1]
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        if action == "edit":
+            return self.mode == "view" and bool(self._field_specs())
+        if action in ("save", "reset_field"):
+            return self.mode != "view"
+        return True
+
+    def on_mount(self) -> None:
+        if self._populating:
+            self.call_after_refresh(self._stop_populating)
+
+    def _stop_populating(self) -> None:
+        self._populating = False
+
+    # ── view mode ────────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        yield Header()
+        if self.mode == "view":
+            yield VerticalScroll(Static(self._body_text(), id=self.BODY_ID))
+        else:
+            yield from self._compose_form()
+        yield Footer()
 
     def _body_text(self) -> str:
         entries = _ENTRY_ACCESSOR[self.kind](self.cfg)
@@ -60,3 +212,234 @@ class DefaultsScreen(DetailScreen):
             )
 
         return "\n".join(lines)
+
+    # ── edit mode ────────────────────────────────────────────────────────────
+
+    def _compute_initial_values(self) -> None:
+        self._reset_keys = {}
+        block = self.cfg.document.get(self.kind) or {}
+        dataclass_defaults = self._dataclass_defaults()
+        for spec in self._field_specs():
+            value = get_nested(block, spec.key)
+            if value is None:
+                value = dataclass_defaults.get(spec.key)
+            # read_widget_value() normalizes an untouched "str"/"list"-kind
+            # box that renders as EMPTY TEXT back to None — text_to_list("")
+            # or None for list, text.strip() or None for str — regardless of
+            # whether the original value was None, "", or []. Without this
+            # same normalization here, a field whose current effective value
+            # is "" or [] (explicit, or absent and defaulting to one of
+            # those) would store that falsy-but-not-None value as its
+            # "initial" value, compare unequal to the widget's real
+            # untouched readback of None, and look spuriously "changed" on
+            # every Save even though the user never touched it —
+            # false-positive blast-radius confirms for a field nobody
+            # actually edited. "int" is deliberately excluded: an explicit
+            # `0` renders as the text "0" (non-empty), which reads back as
+            # the int `0` again — no mismatch there, and normalizing it away
+            # would introduce the exact same false positive in reverse.
+            if spec.kind in ("str", "list") and value is not None and not value:
+                value = None
+            self._initial_values[spec.key] = value
+        self._initial_values["description"] = block.get("description")
+
+    def _compose_form(self) -> ComposeResult:
+        with VerticalScroll(classes="entity-form", can_focus=False):
+            yield Static(f"[bold]{self.kind}[/bold]  (editing)")
+            with Horizontal(classes="field-row"):
+                yield Static("Description", classes="field-label")
+                yield Input(
+                    id="field-description",
+                    value=self._initial_values.get("description") or "",
+                )
+            for spec in self._field_specs():
+                yield from self._compose_field_row(spec)
+
+    def _compose_field_row(self, spec: FieldSpec) -> ComposeResult:
+        initial = self._initial_values.get(spec.key)
+        entries = _ENTRY_ACCESSOR[self.kind](self.cfg)
+        top_key = spec.key.split(".", 1)[0]
+        inherit_count = sum(1 for e in entries if top_key not in e)
+        blast_text = (
+            f"[dim]({inherit_count} inherit, {len(entries) - inherit_count} override)[/dim]"
+        )
+        with Horizontal(classes="field-row"):
+            yield Static(spec.label, classes="field-label")
+            if spec.kind == "bool":
+                widget = Checkbox(value=bool(initial), id=widget_id(spec.key))
+            elif spec.kind == "enum":
+                options = spec.options or ()
+                widget = Select(
+                    [(o, o) for o in options],
+                    value=initial if initial in options else (options or (None,))[0],
+                    allow_blank=False,
+                    id=widget_id(spec.key),
+                )
+            elif spec.kind == "list":
+                widget = Input(value=list_to_text(initial), id=widget_id(spec.key))
+            else:
+                widget = Input(value="" if initial is None else str(initial), id=widget_id(spec.key))
+            widget.field_key = spec.key
+            yield widget
+            yield Static(blast_text, classes="field-provenance")
+
+    def on_input_changed(self, event: Input.Changed) -> None:
+        if self._populating:
+            return
+        self._form_dirty = True
+
+    def on_checkbox_changed(self, event: Checkbox.Changed) -> None:
+        if self._populating:
+            return
+        self._form_dirty = True
+
+    def on_select_changed(self, event: Select.Changed) -> None:
+        if self._populating:
+            return
+        self._form_dirty = True
+
+    # ── navigation ───────────────────────────────────────────────────────────
+
+    async def action_edit(self) -> None:
+        if self.mode != "view" or not self._field_specs():
+            return
+        self.mode = "edit"
+        self._form_dirty = False
+        self._compute_initial_values()
+        self._populating = True
+        await self.recompose()
+        self.call_after_refresh(self._stop_populating)
+        self.refresh_bindings()
+
+    @work
+    async def action_back(self) -> None:
+        if self.mode == "view":
+            self.app.pop_screen()
+            return
+        if self._form_dirty:
+            discard = await self.app.push_screen_wait(
+                ConfirmModal(
+                    f"Discard unsaved changes to {self.kind}?",
+                    confirm_label="Discard",
+                )
+            )
+            if not discard:
+                return
+        self.mode = "view"
+        self._form_dirty = False
+        await self.recompose()
+        self.refresh_bindings()
+
+    def action_reset_field(self) -> None:
+        """ctrl+r: clear the FOCUSED field back to "no shared default set"
+        (pop it from the block on Save) — the equivalent, for a *_defaults
+        block itself, of FormScreen's own ctrl+r "revert to inherited": a
+        defaults block has no further parent to revert TO, so the target
+        state here is simply absent. A no-op if focus isn't on a resettable
+        field (the Description Input isn't tagged with `field_key`)."""
+        widget = self.focused
+        field_key = getattr(widget, "field_key", None)
+        if field_key is None:
+            return
+        spec = next((s for s in self._field_specs() if s.key == field_key), None)
+        if spec is None:
+            return
+        value = self._dataclass_defaults().get(spec.key)
+        set_widget_value(spec, widget, value)
+        self._reset_keys[spec.key] = read_widget_value(spec, widget)
+        self._form_dirty = True
+        self.notify(f"{spec.label}: will clear this shared default on Save.", severity="information")
+
+    # ── save ─────────────────────────────────────────────────────────────────
+
+    def _collect_updates(self) -> dict[str, object] | None:
+        self._last_field_error = None
+        updates: dict[str, object] = {}
+        for spec in self._field_specs():
+            widget = self.query_one("#" + widget_id(spec.key))
+            try:
+                new_value = read_widget_value(spec, widget)
+            except ValueError as exc:
+                self._last_field_error = str(exc)
+                return None
+            if spec.key in self._reset_keys and new_value == self._reset_keys[spec.key]:
+                updates[spec.key] = None
+                continue
+            if new_value != self._initial_values.get(spec.key):
+                updates[spec.key] = new_value
+
+        desc_widget = self.query_one("#field-description", Input)
+        new_desc = desc_widget.value.strip() or None
+        if new_desc != self._initial_values.get("description"):
+            updates["description"] = new_desc
+        return updates
+
+    @work
+    async def action_save(self) -> None:
+        if self.mode != "edit":
+            return
+
+        updates = self._collect_updates()
+        if updates is None:
+            await self.app.push_screen_wait(
+                MessageModal(self._last_field_error or "Invalid field.", title="Could not save")
+            )
+            return
+        if not updates:
+            self.mode = "view"
+            await self.recompose()
+            self.refresh_bindings()
+            return
+
+        # Blast-radius confirm (docs/design/config-tool.md decision 2): a
+        # changed/removed key only needs confirming if it actually affects
+        # an entry that doesn't already override it — "description" is
+        # informational only and is never merged into any entry, so it's
+        # excluded here regardless of how many entries exist.
+        entries = _labeled_entries(self.cfg, self.kind)
+        affected: dict[str, list[str]] = {}
+        for key in updates:
+            if key == "description":
+                continue
+            names = [name for name, e in entries if key not in e]
+            if names:
+                affected[key] = names
+
+        if affected:
+            lines = [f"{key}: {', '.join(names)}" for key, names in affected.items()]
+            confirmed = await self.app.push_screen_wait(
+                ConfirmModal(
+                    "This changes the EFFECTIVE value for —\n" + "\n".join(lines) +
+                    "\n\nContinue?",
+                    confirm_label="Save",
+                )
+            )
+            if not confirmed:
+                return
+
+        original_block = self.cfg.document.get(self.kind) or {}
+        target_block = dict(original_block)
+        for key, value in updates.items():
+            apply_update(target_block, key, value)
+
+        had_block = self.kind in self.cfg.document
+        if target_block:
+            self.cfg.document[self.kind] = target_block
+        else:
+            self.cfg.document.pop(self.kind, None)
+        self.cfg.mark_dirty()
+
+        try:
+            self.cfg.save()
+        except (ValueError, FileNotFoundError) as exc:
+            if had_block:
+                self.cfg.document[self.kind] = original_block
+            else:
+                self.cfg.document.pop(self.kind, None)
+            await self.app.push_screen_wait(MessageModal(str(exc), title="Could not save"))
+            return
+
+        self.app.pop_screen()
+        app = self.app
+        app.notify(f"Saved {self.kind}.", severity="information")
+        app.reload_config()

--- a/gateway/configtool/screens/defaults.py
+++ b/gateway/configtool/screens/defaults.py
@@ -113,6 +113,15 @@ _EDITABLE_KINDS: dict[str, tuple[tuple[FieldSpec, ...], dict[str, object]]] = {
 }
 
 
+def is_editable_kind(kind: str) -> bool:
+    """Whether `kind` has anything to edit at all — used by OverviewScreen's
+    direct-edit-from-list shortcut (action_edit_row()) to decide whether to
+    push straight into edit mode or just notify, without needing to
+    construct a DefaultsScreen (or reach into `_EDITABLE_KINDS` itself) to
+    find out."""
+    return bool(_EDITABLE_KINDS.get(kind, ((), {}))[0])
+
+
 def _labeled_entries(cfg: EditableConfig, kind: str) -> list[tuple[str, dict]]:
     """Like _ENTRY_ACCESSOR, but (label, raw_entry) pairs — used only by the
     edit flow's blast-radius CONFIRM dialog, which needs to NAME affected
@@ -152,6 +161,16 @@ class DefaultsScreen(DetailScreen):
         self._form_dirty = False
         self._last_field_error: str | None = None
         self._populating = False
+        # True when pushed ALREADY in edit mode (OverviewScreen's direct-
+        # edit-from-list shortcut — action_edit_row()) rather than reached
+        # via view mode's own 'e' key. Consulted by action_back(): a screen
+        # that skipped view mode entirely has no view state to "fall back"
+        # to — Escape must pop straight back to the list, matching
+        # FormScreen's own `_started_in_edit_mode` (form_common.py).
+        self._started_in_edit_mode = False
+        if self.mode != "view":
+            self._compute_initial_values()
+            self._populating = True
 
     def _field_specs(self) -> tuple[FieldSpec, ...]:
         return _EDITABLE_KINDS.get(self.kind, ((), {}))[0]
@@ -325,6 +344,13 @@ class DefaultsScreen(DetailScreen):
             )
             if not discard:
                 return
+        if self._started_in_edit_mode:
+            # This screen skipped view mode entirely (pushed straight into
+            # edit by OverviewScreen's direct-edit shortcut) — there is no
+            # view rendering to "fall back" to, so Escape must return to
+            # the list, the same as every other exit from that shortcut.
+            self.app.pop_screen()
+            return
         self.mode = "view"
         self._form_dirty = False
         await self.recompose()
@@ -386,6 +412,11 @@ class DefaultsScreen(DetailScreen):
             )
             return
         if not updates:
+            if self._started_in_edit_mode:
+                # No view state to fall back to (see action_back()) --
+                # nothing changed, so just return to the list directly.
+                self.app.pop_screen()
+                return
             self.mode = "view"
             await self.recompose()
             self.refresh_bindings()

--- a/gateway/configtool/screens/form_common.py
+++ b/gateway/configtool/screens/form_common.py
@@ -258,42 +258,12 @@ class FormScreen(DetailScreen):
         Binding("ctrl+t", "toggle_password_visibility", "Show/hide password", show=True),
     ]
 
-    DEFAULT_CSS = """
-    FormScreen .entity-form {
-        padding: 1 2;
-    }
-    FormScreen .field-row {
-        height: auto;
-        margin-bottom: 1;
-    }
-    FormScreen .field-label {
-        width: 30;
-        padding-top: 1;
-    }
-    FormScreen .field-provenance {
-        padding-top: 1;
-        margin-left: 2;
-        width: auto;
-    }
-    FormScreen Checkbox {
-        width: auto;
-    }
-    /* Input's own DEFAULT_CSS is `width: 100%` — inside a Horizontal
-    field-row, that claims the ENTIRE row's width, pushing every sibling
-    that comes after it (the "Store in .env" Checkbox, the provenance
-    marker) off past the terminal's right edge. Confirmed as the actual,
-    user-reported cause of a "missing" checkbox — it was rendering, just
-    off-screen; the SAME bug had already been silently hiding every
-    provenance marker on every field row since Phase 2's agent form
-    shipped (a dim decorative label going unnoticed off-screen is a lot
-    less obvious than an interactive control). `1fr` matches Select's own
-    DEFAULT_CSS (which never had this problem) — share the row's
-    remaining space with fixed/auto-width siblings instead of claiming
-    all of it. */
-    FormScreen .field-row Input {
-        width: 1fr;
-    }
-    """
+    # Field-row layout (.entity-form/.field-row/.field-label/.field-provenance/
+    # Checkbox/Input widths) moved to DetailScreen.DEFAULT_CSS (base.py) once
+    # DefaultsScreen needed the exact same layout without extending
+    # FormScreen — Textual's CSS type selectors match by ancestry, so
+    # `DetailScreen .field-row` (the common ancestor) covers both without
+    # duplicating the block here.
 
     def __init__(self):
         super().__init__()

--- a/gateway/configtool/screens/overview.py
+++ b/gateway/configtool/screens/overview.py
@@ -3,17 +3,21 @@
 Five tabs: Connectors, Agents, Watchers, Defaults, Tool Presets — the latter
 two are first-class per docs/design/config-tool.md (shared resources, not
 footnotes). Selecting a row (Enter) pushes a *DetailScreen in view mode.
-'e'/'d' on the Connectors/Agents tabs act directly on the row under the
-cursor — edit opens straight into edit mode (no view detour), delete runs
-the same confirm/referencing-watcher-check/save flow FormScreen.
-action_delete() already has, without requiring a screen push first (user-
-reported: 'e' used to be shadowed by this screen's OWN 'e' binding for the
-$EDITOR escape hatch — see action_edit_config() below, now on ctrl+e). 'n'
+'e'/'d' on the Connectors/Agents/Defaults tabs act directly on the row
+under the cursor — edit opens straight into edit mode (no view detour;
+Defaults added once agent_defaults/watcher_defaults editing shipped —
+user-requested, for the same consistency the other tabs already have;
+connector_defaults specifically has nothing editable yet, so 'e' there
+just notifies rather than opening an empty form), delete runs the same
+confirm/referencing-watcher-check/save flow FormScreen.action_delete()
+already has, without requiring a screen push first (user-reported: 'e'
+used to be shadowed by this screen's OWN 'e' binding for the $EDITOR
+escape hatch — see action_edit_config() below, now on ctrl+e). 'n'
 (new_entity) creates an entry on the active tab — Agents/Connectors/Tool
-Presets support it; Watchers/Defaults still notify rather than doing
-nothing or crashing (Phase 3). 'd' additionally deletes the whole preset
-under the cursor on the Tool Presets tab (there's no separate "edit mode"
-to give 'e' a meaning there — see tool_presets.py).
+Presets support it; Watchers still notifies rather than doing nothing or
+crashing (Phase 3). 'd' additionally deletes the whole preset under the
+cursor on the Tool Presets tab (there's no separate "edit mode" to give
+'e' a meaning there — see tool_presets.py).
 """
 
 from __future__ import annotations
@@ -33,7 +37,7 @@ from ..modals import ConfirmModal, MessageModal, TextPromptModal, TypePickerModa
 from ..model import StatusIndex
 from .agent_detail import AgentDetailScreen
 from .connector_detail import CONNECTOR_TYPES, ConnectorDetailScreen
-from .defaults import DefaultsScreen
+from .defaults import DefaultsScreen, is_editable_kind
 from .form_common import find_agents_referencing_preset
 from .tool_presets import ToolPresetsScreen
 from .watcher_detail import WatcherDetailScreen
@@ -166,15 +170,21 @@ class OverviewScreen(Screen):
     # ── Actions ──────────────────────────────────────────────────────────────
 
     def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
-        """Hide 'Edit' from the footer on tabs that don't support it
-        (Watchers/Defaults — Phase 3; Tool Presets has no separate "edit
-        mode" to enter, see tool_presets.py). 'Delete' additionally supports
-        Tool Presets (deletes the whole preset, not a rule — see
-        action_delete_row() below) so the footer never
+        """Hide 'Edit' from the footer on tabs that don't support it at all
+        (Watchers — Phase 3; Tool Presets has no separate "edit mode" to
+        enter, see tool_presets.py). Defaults is included even though
+        connector_defaults specifically has nothing to edit — same
+        notify-instead-of-hiding precedent action_new_entity() already uses
+        for tabs it doesn't support at all (user-requested, matching the
+        Connectors/Agents/Tool-Presets convention for consistency, once
+        agent_defaults/watcher_defaults editing shipped — see
+        action_edit_row() below for the per-row check). 'Delete'
+        additionally supports Tool Presets (deletes the whole preset, not a
+        rule — see action_delete_row() below) so the footer never
         advertises a key that would just notify "not supported yet"."""
         active_tab = self.query_one(TabbedContent).active
         if action == "edit_row":
-            return active_tab in ("tab-connectors", "tab-agents")
+            return active_tab in ("tab-connectors", "tab-agents", "tab-defaults")
         if action == "delete_row":
             return active_tab in ("tab-connectors", "tab-agents", "tab-presets")
         return True
@@ -234,6 +244,18 @@ class OverviewScreen(Screen):
             if entry is None:
                 return
             screen = AgentDetailScreen(cfg, key, entry, mode="edit")
+        elif active_tab == "tab-defaults":
+            key = self._cursor_row_key("defaults-table")
+            if key is None:
+                return
+            if not is_editable_kind(key):
+                # connector_defaults specifically — nothing editable yet
+                # (see defaults.py's module docstring). Notify rather than
+                # silently doing nothing or crashing, same precedent
+                # action_new_entity() already uses for unsupported tabs.
+                self.notify(f"'{key}' has nothing editable yet.", severity="warning")
+                return
+            screen = DefaultsScreen(cfg, key, mode="edit")
         else:
             return
         screen._started_in_edit_mode = True

--- a/tests/unit/test_configtool_defaults_editable.py
+++ b/tests/unit/test_configtool_defaults_editable.py
@@ -1,0 +1,309 @@
+"""Pilot-based tests for DefaultsScreen's edit mode — making agent_defaults/
+watcher_defaults editable (docs/design/config-tool.md decision 2:
+"editing a shared default must show its blast radius before commit").
+
+connector_defaults intentionally stays view-only (see defaults.py's module
+docstring for why) — covered by the existing view-mode test in
+test_configtool_app.py, not duplicated here.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+import yaml
+from textual.widgets import DataTable, Input, Select, Static
+
+from gateway.configtool.app import ConfigToolApp
+from gateway.configtool.modals import ConfirmModal, MessageModal
+from gateway.configtool.screens.defaults import DefaultsScreen
+from gateway.configtool.screens.overview import OverviewScreen
+
+
+def _write_config(tmp_path: Path, yaml_text: str) -> str:
+    path = tmp_path / "config.yaml"
+    path.write_text(textwrap.dedent(yaml_text))
+    return str(path)
+
+
+@pytest.fixture
+def work_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "work"
+    d.mkdir()
+    return d
+
+
+def _config_text(work_dir: Path) -> str:
+    """agent-a inherits agent_defaults.timeout (not overridden); agent-b
+    overrides it. w1 inherits watcher_defaults.online_notification; w2
+    overrides it. Gives every test a mix of affected/unaffected entries to
+    exercise the blast-radius confirm."""
+    return f"""\
+        agent_defaults:
+          type: claude
+          timeout: 1800
+        watcher_defaults:
+          online_notification: "hi"
+        agents:
+          agent-a:
+            working_directory: {work_dir}
+          agent-b:
+            working_directory: {work_dir}
+            timeout: 60
+        connectors:
+          - name: rc
+            type: rocketchat
+            server: {{url: "http://localhost:3000", username: bot, password: pw}}
+        watchers:
+          - name: w1
+            connector: rc
+            agent: agent-a
+            room: general
+          - name: w2
+            connector: rc
+            agent: agent-b
+            room: dev
+            online_notification: "custom"
+    """
+
+
+async def _open_defaults_edit(pilot, app, row: int) -> None:
+    app.screen.query_one("TabbedContent").active = "tab-defaults"
+    await pilot.pause()
+    table = app.screen.query_one("#defaults-table", DataTable)
+    table.focus()
+    table.move_cursor(row=row)
+    await pilot.press("enter")
+    await pilot.pause()
+    await pilot.press("e")
+    await pilot.pause()
+
+
+class TestDefaultsEditVisibility:
+    async def test_e_opens_edit_mode_for_agent_defaults(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=1)  # agent_defaults
+            assert isinstance(app.screen, DefaultsScreen)
+            assert app.screen.mode == "edit"
+            assert app.screen.query_one("#field-timeout", Input).value == "1800"
+            assert app.screen.query_one("#field-type", Select).value == "claude"
+
+    async def test_e_is_a_no_op_for_connector_defaults(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-defaults"
+            await pilot.pause()
+            table = app.screen.query_one("#defaults-table", DataTable)
+            table.focus()
+            table.move_cursor(row=0)  # connector_defaults
+            await pilot.press("enter")
+            await pilot.pause()
+
+            assert isinstance(app.screen, DefaultsScreen)
+            assert app.screen.mode == "view"
+            await pilot.press("e")
+            await pilot.pause()
+            assert app.screen.mode == "view"  # unchanged — nothing editable
+
+
+class TestDefaultsSaveDiffing:
+    async def test_untouched_fields_are_not_rewritten(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        original = Path(config_path).read_text()
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=1)
+
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, DefaultsScreen)
+            assert app.screen.mode == "view"  # returned to view, nothing to confirm
+            assert Path(config_path).read_text() == original
+
+    async def test_changing_a_field_with_affected_entries_requires_confirm(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=1)  # agent_defaults
+
+            app.screen.query_one("#field-timeout", Input).value = "900"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, ConfirmModal)
+            body = str(app.screen.query_one("#confirm-message", Static).render())
+            assert "agent-a" in body  # doesn't override timeout — affected
+            assert "agent-b" not in body  # already overrides it — unaffected
+
+            await pilot.press("tab", "enter")  # confirm
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["agent_defaults"]["timeout"] == 900
+
+    async def test_cancelling_the_blast_radius_confirm_leaves_it_unsaved(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=1)
+
+            app.screen.query_one("#field-timeout", Input).value = "900"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)
+
+            await pilot.press("enter")  # Cancel is focused by default
+            await pilot.pause()
+
+            assert isinstance(app.screen, DefaultsScreen)
+            assert app.screen.mode == "edit"
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["agent_defaults"]["timeout"] == 1800  # untouched
+
+    async def test_changing_a_field_nobody_inherits_saves_without_confirm(
+        self, tmp_path, work_dir
+    ):
+        """Both agents already override 'type'? No -- craft a case where
+        EVERY agent overrides the changed key, so the blast radius is
+        empty and no confirm should appear at all."""
+        text = _config_text(work_dir).replace(
+            "          agent-a:\n            working_directory: " + str(work_dir) + "\n",
+            f"          agent-a:\n            working_directory: {work_dir}\n            timeout: 120\n",
+        )
+        config_path = _write_config(tmp_path, text)
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=1)
+
+            app.screen.query_one("#field-timeout", Input).value = "900"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            # Straight through to Overview -- no ConfirmModal, both agents
+            # already had their own explicit timeout.
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["agent_defaults"]["timeout"] == 900
+
+    async def test_clearing_a_field_via_ctrl_r_removes_it_from_the_block(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=1)
+
+            app.screen.query_one("#field-timeout", Input).focus()
+            await pilot.pause()
+            await pilot.press("ctrl+r")
+            await pilot.pause()
+
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)  # agent-a is affected
+            await pilot.press("tab", "enter")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert "timeout" not in raw["agent_defaults"]
+
+    async def test_invalid_int_shows_a_message_modal(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=1)
+
+            app.screen.query_one("#field-timeout", Input).value = "not-a-number"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, MessageModal)
+
+
+class TestDefaultsEditWatcherDefaults:
+    async def test_editing_online_notification_requires_confirm_naming_the_watcher(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=2)  # watcher_defaults
+            assert app.screen.query_one("#field-online_notification", Input).value == "hi"
+
+            app.screen.query_one("#field-online_notification", Input).value = "bye"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, ConfirmModal)
+            body = str(app.screen.query_one("#confirm-message", Static).render())
+            assert "w1" in body
+            assert "w2" not in body  # w2 already overrides it
+
+            await pilot.press("tab", "enter")
+            await pilot.pause()
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["watcher_defaults"]["online_notification"] == "bye"
+
+
+class TestDefaultsEditDiscard:
+    async def test_escape_with_unsaved_changes_prompts_discard_confirm(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=1)
+
+            app.screen.query_one("#field-timeout", Input).value = "42"
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert isinstance(app.screen, ConfirmModal)
+            await pilot.press("tab", "enter")  # Discard
+            await pilot.pause()
+
+            assert isinstance(app.screen, DefaultsScreen)
+            assert app.screen.mode == "view"
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["agent_defaults"]["timeout"] == 1800  # untouched
+
+    async def test_escape_without_changes_returns_to_view_directly(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await _open_defaults_edit(pilot, app, row=1)
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert isinstance(app.screen, DefaultsScreen)
+            assert app.screen.mode == "view"

--- a/tests/unit/test_configtool_defaults_editable.py
+++ b/tests/unit/test_configtool_defaults_editable.py
@@ -307,3 +307,123 @@ class TestDefaultsEditDiscard:
 
             assert isinstance(app.screen, DefaultsScreen)
             assert app.screen.mode == "view"
+
+
+class TestDirectEditFromList:
+    """'e' directly on the Defaults tab's list row — no Enter-first detour —
+    matching the shortcut Connectors/Agents/Tool Presets already have
+    (OverviewScreen.action_edit_row()). Added after a user report that
+    turned out to be an actual, reasonable UX gap once agent_defaults/
+    watcher_defaults editing shipped, not a bug in the Enter-then-'e' path
+    (which already had its own coverage above)."""
+
+    async def test_e_on_agent_defaults_row_opens_edit_mode_directly(self, tmp_path, work_dir):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-defaults"
+            await pilot.pause()
+            table = app.screen.query_one("#defaults-table", DataTable)
+            table.focus()
+            table.move_cursor(row=1)  # agent_defaults
+            await pilot.pause()
+
+            await pilot.press("e")
+            await pilot.pause()
+
+            assert isinstance(app.screen, DefaultsScreen)
+            assert app.screen.mode == "edit"
+            assert app.screen.query_one("#field-timeout", Input).value == "1800"
+
+    async def test_e_on_connector_defaults_row_notifies_instead_of_opening(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-defaults"
+            await pilot.pause()
+            table = app.screen.query_one("#defaults-table", DataTable)
+            table.focus()
+            table.move_cursor(row=0)  # connector_defaults
+            await pilot.pause()
+
+            await pilot.press("e")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)  # never navigated
+
+    async def test_escape_from_direct_edit_with_no_changes_returns_to_the_list(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-defaults"
+            await pilot.pause()
+            table = app.screen.query_one("#defaults-table", DataTable)
+            table.focus()
+            table.move_cursor(row=1)
+            await pilot.pause()
+            await pilot.press("e")
+            await pilot.pause()
+            assert app.screen.mode == "edit"
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            # No view-mode fallback -- straight back to the list, since
+            # this screen never had a view rendering to begin with.
+            assert isinstance(app.screen, OverviewScreen)
+
+    async def test_saving_with_no_changes_from_direct_edit_returns_to_the_list(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-defaults"
+            await pilot.pause()
+            table = app.screen.query_one("#defaults-table", DataTable)
+            table.focus()
+            table.move_cursor(row=1)
+            await pilot.pause()
+            await pilot.press("e")
+            await pilot.pause()
+
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+
+    async def test_saving_a_real_change_from_direct_edit_persists_and_returns(
+        self, tmp_path, work_dir
+    ):
+        config_path = _write_config(tmp_path, _config_text(work_dir))
+        app = ConfigToolApp(config_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.screen.query_one("TabbedContent").active = "tab-defaults"
+            await pilot.pause()
+            table = app.screen.query_one("#defaults-table", DataTable)
+            table.focus()
+            table.move_cursor(row=1)
+            await pilot.pause()
+            await pilot.press("e")
+            await pilot.pause()
+
+            app.screen.query_one("#field-timeout", Input).value = "120"
+            await pilot.pause()
+            await pilot.press("ctrl+s")
+            await pilot.pause()
+            assert isinstance(app.screen, ConfirmModal)  # agent-a is affected
+            await pilot.press("tab", "enter")
+            await pilot.pause()
+
+            assert isinstance(app.screen, OverviewScreen)
+            raw = yaml.safe_load(Path(config_path).read_text())
+            assert raw["agent_defaults"]["timeout"] == 120


### PR DESCRIPTION
## Summary
- `DefaultsScreen` (config TUI) is now editable for `agent_defaults` and `watcher_defaults` — reuses `AgentDetailScreen`'s own field list for the former (zero drift risk), a small dedicated field list for the latter.
- `connector_defaults` stays view-only, deliberately deferred — see docs/design/config-tool.md for why (which fields are safe to share across connector *types* is a real, separate design question).
- Save is gated behind a blast-radius `ConfirmModal` (docs/design/config-tool.md decision 2) naming every entry that would see its effective value change, whenever that list is non-empty.
- Refactor: shared field-row CSS moved from `FormScreen.DEFAULT_CSS` to `DetailScreen.DEFAULT_CSS` so `DefaultsScreen` (which deliberately does not extend `FormScreen`) can reuse the same layout.
- Found and fixed a real diffing bug in this session's own new code: an untouched str/list-kind field whose effective value was empty (`""`/`[]`) registered as "changed" on every Save. Regression-tested.
- **Follow-up in this branch**: added a direct edit-from-list shortcut (`e` on the Defaults tab's row, skipping the Enter-first detour), matching the shortcut Connectors/Agents/Tool Presets already have. Prompted by a user report that turned out to be testing/terminology confusion (not an actual bug — see docs/design/config-tool.md for the investigation), but surfaced a genuine, reasonable UX inconsistency worth fixing.
- Note: this scopes down the original Phase 3 plan (which also included watcher CRUD + the `rooms:` group auto-split rule) — that's deferred to its own future branch after a scope check-in.

## Test plan
- [x] `uv run pytest tests/unit tests/integration -q` — 2042 passed
- [x] `uv run ruff check gateway/ tests/` — clean
- [x] New tests: `tests/unit/test_configtool_defaults_editable.py` (16 tests total: edit visibility, untouched-writes-nothing, blast-radius confirm shown/named correctly, zero-affected saves without confirm, ctrl+r clear, invalid-int error, watcher_defaults fields, Escape discard-confirm, and the new direct-edit-from-list shortcut)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
